### PR TITLE
[xcvrd] Catch TypeError and KeyError exception to protect xcvrd from crashing

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -304,73 +304,76 @@ def post_port_sfp_info_to_db(logical_port_name, port_mapping, table, transceiver
                 transceiver_dict[physical_port] = port_info_dict
                 # if cmis is supported by the module
                 if 'cmis_rev' in port_info_dict:
-                    fvs = swsscommon.FieldValuePairs(
-                        [('type', port_info_dict['type']),
-                        ('vendor_rev', port_info_dict['vendor_rev']),
-                        ('serial', port_info_dict['serial']),
-                        ('manufacturer', port_info_dict['manufacturer']),
-                        ('model', port_info_dict['model']),
-                        ('vendor_oui', port_info_dict['vendor_oui']),
-                        ('vendor_date', port_info_dict['vendor_date']),
-                        ('connector', port_info_dict['connector']),
-                        ('encoding', port_info_dict['encoding']),
-                        ('ext_identifier', port_info_dict['ext_identifier']),
-                        ('ext_rateselect_compliance', port_info_dict['ext_rateselect_compliance']),
-                        ('cable_type', port_info_dict['cable_type']),
-                        ('cable_length', str(port_info_dict['cable_length'])),
-                        ('specification_compliance', port_info_dict['specification_compliance']),
-                        ('nominal_bit_rate', str(port_info_dict['nominal_bit_rate'])),
-                        ('application_advertisement', port_info_dict['application_advertisement']
-                        if 'application_advertisement' in port_info_dict else 'N/A'),
-                        ('is_replaceable', str(is_replaceable)),
-                        ('dom_capability', port_info_dict['dom_capability']
-                        if 'dom_capability' in port_info_dict else 'N/A'),
-                        ('cmis_rev', port_info_dict['cmis_rev'] if 'cmis_rev' in port_info_dict else 'N/A'),
-                        ('active_firmware', port_info_dict['active_firmware']
-                        if 'active_firmware' in port_info_dict else 'N/A'),
-                        ('inactive_firmware', port_info_dict['inactive_firmware']
-                        if 'inactive_firmware' in port_info_dict else 'N/A'),
-                        ('hardware_rev', port_info_dict['hardware_rev']
-                        if 'hardware_rev' in port_info_dict else 'N/A'),
-                        ('media_interface_code', port_info_dict['media_interface_code']
-                        if 'media_interface_code' in port_info_dict else 'N/A'),
-                        ('host_electrical_interface', port_info_dict['host_electrical_interface']
-                        if 'host_electrical_interface' in port_info_dict else 'N/A'),
-                        ('host_lane_count', str(port_info_dict['host_lane_count'])
-                        if 'host_lane_count' in port_info_dict else 'N/A'),
-                        ('media_lane_count', str(port_info_dict['media_lane_count'])
-                        if 'media_lane_count' in port_info_dict else 'N/A'),
-                        ('host_lane_assignment_option', str(port_info_dict['host_lane_assignment_option'])
-                        if 'host_lane_assignment_option' in port_info_dict else 'N/A'),
-                        ('media_lane_assignment_option', str(port_info_dict['media_lane_assignment_option'])
-                        if 'media_lane_assignment_option' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane1', str(port_info_dict['active_apsel_hostlane1'])
-                        if 'active_apsel_hostlane1' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane2', str(port_info_dict['active_apsel_hostlane2'])
-                        if 'active_apsel_hostlane2' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane3', str(port_info_dict['active_apsel_hostlane3'])
-                        if 'active_apsel_hostlane3' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane4', str(port_info_dict['active_apsel_hostlane4'])
-                        if 'active_apsel_hostlane4' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane5', str(port_info_dict['active_apsel_hostlane5'])
-                        if 'active_apsel_hostlane5' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane6', str(port_info_dict['active_apsel_hostlane6'])
-                        if 'active_apsel_hostlane6' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane7', str(port_info_dict['active_apsel_hostlane7'])
-                        if 'active_apsel_hostlane7' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane8', str(port_info_dict['active_apsel_hostlane8'])
-                        if 'active_apsel_hostlane8' in port_info_dict else 'N/A'),
-                        ('media_interface_technology', port_info_dict['media_interface_technology']
-                        if 'media_interface_technology' in port_info_dict else 'N/A'),
-                        ('supported_max_tx_power', str(port_info_dict['supported_max_tx_power'])
-                        if 'supported_max_tx_power' in port_info_dict else 'N/A'),
-                        ('supported_min_tx_power', str(port_info_dict['supported_min_tx_power'])
-                        if 'supported_min_tx_power' in port_info_dict else 'N/A'),
-                        ('supported_max_laser_freq', str(port_info_dict['supported_max_laser_freq'])
-                        if 'supported_max_laser_freq' in port_info_dict else 'N/A'),
-                        ('supported_min_laser_freq', str(port_info_dict['supported_min_laser_freq'])
-                        if 'supported_min_laser_freq' in port_info_dict else 'N/A')
-                    ])
+                    try:
+                        fvs = swsscommon.FieldValuePairs(
+                            [('type', port_info_dict['type']),
+                            ('vendor_rev', port_info_dict['vendor_rev']),
+                            ('serial', port_info_dict['serial']),
+                            ('manufacturer', port_info_dict['manufacturer']),
+                            ('model', port_info_dict['model']),
+                            ('vendor_oui', port_info_dict['vendor_oui']),
+                            ('vendor_date', port_info_dict['vendor_date']),
+                            ('connector', port_info_dict['connector']),
+                            ('encoding', port_info_dict['encoding']),
+                            ('ext_identifier', port_info_dict['ext_identifier']),
+                            ('ext_rateselect_compliance', port_info_dict['ext_rateselect_compliance']),
+                            ('cable_type', port_info_dict['cable_type']),
+                            ('cable_length', str(port_info_dict['cable_length'])),
+                            ('specification_compliance', port_info_dict['specification_compliance']),
+                            ('nominal_bit_rate', str(port_info_dict['nominal_bit_rate'])),
+                            ('application_advertisement', port_info_dict['application_advertisement']
+                            if 'application_advertisement' in port_info_dict else 'N/A'),
+                            ('is_replaceable', str(is_replaceable)),
+                            ('dom_capability', port_info_dict['dom_capability']
+                            if 'dom_capability' in port_info_dict else 'N/A'),
+                            ('cmis_rev', port_info_dict['cmis_rev'] if 'cmis_rev' in port_info_dict else 'N/A'),
+                            ('active_firmware', port_info_dict['active_firmware']
+                            if 'active_firmware' in port_info_dict else 'N/A'),
+                            ('inactive_firmware', port_info_dict['inactive_firmware']
+                            if 'inactive_firmware' in port_info_dict else 'N/A'),
+                            ('hardware_rev', port_info_dict['hardware_rev']
+                            if 'hardware_rev' in port_info_dict else 'N/A'),
+                            ('media_interface_code', port_info_dict['media_interface_code']
+                            if 'media_interface_code' in port_info_dict else 'N/A'),
+                            ('host_electrical_interface', port_info_dict['host_electrical_interface']
+                            if 'host_electrical_interface' in port_info_dict else 'N/A'),
+                            ('host_lane_count', str(port_info_dict['host_lane_count'])
+                            if 'host_lane_count' in port_info_dict else 'N/A'),
+                            ('media_lane_count', str(port_info_dict['media_lane_count'])
+                            if 'media_lane_count' in port_info_dict else 'N/A'),
+                            ('host_lane_assignment_option', str(port_info_dict['host_lane_assignment_option'])
+                            if 'host_lane_assignment_option' in port_info_dict else 'N/A'),
+                            ('media_lane_assignment_option', str(port_info_dict['media_lane_assignment_option'])
+                            if 'media_lane_assignment_option' in port_info_dict else 'N/A'),
+                            ('active_apsel_hostlane1', str(port_info_dict['active_apsel_hostlane1'])
+                            if 'active_apsel_hostlane1' in port_info_dict else 'N/A'),
+                            ('active_apsel_hostlane2', str(port_info_dict['active_apsel_hostlane2'])
+                            if 'active_apsel_hostlane2' in port_info_dict else 'N/A'),
+                            ('active_apsel_hostlane3', str(port_info_dict['active_apsel_hostlane3'])
+                            if 'active_apsel_hostlane3' in port_info_dict else 'N/A'),
+                            ('active_apsel_hostlane4', str(port_info_dict['active_apsel_hostlane4'])
+                            if 'active_apsel_hostlane4' in port_info_dict else 'N/A'),
+                            ('active_apsel_hostlane5', str(port_info_dict['active_apsel_hostlane5'])
+                            if 'active_apsel_hostlane5' in port_info_dict else 'N/A'),
+                            ('active_apsel_hostlane6', str(port_info_dict['active_apsel_hostlane6'])
+                            if 'active_apsel_hostlane6' in port_info_dict else 'N/A'),
+                            ('active_apsel_hostlane7', str(port_info_dict['active_apsel_hostlane7'])
+                            if 'active_apsel_hostlane7' in port_info_dict else 'N/A'),
+                            ('active_apsel_hostlane8', str(port_info_dict['active_apsel_hostlane8'])
+                            if 'active_apsel_hostlane8' in port_info_dict else 'N/A'),
+                            ('media_interface_technology', port_info_dict['media_interface_technology']
+                            if 'media_interface_technology' in port_info_dict else 'N/A'),
+                            ('supported_max_tx_power', str(port_info_dict['supported_max_tx_power'])
+                            if 'supported_max_tx_power' in port_info_dict else 'N/A'),
+                            ('supported_min_tx_power', str(port_info_dict['supported_min_tx_power'])
+                            if 'supported_min_tx_power' in port_info_dict else 'N/A'),
+                            ('supported_max_laser_freq', str(port_info_dict['supported_max_laser_freq'])
+                            if 'supported_max_laser_freq' in port_info_dict else 'N/A'),
+                            ('supported_min_laser_freq', str(port_info_dict['supported_min_laser_freq'])
+                            if 'supported_min_laser_freq' in port_info_dict else 'N/A')
+                        ])
+                    except (KeyError, TypeError) as e:
+                        helper_logger.log_error("Wrong port_info_dict: {} {}".format(str(e), port_info_dict))
                 # else cmis is not supported by the module
                 else:
                     fvs = swsscommon.FieldValuePairs([


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Catch TypeError and KeyError exception to protect xcvrd from crashing

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This is to fix a crash issue:  https://github.com/sonic-net/sonic-buildimage/issues/11525

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
run sonic-mgmt sfp reset test case: platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset to make sure xcvrd will not crash

#### Additional Information (Optional)
