### PR TITLE
Use get() to fetch default value from dictionary for port admin_status 

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1253,7 +1253,7 @@ class CmisManagerTask:
         found, port_info = cfg_port_tbl.get(lport)
         if found:
             # Check admin_status too ...just in case
-            admin_status = dict(port_info)['admin_status']
+            admin_status = dict(port_info).get('admin_status', 'down')
         return admin_status
 
     def configure_tx_output_power(self, api, lport, tx_power):


### PR DESCRIPTION
Signed-off-by: anamehra <anamehra@cisco.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
    The config db dictionary may not have admin_status available for a
port if the same is not set in config db file. Use get() function to
prevent crashes and set the default status to 'down'.

<!--
     Describe your changes in detail
-->

#### Motivation and Context

xcvrd crash is observed during boot on multi-asic chassis system.
The crash is reported in https://github.com/sonic-net/sonic-buildimage/issues/11707

On debugging the issue, found that at the point of the crash, the data being used is from config db.
It was observed that the Ethernet ports, which are not configured for admin_state field explicitly in the config  is causing the crash. This is a valid config as admin_status is not a mandatory field and is considerd by default 'down' if missing in port config in config db file.

for example, the Ethernet31 is configured for a far-end, and has this field populated while Ethernet32, as was not being used, has this field missing.

    "Ethernet31": {
        "admin_status": "up",
        "alias": "Eth0/2/31",
        "asic_port_name": "Eth31-ASIC2",
        "description": "ARISTA32T3:Ethernet1",
        "fec": "rs",
        "index": "31",
        "lanes": "512,513,514,515",
        "mtu": "9100",
        "pfc_asym": "off",
        "role": "Ext",
        "speed": "100000",
        "tpid": "0x8100"
    },
    "Ethernet32": {
        "alias": "Eth0/2/32",
        "asic_port_name": "Eth32-ASIC2",
        "description": "Eth0/2/32",
        "fec": "rs",
        "index": "32",
        "lanes": "264,265,266,267",
        "mtu": "9100",
        "pfc_asym": "off",
        "role": "Ext",
        "speed": "100000",
        "tpid": "0x8100"
    },
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
closes https://github.com/sonic-net/sonic-buildimage/issues/11707

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Loaded image on single and multi-asic system. Tested for normal boot. No crash observed.

#### Additional Information (Optional)
