### PR TITLE
Correct the peer forwarding state table

### DIFF
--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3400,8 +3400,8 @@ class YCableTableUpdateTask(object):
             hw_mux_cable_tbl[asic_id] = swsscommon.Table(
                 state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
             # TODO add definition inside app DB
-            status_tbl_peer[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
+            status_tbl_peer[asic_id] = swsscommon.ConsumerStateTable(
+                appl_db[asic_id], "HW_FORWARDING_STATE_PEER")
             fwd_state_command_tbl[asic_id] = swsscommon.SubscriberStateTable(
                 appl_db[asic_id], "FORWARDING_STATE_COMMAND")
             fwd_state_response_tbl[asic_id] = swsscommon.Table(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Fixes: https://github.com/sonic-net/sonic-linkmgrd/issues/101

`ycabled` failed to toggle peer forwarding state for `active-active` ports.
Use `ConsumerStateTable` to listen to `HW_FORWARDING_STATE_PEER`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
As the description

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
On a `dualtor-mixed` testbed, shutdown a port on upper ToR, verified the lower ToR could toggle the `nic_simulator` upper ToR forwarding state to `standby`.

#### Additional Information (Optional)
