### PR TITLE
Fix xcvrd to support 400G ZR optic

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -515,6 +515,17 @@ class TestXcvrdScript(object):
         mock_xcvr_api.get_laser_config_freq = MagicMock(return_value=0)
         mock_xcvr_api.get_module_type_abbreviation = MagicMock(return_value='QSFP-DD')
         mock_xcvr_api.get_datapath_init_duration = MagicMock(return_value=60000.0)
+        mock_xcvr_api.get_datapath_deinit_duration = MagicMock(return_value=600000.0)
+        mock_xcvr_api.get_dpinit_pending = MagicMock(return_value={
+            'DPInitPending1': False,
+            'DPInitPending2': False,
+            'DPInitPending3': False,
+            'DPInitPending4': False,
+            'DPInitPending5': False,
+            'DPInitPending6': False,
+            'DPInitPending7': False,
+            'DPInitPending8': False
+        })
         mock_xcvr_api.get_application_advertisement = MagicMock(return_value={
             1: {
                 'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)',
@@ -705,7 +716,7 @@ class TestXcvrdScript(object):
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         wait_time = 5
         while wait_time > 0:
-            task.on_port_config_change(None, port_change_event)
+            task.on_port_config_change(port_change_event)
             if task.port_mapping.logical_port_list:
                 break
             wait_time -= 1
@@ -718,7 +729,7 @@ class TestXcvrdScript(object):
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_REMOVE)
         wait_time = 5
         while wait_time > 0:
-            task.on_port_config_change(None, port_change_event)
+            task.on_port_config_change(port_change_event)
             if not task.port_mapping.logical_port_list:
                 break
             wait_time -= 1

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -634,14 +634,14 @@ class TestXcvrdScript(object):
         task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
-        task.on_port_config_change(None, port_change_event)
+        task.on_port_config_change(port_change_event)
         assert task.port_mapping.logical_port_list.count('Ethernet0')
         assert task.port_mapping.get_asic_id_for_logical_port('Ethernet0') == 0
         assert task.port_mapping.get_physical_to_logical(1) == ['Ethernet0']
         assert task.port_mapping.get_logical_to_physical('Ethernet0') == [1]
 
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_REMOVE)
-        task.on_port_config_change(None, port_change_event)
+        task.on_port_config_change(port_change_event)
         assert not task.port_mapping.logical_port_list
         assert not task.port_mapping.logical_to_physical
         assert not task.port_mapping.physical_to_logical
@@ -704,7 +704,7 @@ class TestXcvrdScript(object):
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         wait_time = 5
         while wait_time > 0:
-            task.on_port_config_change(port_change_event)
+            task.on_port_config_change(None, port_change_event)
             if task.port_mapping.logical_port_list:
                 break
             wait_time -= 1
@@ -717,7 +717,7 @@ class TestXcvrdScript(object):
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_REMOVE)
         wait_time = 5
         while wait_time > 0:
-            task.on_port_config_change(port_change_event)
+            task.on_port_config_change(None, port_change_event)
             if not task.port_mapping.logical_port_list:
                 break
             wait_time -= 1

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -516,6 +516,7 @@ class TestXcvrdScript(object):
         mock_xcvr_api.get_module_type_abbreviation = MagicMock(return_value='QSFP-DD')
         mock_xcvr_api.get_datapath_init_duration = MagicMock(return_value=60000.0)
         mock_xcvr_api.get_datapath_deinit_duration = MagicMock(return_value=600000.0)
+        mock_xcvr_api.get_cmis_rev = MagicMock(return_value='5.0')
         mock_xcvr_api.get_dpinit_pending = MagicMock(return_value={
             'DPInitPending1': True,
             'DPInitPending2': True,

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -517,14 +517,14 @@ class TestXcvrdScript(object):
         mock_xcvr_api.get_datapath_init_duration = MagicMock(return_value=60000.0)
         mock_xcvr_api.get_datapath_deinit_duration = MagicMock(return_value=600000.0)
         mock_xcvr_api.get_dpinit_pending = MagicMock(return_value={
-            'DPInitPending1': False,
-            'DPInitPending2': False,
-            'DPInitPending3': False,
-            'DPInitPending4': False,
-            'DPInitPending5': False,
-            'DPInitPending6': False,
-            'DPInitPending7': False,
-            'DPInitPending8': False
+            'DPInitPending1': True,
+            'DPInitPending2': True,
+            'DPInitPending3': True,
+            'DPInitPending4': True,
+            'DPInitPending5': True,
+            'DPInitPending6': True,
+            'DPInitPending7': True,
+            'DPInitPending8': True
         })
         mock_xcvr_api.get_application_advertisement = MagicMock(return_value={
             1: {

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -514,6 +514,7 @@ class TestXcvrdScript(object):
         mock_xcvr_api.get_tx_config_power = MagicMock(return_value=0)
         mock_xcvr_api.get_laser_config_freq = MagicMock(return_value=0)
         mock_xcvr_api.get_module_type_abbreviation = MagicMock(return_value='QSFP-DD')
+        mock_xcvr_api.get_datapath_init_duration = MagicMock(return_value=60000.0)
         mock_xcvr_api.get_application_advertisement = MagicMock(return_value={
             1: {
                 'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)',

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -634,14 +634,14 @@ class TestXcvrdScript(object):
         task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
-        task.on_port_config_change(port_change_event)
+        task.on_port_config_change(None, port_change_event)
         assert task.port_mapping.logical_port_list.count('Ethernet0')
         assert task.port_mapping.get_asic_id_for_logical_port('Ethernet0') == 0
         assert task.port_mapping.get_physical_to_logical(1) == ['Ethernet0']
         assert task.port_mapping.get_logical_to_physical('Ethernet0') == [1]
 
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_REMOVE)
-        task.on_port_config_change(port_change_event)
+        task.on_port_config_change(None, port_change_event)
         assert not task.port_mapping.logical_port_list
         assert not task.port_mapping.logical_to_physical
         assert not task.port_mapping.physical_to_logical

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1637,7 +1637,7 @@ class DomInfoUpdateTask(object):
         self.task_stopping_event.set()
         self.task_thread.join()
 
-    def on_port_config_change(self, stopping_event, port_change_event):
+    def on_port_config_change(self, port_change_event):
         if port_change_event.event_type == port_mapping.PortChangeEvent.PORT_REMOVE:
             self.on_remove_logical_port(port_change_event)
         self.port_mapping.handle_port_change_event(port_change_event)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1490,7 +1490,9 @@ class CmisManagerTask:
                         # TODO: Make sure this doesn't impact other datapaths
                         api.set_lpmode(False)
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_AP_CONF
-                        self.port_dict[lport]['cmis_expired'] = now + datetime.timedelta(seconds=self.get_cmis_dp_deinit_duration_secs(api))
+                        dpDeinitDuration = self.get_cmis_dp_deinit_duration_secs(api)
+                        self.log_notice("{} DpDeinit duration {} secs".format(lport, dpDeinitDuration))
+                        self.port_dict[lport]['cmis_expired'] = now + datetime.timedelta(seconds=dpDeinitDuration)
                     elif state == self.CMIS_STATE_AP_CONF:
                         # TODO: Use fine grained time when the CMIS memory map is available
                         if not self.check_module_state(api, ['ModuleReady']):
@@ -1553,7 +1555,9 @@ class CmisManagerTask:
 
                         # D.1.3 Software Configuration and Initialization
                         api.set_datapath_init(host_lanes)
-                        self.port_dict[lport]['cmis_expired'] = now + datetime.timedelta(seconds=self.get_cmis_dp_init_duration_secs(api))
+                        dpInitDuration = self.get_cmis_dp_init_duration_secs(api)
+                        self.log_notice("{} DpInit duration {} secs".format(lport, dpInitDuration))
+                        self.port_dict[lport]['cmis_expired'] = now + datetime.timedelta(seconds=dpInitDuration)
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_DP_TXON
                     elif state == self.CMIS_STATE_DP_TXON:
                         if not self.check_datapath_state(api, host_lanes, ['DataPathInitialized']):

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1960,7 +1960,7 @@ class SfpStateUpdateTask(object):
         self.task_stopping_event.set()
         os.kill(self.task_process.pid, signal.SIGKILL)
 
-    def on_port_config_change(self , port_change_event):
+    def on_port_config_change(self, stopping_event, port_change_event):
         if port_change_event.event_type == port_mapping.PortChangeEvent.PORT_REMOVE:
             self.on_remove_logical_port(port_change_event)
             self.port_mapping.handle_port_change_event(port_change_event)


### PR DESCRIPTION
Fix Xcvrd code to support 400G ZR optic

#### Description
While bringing the 400G ZR module, I found an issue where some 400G ZR optics may take more than 60 secs to finish up the Datapath initialization. This is a problem because the xcvrd uses a hardcoded 60 secs Datapath initialization timeout for all CMIS modules and apparently, this 60 secs timeout is not sufficient for the 400G ZR module.
The CMIS spec has Datapath init/de-init timeout values defined in Byte 144. We can use these values from the EEPROM instead of presenting any hardcoded values.

#### Motivation and Context
This is needed to bring up 400G ZR module.

#### How Has This Been Tested?
These changes are tested against arista_7800r3a_36d2_lc and arista_7280cr3_32p4 platforms.