### PR TITLE
[ycable] cleanup logic for creating grpc future ready

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -4967,6 +4967,13 @@ class TestYCableScript(object):
         assert(stub == True)
         assert(channel != None)
 
+    def test_connect_channel(self):
+
+        with patch('grpc.channel_ready_future') as patched_util:
+
+            patched_util.result.return_value = 0
+            rc = connect_channel(channel, stub, port)
+            assert(rc == None)
 
     def test_setup_grpc_channels(self):
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -4962,9 +4962,10 @@ class TestYCableScript(object):
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
-            rc = setup_grpc_channel_for_port("Ethernet0", "192.168.0.1")
+            (channel, stub) = setup_grpc_channel_for_port("Ethernet0", "192.168.0.1")
 
-        assert(rc == (None, None))
+        assert(stub == True)
+        assert(channel != None)
 
 
     def test_setup_grpc_channels(self):

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -4972,7 +4972,7 @@ class TestYCableScript(object):
         with patch('grpc.channel_ready_future') as patched_util:
 
             patched_util.result.return_value = 0
-            rc = connect_channel(channel, stub, port)
+            rc = connect_channel(patched_util, None, None)
             assert(rc == None)
 
     def test_setup_grpc_channels(self):

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -461,8 +461,8 @@ def create_channel(type, level, kvp, soc_ip, port):
     #connect_channel(channel, stub, port)
     """
     Comment the connect channel call for now, since it is not required for normal gRPC I/O
-    and all use cases seem to work without it.
-    TODO: will need to see if this subroutine call can be ommitted for all use cases
+    and all use cases work without it.
+    TODO: check if this subroutine call can be ommitted for all use cases in future enhancements
     """
 
     return channel, stub

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -423,7 +423,6 @@ def connect_channel(channel, stub, port):
 
 def create_channel(type, level, kvp, soc_ip, port):
 
-    channel, stub = None, None
 
     #Helper callback to get an channel connectivity state
     def wait_for_state_change(channel_connectivity):

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -456,12 +456,12 @@ def create_channel(type,level, kvp, soc_ip, port):
     if channel is not None:
         channel.subscribe(wait_for_state_change)
 
-    connect_channel(channel, stub, port)
-    if channel is None:
-        helper_logger.log_notice("gRPC port {} channel is None".format(port))
-    if stub is None:
-        helper_logger.log_notice("gRPC port {} stub is None".format(port))
-   
+    #connect_channel(channel, stub, port)
+    """
+    Removing the connect channel call for now, since it is not required for normal gRPC
+    and all use cases seem to work without it
+    """
+
     return channel, stub
 
 def setup_grpc_channel_for_port(port, soc_ip):
@@ -515,6 +515,11 @@ def setup_grpc_channel_for_port(port, soc_ip):
 
 
     channel, stub = create_channel(type, level, kvp, soc_ip, port) 
+
+    if stub is None:
+        helper_logger.log_warning("stub was not setup for gRPC soc ip {} port {}, no gRPC soc server running ?".format(soc_ip, port))
+    if channel is None:
+        helper_logger.log_warning("channel was not setup for gRPC soc ip {} port {}, no gRPC soc server running ?".format(soc_ip, port))
 
     return channel, stub
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -332,7 +332,6 @@ def hook_grpc_nic_simulated(target, soc_ip):
 
     return wrapper
 
-
 def retry_setup_grpc_channel_for_port(port, asic_index):
 
     global grpc_port_stubs
@@ -409,35 +408,60 @@ def get_grpc_credentials(type, kvp):
 
     return credential
 
-def create_channel(type,level, kvp, soc_ip):
+def connect_channel(channel, stub, port):
 
+    channel_ready = grpc.channel_ready_future(channel)
     retries = 3
+
     for _ in range(retries):
-
-        if type == "secure": 
-            credential = get_grpc_credentials(level, kvp)
-            target_name = kvp.get("grpc_ssl_credential", None)
-            if credential is None or target_name is None:
-                return (None, None)
-
-            GRPC_CLIENT_OPTIONS.append(('grpc.ssl_target_name_override', '{}'.format(target_name)))
-
-            channel = grpc.secure_channel("{}:{}".format(soc_ip, GRPC_PORT), credential, options=GRPC_CLIENT_OPTIONS)
-        else:
-            channel = grpc.insecure_channel("{}:{}".format(soc_ip, GRPC_PORT), options=GRPC_CLIENT_OPTIONS)
-
-        stub = linkmgr_grpc_driver_pb2_grpc.DualToRActiveStub(channel)
-
-        channel_ready = grpc.channel_ready_future(channel)
-
         try:
             channel_ready.result(timeout=2)
         except grpc.FutureTimeoutError:
-            channel = None
-            stub = None
+            helper_logger.log_warning("gRPC port {} state changed to SHUTDOWN".format(port))
         else:
             break
 
+def create_channel(type,level, kvp, soc_ip, port):
+
+    channel, stub = None, None
+    def wait_for_state_change(channel_connectivity):
+        if channel_connectivity == grpc.ChannelConnectivity.TRANSIENT_FAILURE:
+            helper_logger.log_notice("gRPC port {} state changed to TRANSIENT_FAILURE".format(port))
+        if channel_connectivity == grpc.ChannelConnectivity.CONNECTING:
+            helper_logger.log_notice("gRPC port {} state changed to CONNECTING".format(port))
+        if channel_connectivity == grpc.ChannelConnectivity.READY:
+            helper_logger.log_notice("gRPC port {} state changed to READY".format(port))
+        if channel_connectivity == grpc.ChannelConnectivity.IDLE:
+            helper_logger.log_notice("gRPC port {} state changed to IDLE".format(port))
+        if channel_connectivity == grpc.ChannelConnectivity.SHUTDOWN:
+            helper_logger.log_notice("gRPC port {} state changed to SHUTDOWN".format(port))
+
+
+    if type == "secure": 
+        credential = get_grpc_credentials(level, kvp)
+        target_name = kvp.get("grpc_ssl_credential", None)
+        if credential is None or target_name is None:
+            return (None, None)
+
+        GRPC_CLIENT_OPTIONS.append(('grpc.ssl_target_name_override', '{}'.format(target_name)))
+
+        channel = grpc.secure_channel("{}:{}".format(soc_ip, GRPC_PORT), credential, options=GRPC_CLIENT_OPTIONS)
+    else:
+        channel = grpc.insecure_channel("{}:{}".format(soc_ip, GRPC_PORT), options=GRPC_CLIENT_OPTIONS)
+
+
+    stub = linkmgr_grpc_driver_pb2_grpc.DualToRActiveStub(channel)
+
+
+    if channel is not None:
+        channel.subscribe(wait_for_state_change)
+
+    connect_channel(channel, stub, port)
+    if channel is None:
+        helper_logger.log_notice("gRPC port {} channel is None".format(port))
+    if stub is None:
+        helper_logger.log_notice("gRPC port {} stub is None".format(port))
+   
     return channel, stub
 
 def setup_grpc_channel_for_port(port, soc_ip):
@@ -490,12 +514,7 @@ def setup_grpc_channel_for_port(port, soc_ip):
         kvp = dict(fvs)
 
 
-    channel, stub = create_channel(type, level, kvp, soc_ip) 
-
-    if stub is None:
-        helper_logger.log_warning("stub was not setup for gRPC soc ip {} port {}, no gRPC soc server running ?".format(soc_ip, port))
-    if channel is None:
-        helper_logger.log_warning("channel was not setup for gRPC soc ip {} port {}, no gRPC server running ?".format(soc_ip, port))
+    channel, stub = create_channel(type, level, kvp, soc_ip, port) 
 
     return channel, stub
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -421,9 +421,11 @@ def connect_channel(channel, stub, port):
         else:
             break
 
-def create_channel(type,level, kvp, soc_ip, port):
+def create_channel(type, level, kvp, soc_ip, port):
 
     channel, stub = None, None
+
+    #Helper callback to get an channel connectivity state
     def wait_for_state_change(channel_connectivity):
         if channel_connectivity == grpc.ChannelConnectivity.TRANSIENT_FAILURE:
             helper_logger.log_notice("gRPC port {} state changed to TRANSIENT_FAILURE".format(port))
@@ -458,8 +460,9 @@ def create_channel(type,level, kvp, soc_ip, port):
 
     #connect_channel(channel, stub, port)
     """
-    Removing the connect channel call for now, since it is not required for normal gRPC
-    and all use cases seem to work without it
+    Comment the connect channel call for now, since it is not required for normal gRPC I/O
+    and all use cases seem to work without it.
+    TODO: will need to see if this subroutine call can be ommitted for all use cases
     """
 
     return channel, stub


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
This PR attempts to remove this call
`channel_ready = grpc.channel_ready_future` for the ycabled gRPC implementation. The reason to do this is incase of channel not being connected ycabled tries to reattempt the channel creation again with each RPC request from linkmgrd. 
This is not the right way to maintain the channels/stubs, and actually adds unrequired overhead for ycabled. This PR supports creating channel/stub in ycabled in correct manner. 


<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
Required to reduce CPU usage for ycabled
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Deploying the changes on Arista testbed and UT
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
