### PR TITLE
Xcvrd changes to support 400G ZR configuration

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -469,6 +469,9 @@ class TestXcvrdScript(object):
         mock_xcvr_api.set_lpmode = MagicMock(return_value=True)
         mock_xcvr_api.set_application = MagicMock(return_value=True)
         mock_xcvr_api.is_flat_memory = MagicMock(return_value=False)
+        mock_xcvr_api.is_coherent_module = MagicMock(return_value=True)
+        mock_xcvr_api.get_tx_config_power = MagicMock(return_value=0)
+        mock_xcvr_api.get_laser_config_freq = MagicMock(return_value=0)
         mock_xcvr_api.get_module_type_abbreviation = MagicMock(return_value='QSFP-DD')
         mock_xcvr_api.get_application_advertisement = MagicMock(return_value={
             1: {
@@ -551,6 +554,10 @@ class TestXcvrdScript(object):
 
         task.get_host_tx_status = MagicMock(return_value='true')
         task.get_port_admin_status = MagicMock(return_value='up')
+        task.get_configured_tx_power = MagicMock(return_value=-13)
+        task.get_configured_laser_freq = MagicMock(return_value=193100)
+        task.configure_tx_output_power = MagicMock(return_value=1)
+        task.configure_laser_frequency = MagicMock(return_value=1)
 
         # Case 1: Module Inserted --> DP_DEINIT
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -452,17 +452,17 @@ class TestXcvrdScript(object):
         cfg_port_tbl.get = MagicMock(return_value=(True, (('laser_freq', 193100),)))
         mock_table_helper.get_cfg_port_tbl = MagicMock(return_value=cfg_port_tbl)
         task.xcvr_table_helper.get_cfg_port_tbl = mock_table_helper.get_cfg_port_tbl
-        assert task.get_configured_laser_freq('Ethernet0') == 193100
+        assert task.get_configured_laser_freq_from_db('Ethernet0') == 193100
 
     @patch('xcvrd.xcvrd.XcvrTableHelper')
-    def test_CmisManagerTask_get_configured_tx_power(self, mock_table_helper):
+    def test_CmisManagerTask_get_configured_tx_power_from_db(self, mock_table_helper):
         port_mapping = PortMapping()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping)
         cfg_port_tbl = MagicMock()
         cfg_port_tbl.get = MagicMock(return_value=(True, (('tx_power', -10),)))
         mock_table_helper.get_cfg_port_tbl = MagicMock(return_value=cfg_port_tbl)
         task.xcvr_table_helper.get_cfg_port_tbl = mock_table_helper.get_cfg_port_tbl
-        assert task.get_configured_tx_power('Ethernet0') == -10
+        assert task.get_configured_tx_power_from_db('Ethernet0') == -10
 
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_update_event', MagicMock(return_value=(None, None)))
@@ -575,8 +575,8 @@ class TestXcvrdScript(object):
 
         task.get_host_tx_status = MagicMock(return_value='true')
         task.get_port_admin_status = MagicMock(return_value='up')
-        task.get_configured_tx_power = MagicMock(return_value=-13)
-        task.get_configured_laser_freq = MagicMock(return_value=193100)
+        task.get_configured_tx_power_from_db = MagicMock(return_value=-13)
+        task.get_configured_laser_freq_from_db = MagicMock(return_value=193100)
         task.configure_tx_output_power = MagicMock(return_value=1)
         task.configure_laser_frequency = MagicMock(return_value=1)
 

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -443,6 +443,27 @@ class TestXcvrdScript(object):
         task.on_port_update_event(port_change_event)
         assert len(task.port_dict) == 1
 
+    
+    @patch('xcvrd.xcvrd.XcvrTableHelper')
+    def test_CmisManagerTask_get_configured_freq(self, mock_table_helper):
+        port_mapping = PortMapping()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping)
+        cfg_port_tbl = MagicMock()
+        cfg_port_tbl.get = MagicMock(return_value=(True, (('laser_freq', 193100),)))
+        mock_table_helper.get_cfg_port_tbl = MagicMock(return_value=cfg_port_tbl)
+        task.xcvr_table_helper.get_cfg_port_tbl = mock_table_helper.get_cfg_port_tbl
+        assert task.get_configured_laser_freq('Ethernet0') == 193100
+
+    @patch('xcvrd.xcvrd.XcvrTableHelper')
+    def test_CmisManagerTask_get_configured_tx_power(self, mock_table_helper):
+        port_mapping = PortMapping()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping)
+        cfg_port_tbl = MagicMock()
+        cfg_port_tbl.get = MagicMock(return_value=(True, (('tx_power', -10),)))
+        mock_table_helper.get_cfg_port_tbl = MagicMock(return_value=cfg_port_tbl)
+        task.xcvr_table_helper.get_cfg_port_tbl = mock_table_helper.get_cfg_port_tbl
+        assert task.get_configured_tx_power('Ethernet0') == -10
+
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_update_event', MagicMock(return_value=(None, None)))
     @patch('xcvrd.xcvrd_utilities.port_mapping.handle_port_update_event', MagicMock())

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -999,6 +999,11 @@ class CmisManagerTask:
                 # We dont have better way to check if 'admin_status' is from APPL_DB or STATE_DB so this
                 # check is put temporarily to listen only to APPL_DB's admin_status and ignore that of STATE_DB
                 self.port_dict[lport]['admin_status'] = port_change_event.port_dict['admin_status']
+            if 'laser_freq' in port_change_event.port_dict:
+                self.port_dict[lport]['laser_freq'] = int(port_change_event.port_dict['laser_freq'])
+            if 'tx_power' in port_change_event.port_dict:
+                self.port_dict[lport]['tx_power'] = float(port_change_event.port_dict['tx_power'])
+
             self.force_cmis_reinit(lport, 0)
         else:
             self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_REMOVED
@@ -1121,7 +1126,6 @@ class CmisManagerTask:
                     skip = False
                     break
             return (not skip)
-
         return True
 
     def force_cmis_reinit(self, lport, retries=0):
@@ -1203,6 +1207,32 @@ class CmisManagerTask:
 
         return done
 
+    def get_configured_laser_freq(self, lport):
+        """
+           Return the Tx power configured by user in CONFIG_DB's PORT table
+        """
+        freq = 0
+        asic_index = self.port_mapping.get_asic_id_for_logical_port(lport)
+        port_tbl = self.xcvr_table_helper.get_cfg_port_tbl(asic_index)
+
+        found, port_info = port_tbl.get(lport)
+        if found and 'laser_freq' in dict(port_info):
+            freq = dict(port_info)['laser_freq']
+        return int(freq)
+
+    def get_configured_tx_power(self, lport):
+        """
+           Return the Tx power configured by user in CONFIG_DB's PORT table
+        """
+        power = 0
+        asic_index = self.port_mapping.get_asic_id_for_logical_port(lport)
+        port_tbl = self.xcvr_table_helper.get_cfg_port_tbl(asic_index)
+
+        found, port_info = port_tbl.get(lport)
+        if found and 'tx_power' in dict(port_info):
+            power = dict(port_info)['tx_power']
+        return float(power)
+
     def get_host_tx_status(self, lport):
         host_tx_ready = 'false'
 
@@ -1225,6 +1255,27 @@ class CmisManagerTask:
             # Check admin_status too ...just in case
             admin_status = dict(port_info)['admin_status']
         return admin_status
+
+    def configure_tx_output_power(self, api, lport, tx_power):
+        min_p, max_p = api.get_supported_power_config()
+        if tx_power < min_p:
+           self.log_error("{} configured tx power {} < minimum power {} supported".format(lport, tx_power, min_p))
+        if tx_power > max_p:
+           self.log_error("{} configured tx power {} > maximum power {} supported".format(lport, tx_power, max_p))
+        return api.set_tx_power(tx_power)
+
+    def configure_laser_frequency(self, api, lport, freq):
+        _, _,  _, lowf, highf = api.get_supported_freq_config()
+        if freq < lowf:
+            self.log_error("{} configured freq:{} GHz is lower than the supported freq:{} GHz".format(lport, freq, lowf))
+        if freq > highf:
+            self.log_error("{} configured freq:{} GHz is higher than the supported freq:{} GHz".format(lport, freq, highf))
+        chan = int(round((freq - 193100)/25))
+        if chan % 3 != 0:
+            self.log_error("{} configured freq:{} GHz is NOT in 75GHz grid".format(lport, freq))
+        if api.get_tuning_in_progress():
+            self.log_error("{} Tuning in progress, channel selection may fail!".format(lport))
+        return api.set_laser_freq(freq)
 
     def task_worker(self):
         self.xcvr_table_helper = XcvrTableHelper(self.namespaces)
@@ -1309,6 +1360,12 @@ class CmisManagerTask:
                     if (type is None) or (type not in self.CMIS_MODULE_TYPES):
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
                         continue
+
+                    if api.is_coherent_module():
+                       if 'tx_power' not in self.port_dict[lport]:
+                           self.port_dic[lport]['tx_power'] = self.get_configured_tx_power(lport)
+                       if 'laser_freq' not in self.port_dict[lport]:
+                           self.port_dic[lport]['laser_freq'] = self.get_configured_laser_freq(lport)
                 except AttributeError:
                     # Skip if these essential routines are not available
                     self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
@@ -1340,19 +1397,38 @@ class CmisManagerTask:
                            self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
                            continue
 
+                    # Configure the target output power if ZR module
+                        if api.is_coherent_module():
+                           tx_power = self.port_dict[lport]['tx_power']
+                           # Prevent configuring same tx power multiple times
+                           if 0 != tx_power and tx_power != api.get_tx_config_power():
+                              if 1 != self.configure_tx_output_power(api, lport, tx_power):
+                                 self.log_error("{} failed to configure Tx power = {}".format(lport, tx_power))
+                              else:
+                                 self.log_notice("{} Successfully configured Tx power = {}".format(lport, tx_power))
+
                         appl = self.get_cmis_application_desired(api, host_lanes, host_speed)
                         if appl < 1:
                             self.log_error("{}: no suitable app for the port".format(lport))
                             self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
                             continue
 
-                        has_update = self.is_cmis_application_update_required(api, host_lanes, host_speed)
-                        if not has_update:
+                        need_update = self.is_cmis_application_update_required(api, host_lanes, host_speed)
+
+                        # For ZR module, Datapath needes to be re-initlialized on new channel selection
+                        if api.is_coherent_module():
+                           freq = self.port_dict[lport]['laser_freq']
+                           # If user requested frequency is NOT the same as configured on the module
+                           # force datapath re-initialization
+                           if 0 != freq and freq != api.get_laser_config_freq():
+                              need_update = True
+
+                        if not need_update:
                             # No application updates
                             self.log_notice("{}: no CMIS application update required...READY".format(lport))
                             self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
                             continue
-
+                        self.log_notice("{}: force Datapath reinit".format(lport))
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_DP_DEINIT
                     elif state == self.CMIS_STATE_DP_DEINIT:
                         # D.2.2 Software Deinitialization
@@ -1381,6 +1457,15 @@ class CmisManagerTask:
                                 self.log_notice("{}: timeout for 'DataPathDeactivated state'".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
                             continue
+
+                        if api.is_coherent_module():
+                        # For ZR module, configure the laser frequency when Datapath is in Deactivated state
+                           freq = self.port_dict[lport]['laser_freq']
+                           if 0 != freq:
+                                if 1 != self.configure_laser_frequency(api, lport, freq):
+                                   self.log_error("{} failed to configure laser frequency {} GHz".format(lport, freq))
+                                else:
+                                   self.log_notice("{} configured laser frequency {} GHz".format(lport, freq))
 
                         # D.1.3 Software Configuration and Initialization
                         appl = self.get_cmis_application_desired(api, host_lanes, host_speed)
@@ -2080,7 +2165,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         if multi_asic.is_multi_asic():
             # Load the namespace details first from the database_global.json file.
             swsscommon.SonicDBConfig.initializeGlobalConfig()
-        # To prevent race condition in get_all_namespaces() we cache the namespaces before 
+        # To prevent race condition in get_all_namespaces() we cache the namespaces before
         # creating any worker threads
         self.namespaces = multi_asic.get_front_end_namespaces()
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1281,7 +1281,6 @@ class CmisManagerTask:
         self.xcvr_table_helper = XcvrTableHelper(self.namespaces)
 
         self.log_notice("Starting...")
-        print("Starting")
 
         # APPL_DB for CONFIG updates, and STATE_DB for insertion/removal
         sel, asic_context = port_mapping.subscribe_port_update_event(self.namespaces)
@@ -1363,12 +1362,13 @@ class CmisManagerTask:
 
                     if api.is_coherent_module():
                        if 'tx_power' not in self.port_dict[lport]:
-                           self.port_dic[lport]['tx_power'] = self.get_configured_tx_power(lport)
+                           self.port_dict[lport]['tx_power'] = self.get_configured_tx_power(lport)
                        if 'laser_freq' not in self.port_dict[lport]:
-                           self.port_dic[lport]['laser_freq'] = self.get_configured_laser_freq(lport)
+                           self.port_dict[lport]['laser_freq'] = self.get_configured_laser_freq(lport)
                 except AttributeError:
                     # Skip if these essential routines are not available
                     self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
+                    assert 1 == 0
                     continue
 
                 # CMIS expiration and retries
@@ -1396,7 +1396,6 @@ class CmisManagerTask:
                            api.tx_disable_channel(host_lanes, True)
                            self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
                            continue
-
                     # Configure the target output power if ZR module
                         if api.is_coherent_module():
                            tx_power = self.port_dict[lport]['tx_power']

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1207,7 +1207,7 @@ class CmisManagerTask:
 
         return done
 
-    def get_configured_laser_freq(self, lport):
+    def get_configured_laser_freq_from_db(self, lport):
         """
            Return the Tx power configured by user in CONFIG_DB's PORT table
         """
@@ -1220,7 +1220,7 @@ class CmisManagerTask:
             freq = dict(port_info)['laser_freq']
         return int(freq)
 
-    def get_configured_tx_power(self, lport):
+    def get_configured_tx_power_from_db(self, lport):
         """
            Return the Tx power configured by user in CONFIG_DB's PORT table
         """
@@ -1362,13 +1362,12 @@ class CmisManagerTask:
 
                     if api.is_coherent_module():
                        if 'tx_power' not in self.port_dict[lport]:
-                           self.port_dict[lport]['tx_power'] = self.get_configured_tx_power(lport)
+                           self.port_dict[lport]['tx_power'] = self.get_configured_tx_power_from_db(lport)
                        if 'laser_freq' not in self.port_dict[lport]:
-                           self.port_dict[lport]['laser_freq'] = self.get_configured_laser_freq(lport)
+                           self.port_dict[lport]['laser_freq'] = self.get_configured_laser_freq_from_db(lport)
                 except AttributeError:
                     # Skip if these essential routines are not available
                     self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
-                    assert 1 == 0
                     continue
 
                 # CMIS expiration and retries


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
400G ZR configuration support

#### Motivation and Context
400G ZR needs configuration changes for laser frequency and Tx target output power

#### How Has This Been Tested?
Xcvrd honors the configuration changes for both Tx power and laser frequency:
1. When Xcvrd is running
2. When Xcvrd comes up 

```
root@sonic:~# sfputil show eeprom -d -p Ethernet0
Ethernet0: SFP EEPROM detected
        Active App Selection Host Lane 1: 1
        Active App Selection Host Lane 2: 1
        Active App Selection Host Lane 3: 1
        Active App Selection Host Lane 4: 1
        Active App Selection Host Lane 5: 1
        Active App Selection Host Lane 6: 1
        Active App Selection Host Lane 7: 1
        Active App Selection Host Lane 8: 1
        Active Firmware Version: 61.20
        Application Advertisement: {1: {'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)', 'module_media_interface_id': '400ZR, DWDM, amplified', 'media_lane_count': 1, 'host_lane_count': 8, 'host_lane_assignment_options': 1}, 2: {'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)', 'module_media_interface_id': '400ZR, Single Wavelength, Unamplified', 'media_lane_count': 1, 'host_lane_count': 8, 'host_lane_assignment_options': 1}, 3: {'host_electrical_interface_id': '100GAUI-2 C2M (Annex 135G)', 'module_media_interface_id': '400ZR, DWDM, amplified', 'media_lane_count': 1, 'host_lane_count': 2, 'host_lane_assignment_options': 85}}
        CMIS Revision: 4.1
        Connector: LC
        Encoding: N/A
        Extended Identifier: Power Class 8 (20.0W Max)
        Extended RateSelect Compliance: N/A
        Hardware Revision: 1.1
        Host Electrical Interface: 400GAUI-8 C2M (Annex 120E)
        Host Lane Assignment Options: 1
        Host Lane Count: 8
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware Version: 161.10
        Length Cable Assembly(m): 0.0
        Media Interface Code: 400ZR, DWDM, amplified
        Media Interface Technology: 1550 nm DFB
        Media Lane Assignment Options: 1
        Media Lane Count: 1
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: sm_media_interface
        Supported Max Laser Frequency: 196100GHz
        Supported Max TX Power: 4.0dBm
        Supported Min Laser Frequency: 191300GHz
        Supported Min TX Power: -22.9dBm
        Vendor Date Code(YYYY-MM-DD Lot): 2021-11-19   
        Vendor Name: Acacia Comm Inc.
        Vendor OUI: 7c-b2-5c
        Vendor PN: DP04QSDD-E20-001
        Vendor Rev: A 
        Vendor SN: 214455197       
        ChannelMonitorValues:
                RX1Power: -11.884249941294067dBm
                RX2Power: -infdBm
                RX3Power: -infdBm
                RX4Power: -infdBm
                RX5Power: -infdBm
                RX6Power: -infdBm
                RX7Power: -infdBm
                RX8Power: -infdBm
                TX1Bias: 241.496mA
                TX1Power: -13.585258894959004dBm
                TX2Bias: 0.0mA
                TX2Power: -infdBm
                TX3Bias: 0.0mA
                TX3Power: -infdBm
                TX4Bias: 0.0mA
                TX4Power: -infdBm
                TX5Bias: 0.0mA
                TX5Power: -infdBm
                TX6Bias: 0.0mA
                TX6Power: -infdBm
                TX7Bias: 0.0mA
                TX7Power: -infdBm
                TX8Bias: 0.0mA
                TX8Power: -infdBm
        ChannelThresholdValues:
                RxPowerHighAlarm  : 2.0dBm
                RxPowerHighWarning: 0.0dBm
                RxPowerLowAlarm   : -23.01dBm
                RxPowerLowWarning : -20.0dBm
                TxBiasHighAlarm   : 0.0mA
                TxBiasHighWarning : 0.0mA
                TxBiasLowAlarm    : 0.0mA
                TxBiasLowWarning  : 0.0mA
                TxPowerHighAlarm  : 0.0dBm
                TxPowerHighWarning: -2.0dBm
                TxPowerLowAlarm   : -18.013dBm
                TxPowerLowWarning : -16.003dBm
        ModuleMonitorValues:
                Temperature: 66.0C
                Vcc: 3.321Volts
        ModuleThresholdValues:
                TempHighAlarm  : 80.0C
                TempHighWarning: 75.0C
                TempLowAlarm   : -5.0C
                TempLowWarning : 15.0C
                VccHighAlarm   : 3.465Volts
                VccHighWarning : 3.432Volts
                VccLowAlarm    : 3.135Volts
                VccLowWarning  : 3.168Volts


root@sonic:~# 
```

Configured frequency
```
root@sonic:/# python3
Python 3.7.3 (default, Jan 22 2021, 20:04:44) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from sonic_platform.chassis import Chassis
>>> c = Chassis()
>>> sfp = c.get_sfp(1)
>>> api = sfp.get_xcvr_api()
>>> api.get_current_laser_freq()
193175.0
>>> 

```


#### Additional Information (Optional)
