### PR TITLE
[ycabled] fix insert events from xcvrd;cleanup some mux toggle logic

### DIFF
--- a/sonic-ycabled/tests/test_ycable.py
+++ b/sonic-ycabled/tests/test_ycable.py
@@ -296,9 +296,13 @@ class TestYcableScript(object):
 
     @patch('ycable.ycable_utilities.y_cable_helper.change_ports_status_for_y_cable_change_event', MagicMock(return_value=0))
     def test_handle_state_update_task(self):
-
+        
+        port = "Ethernet0"
+        fvp_dict = {}
+        y_cable_presence = false
+        stopping_event = None
         rc = handle_state_update_task(port, fvp_dict, y_cable_presence, stopping_event)
-        assert(rc == 0)
+        assert(rc == None)
 
 
 def wait_until(total_wait_time, interval, call_back, *args, **kwargs):

--- a/sonic-ycabled/tests/test_ycable.py
+++ b/sonic-ycabled/tests/test_ycable.py
@@ -299,7 +299,7 @@ class TestYcableScript(object):
         
         port = "Ethernet0"
         fvp_dict = {}
-        y_cable_presence = false
+        y_cable_presence = False
         stopping_event = None
         rc = handle_state_update_task(port, fvp_dict, y_cable_presence, stopping_event)
         assert(rc == None)

--- a/sonic-ycabled/tests/test_ycable.py
+++ b/sonic-ycabled/tests/test_ycable.py
@@ -297,7 +297,6 @@ class TestYcableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.change_ports_status_for_y_cable_change_event', MagicMock(return_value=0))
     def test_handle_state_update_task(self):
 
-
         rc = handle_state_update_task(port, fvp_dict, y_cable_presence, stopping_event)
         assert(rc == 0)
 
@@ -313,5 +312,3 @@ def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
         time.sleep(interval)
         wait_time += interval
     return False
-
-

--- a/sonic-ycabled/tests/test_ycable.py
+++ b/sonic-ycabled/tests/test_ycable.py
@@ -294,6 +294,13 @@ class TestYcableScript(object):
         # TODO: fow now we only simply call ycable.init/deinit without any further check, it only makes sure that
         # ycable.init/deinit will not raise unexpected exception. In future, probably more check will be added
 
+    @patch('ycable.ycable_utilities.y_cable_helper.change_ports_status_for_y_cable_change_event', MagicMock(return_value=0))
+    def test_handle_state_update_task(self):
+
+
+        rc = handle_state_update_task(port, fvp_dict, y_cable_presence, stopping_event)
+        assert(rc == 0)
+
 
 def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
     wait_time = 0
@@ -306,3 +313,5 @@ def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
         time.sleep(interval)
         wait_time += interval
     return False
+
+

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -149,7 +149,6 @@ class YcableStateUpdateTask(object):
 
         # Connect to STATE_DB and listen to ycable transceiver status update tables
         state_db, status_tbl= {}, {}
-        port_dict = {}
 
         sel = swsscommon.Select()
 
@@ -195,6 +194,7 @@ class YcableStateUpdateTask(object):
                 if not fvp_dict:
                     continue
 
+                port_dict = {}
                 port_dict[port] = fvp_dict.get('status', None)
 
                 y_cable_helper.change_ports_status_for_y_cable_change_event(

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -80,6 +80,16 @@ def detect_port_in_error_status(logical_port_name, status_tbl):
     else:
         return False
 
+def handle_state_update_task(port, fvp_dict, y_cable_presence, stopping_event):
+
+    port_dict = {}
+    port_dict[port] = fvp_dict.get('status', None)
+
+    rc = y_cable_helper.change_ports_status_for_y_cable_change_event(
+        port_dict, y_cable_presence, stopping_event)
+
+    return rc
+
 #
 # Helper classes ===============================================================
 #
@@ -194,11 +204,8 @@ class YcableStateUpdateTask(object):
                 if not fvp_dict:
                     continue
 
-                port_dict = {}
-                port_dict[port] = fvp_dict.get('status', None)
+                handle_state_update_task(port, fvp_dict, y_cable_presence, stopping_event)
 
-                y_cable_helper.change_ports_status_for_y_cable_change_event(
-                    port_dict, y_cable_presence, stopping_event)
 
     def task_run(self, sfp_error_event, y_cable_presence):
         if self.task_stopping_event.is_set():

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -85,10 +85,8 @@ def handle_state_update_task(port, fvp_dict, y_cable_presence, stopping_event):
     port_dict = {}
     port_dict[port] = fvp_dict.get('status', None)
 
-    rc = y_cable_helper.change_ports_status_for_y_cable_change_event(
+    y_cable_helper.change_ports_status_for_y_cable_change_event(
         port_dict, y_cable_presence, stopping_event)
-
-    return rc
 
 #
 # Helper classes ===============================================================

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -746,7 +746,6 @@ def y_cable_toggle_mux_torA(physical_port):
     if port_instance is None:
         helper_logger.log_error(
             "Error: Could not get port instance for read side for  Y cable port {} {}".format(physical_port, threading.currentThread().getName()))
-        port_instance.mux_toggle_status = port_instance.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED
         return -1
 
     try:
@@ -771,7 +770,6 @@ def y_cable_toggle_mux_torB(physical_port):
     port_instance = y_cable_port_instances.get(physical_port)
     if port_instance is None:
         helper_logger.log_error("Error: Could not get port instance for read side for  Y cable port {} {}".format(physical_port, threading.currentThread().getName()))
-        port_instance.mux_toggle_status = port_instance.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED
         return -1
 
     try:
@@ -810,7 +808,6 @@ def toggle_mux_tor_direction_and_update_read_side(state, logical_port_name, phys
     port_instance = y_cable_port_instances.get(physical_port)
     if port_instance is None:
         helper_logger.log_error("Error: Could not get port instance for read side for while processing a toggle Y cable port {} {}".format(physical_port, threading.currentThread().getName()))
-        port_instance.mux_toggle_status = port_instance.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED
         return (-1, -1)
 
     read_side = port_instance.get_read_side()
@@ -2275,6 +2272,9 @@ def handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_t
                     status = -1
                     helper_logger.log_warning("Failed to execute the disable prbs API for port {} due to {}".format(physical_port,repr(e)))
         elif config_prbs_mode == "reset":
+
+            port_instance.mux_toggle_status = port_instance.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED
+            port_instance.download_firmware_status == port_instance.FIRMWARE_DOWNLOAD_STATUS_NOT_INITIATED_OR_FINISHED
             with y_cable_port_locks[physical_port]:
                 try:
                     status = port_instance.reset(target)

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -746,6 +746,7 @@ def y_cable_toggle_mux_torA(physical_port):
     if port_instance is None:
         helper_logger.log_error(
             "Error: Could not get port instance for read side for  Y cable port {} {}".format(physical_port, threading.currentThread().getName()))
+        port_instance.mux_toggle_status = port_instance.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED
         return -1
 
     try:
@@ -770,6 +771,7 @@ def y_cable_toggle_mux_torB(physical_port):
     port_instance = y_cable_port_instances.get(physical_port)
     if port_instance is None:
         helper_logger.log_error("Error: Could not get port instance for read side for  Y cable port {} {}".format(physical_port, threading.currentThread().getName()))
+        port_instance.mux_toggle_status = port_instance.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED
         return -1
 
     try:
@@ -808,6 +810,7 @@ def toggle_mux_tor_direction_and_update_read_side(state, logical_port_name, phys
     port_instance = y_cable_port_instances.get(physical_port)
     if port_instance is None:
         helper_logger.log_error("Error: Could not get port instance for read side for while processing a toggle Y cable port {} {}".format(physical_port, threading.currentThread().getName()))
+        port_instance.mux_toggle_status = port_instance.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED
         return (-1, -1)
 
     read_side = port_instance.get_read_side()


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
This PR intends to help fix the surplus amount of insert/delete events that ycabled gets it is first spawned, it fixes the logic where an insert event is only handled the way it is collected by `xcvrd` one time only. 

Previously there was  a known issue for spurious insert/delete events captured by ycabled on config reload, this PR fixes it

This PR also cleans up some mux toggle blocking other txns logic. 

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Unit-tests and deploying changes on Testbed
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
