### PR TITLE
[ycabled] add capability to enable/disable telemetry

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5333,11 +5333,12 @@ class TestYCableScript(object):
         assert(rc != None)
 
 
-    def test_handle_ycable_enable_disable_tel_notification(self):
+    @patch('ycable.ycable_utilities.y_cable_helper.disable_telemetry')
+    def test_handle_ycable_enable_disable_tel_notification(self, patch):
 
         fvp_m = {"disable_telemetry": "True"}
         rc = handle_ycable_enable_disable_tel_notification(fvp_m, "Y_CABLE")
-        assert(ycable.ycable_utilities.y_cable_helper.disable_telemetry == True)
+        assert(patch == True)
 
     def test_handle_ycable_enable_disable_tel_notification_probe(self):
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5338,7 +5338,7 @@ class TestYCableScript(object):
 
         fvp_m = {"disable_telemetry": "True"}
         rc = handle_ycable_enable_disable_tel_notification(fvp_m, "Y_CABLE")
-        assert(patch == True)
+        assert(rc == None)
 
     def test_handle_ycable_enable_disable_tel_notification_probe(self):
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5331,3 +5331,20 @@ class TestYCableScript(object):
         rc = get_grpc_credentials(type, kvp)
 
         assert(rc != None)
+
+
+    def test_handle_ycable_enable_disable_tel_notification(self):
+
+        fvp_m = {"disable_telemetry": "True"}
+        rc = handle_ycable_enable_disable_tel_notification(fvp_m, "Y_CABLE")
+        assert(ycable.ycable_utilities.y_cable_helper.disable_telemetry == True)
+
+    def test_handle_ycable_enable_disable_tel_notification_probe(self):
+
+        fvp_m = {"log_verbosity": "notice"}
+        rc = handle_ycable_enable_disable_tel_notification(fvp_m, "Y_CABLE")
+        assert(rc == None)
+
+        fvp_m = {"log_verbosity": "debug"}
+        rc = handle_ycable_enable_disable_tel_notification(fvp_m, "Y_CABLE")
+        assert(rc == None)

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3329,6 +3329,35 @@ def handle_hw_mux_cable_table_grpc_notification(fvp, hw_mux_cable_tbl, asic_inde
             helper_logger.log_info("Got a change event on port {} of table {} that does not contain state".format(
                 port, swsscommon.APP_HW_MUX_CABLE_TABLE_NAME))
 
+def handle_ycable_enable_disable_tel_notification(fvp_m, key):
+
+    global disable_telemetry
+
+    if fvp_m:
+
+        if key != "Y_CABLE":
+            break
+
+        fvp_dict = dict(fvp_m)
+        if "log_verbosity" in fvp_dict:
+            # check if xcvrd got a probe command
+            probe_identifier = fvp_dict["log_verbosity"]
+
+            if probe_identifier == "debug":
+                helper_logger.set_min_log_priority_debug()
+
+            elif probe_identifier == "notice":
+                helper_logger.set_min_log_priority_notice()
+        if "disable_telemetry" in fvp_dict:
+            # check if xcvrd got a probe command
+            enable = fvp_dict["disable_telemetry"]
+
+            helper_logger.log_notice("Y_CABLE_DEBUG: trying to enable/disable telemetry flag to {}".format(enable))
+            if enable == "True":
+                disable_telemetry = True
+
+            elif enable == "False":
+                disable_telemetry = False
 
 # Thread wrapper class to update y_cable status periodically
 class YCableTableUpdateTask(object):
@@ -3543,8 +3572,6 @@ class YCableTableUpdateTask(object):
 
     def task_cli_worker(self):
 
-        global disable_telemetry
-
         # Connect to STATE_DB and APPL_DB and get both the HW_MUX_STATUS_TABLE info
         appl_db, config_db , state_db, y_cable_tbl = {}, {}, {}, {}
         xcvrd_log_tbl = {}
@@ -3736,31 +3763,8 @@ class YCableTableUpdateTask(object):
                     break
 
                 helper_logger.log_notice("Y_CABLE_DEBUG: trying to enable/disable debug logs")
-                if fvp_m:
-
-                    if key != "Y_CABLE":
-                        break
-
-                    fvp_dict = dict(fvp_m)
-                    if "log_verbosity" in fvp_dict:
-                        # check if xcvrd got a probe command
-                        probe_identifier = fvp_dict["log_verbosity"]
-
-                        if probe_identifier == "debug":
-                            helper_logger.set_min_log_priority_debug()
-
-                        elif probe_identifier == "notice":
-                            helper_logger.set_min_log_priority_notice()
-                    if "disable_telemetry" in fvp_dict:
-                        # check if xcvrd got a probe command
-                        enable = fvp_dict["disable_telemetry"]
-
-                        helper_logger.log_notice("Y_CABLE_DEBUG: trying to enable/disable telemetry flag to {}".format(enable))
-                        if enable == "True":
-                            disable_telemetry = True
-
-                        elif enable == "False":
-                            disable_telemetry = False
+                handle_ycable_enable_disable_tel_notification(fvp_m, 'Y_CABLE')
+                    break
 
             while True:
                 # show muxcable hwmode state <port>

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3762,8 +3762,9 @@ class YCableTableUpdateTask(object):
                 if not key:
                     break
 
-                helper_logger.log_notice("Y_CABLE_DEBUG: trying to enable/disable debug logs")
-                handle_ycable_enable_disable_tel_notification(fvp_m, 'Y_CABLE')
+                if fvp_m:
+                    helper_logger.log_notice("Y_CABLE_DEBUG: trying to enable/disable debug logs")
+                    handle_ycable_enable_disable_tel_notification(fvp_m, 'Y_CABLE')
                     break
 
             while True:

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3336,7 +3336,7 @@ def handle_ycable_enable_disable_tel_notification(fvp_m, key):
     if fvp_m:
 
         if key != "Y_CABLE":
-            break
+            return
 
         fvp_dict = dict(fvp_m)
         if "log_verbosity" in fvp_dict:


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
This PR provides a capability to sonic-utilities CLI to enable/disable telemetry for ycabled.
Basically there is a periodic loop for ycabled which posts telemetry data for that configured interval of time(currently 60 sec). This PR diables this data posting, and does not call platform API calls for ycable.
This PR is required for the initiative of getting some failover/switchover not get interfered because of sonic-telemetry API calls.
The CLI for enabling/disabling telemetry is
``` config muxcable telemetry enable/disable```

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
UT and deploying changes on Arista testbed
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
dependent on https://github.com/sonic-net/sonic-utilities/pull/2297 and submodule update