### PR TITLE
[ycabled] add support for getting grpc secerts via shared file

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5360,7 +5360,7 @@ class TestYCableScript(object):
 
     def test_apply_grpc_secrets_configuration(self):
 
-        parsed_data = "{'GRPCCLIENT': {'config': {'type': 'secure', 'auth_level': 'server', 'log_level': 'info'}, 'certs': {'client_crt': 'one.crt', 'client_key': 'one.key', 'ca_crt': 'ss.crt', 'grpc_ssl_credential': 'jj.tsl'}}}"
+        parsed_data = "{"GRPCCLIENT": {"config": {"type": "secure", "auth_level": "server", "log_level": "info"}, "certs": {"client_crt": "one.crt", "client_key": "one.key", "ca_crt": "ss.crt", "grpc_ssl_credential": "jj.tsl"}}}"
 
         with patch('builtins.open', new_callable=mock_open, read_data= parsed_data) as mock_fd:
             rc = apply_grpc_secrets_configuration('test')

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5360,7 +5360,7 @@ class TestYCableScript(object):
 
     def test_apply_grpc_secrets_configuration(self):
 
-        parsed_data = {'GRPCCLIENT': {'config': {'type': 'secure', 'auth_level': 'server', 'log_level': 'info'}, 'certs': {'client_crt': 'one.crt', 'client_key': 'one.key', 'ca_crt': 'ss.crt', 'grpc_ssl_credential': 'jj.tsl'}}}
+        parsed_data = "{'GRPCCLIENT': {'config': {'type': 'secure', 'auth_level': 'server', 'log_level': 'info'}, 'certs': {'client_crt': 'one.crt', 'client_key': 'one.key', 'ca_crt': 'ss.crt', 'grpc_ssl_credential': 'jj.tsl'}}}"
 
         with patch('builtins.open', new_callable=mock_open, read_data= parsed_data) as mock_fd:
             rc = apply_grpc_secrets_configuration('test')

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5358,10 +5358,18 @@ class TestYCableScript(object):
         rc = handle_ycable_enable_disable_tel_notification(fvp_m, "Y_CABLE")
         assert(rc == None)
 
-    def test_apply_grpc_secrets_configuration(self):
 
-        parsed_data = "{"GRPCCLIENT": {"config": {"type": "secure", "auth_level": "server", "log_level": "info"}, "certs": {"client_crt": "one.crt", "client_key": "one.key", "ca_crt": "ss.crt", "grpc_ssl_credential": "jj.tsl"}}}"
+    @patch('builtins.open')
+    #@patch('json.load')
+    def test_apply_grpc_secrets_configuration(self, open):
 
-        with patch('builtins.open', new_callable=mock_open, read_data= parsed_data) as mock_fd:
-            rc = apply_grpc_secrets_configuration('test')
+        parsed_data = {'GRPCCLIENT': {'config': {'type': 'secure', 'auth_level': 'server', 'log_level': 'info'}, 'certs': {'client_crt': 'one.crt', 'client_key': 'one.key', 'ca_crt': 'ss.crt', 'grpc_ssl_credential': 'jj.tsl'}}}
+
+        mock_file = MagicMock()
+        mock_file.read = MagicMock(return_value=bytes('abcdefgh', 'utf-8'))
+        open.return_value = mock_file
+        #json_load.return_value = parsed_data
+        with patch('json.load') as patched_util:
+            patched_util.return_value = parsed_data
+            rc = apply_grpc_secrets_configuration(None)
             assert(rc == None)

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -10,9 +10,9 @@ import sys
 import time
 
 if sys.version_info >= (3, 3):
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import MagicMock, patch, mock_open
 else:
-    from mock import MagicMock, patch
+    from mock import MagicMock, patch, mock_open
 
 
 daemon_base.db_connect = MagicMock()
@@ -5358,12 +5358,10 @@ class TestYCableScript(object):
         rc = handle_ycable_enable_disable_tel_notification(fvp_m, "Y_CABLE")
         assert(rc == None)
 
-    @patch('builtins.open')
-    @patch('json.load')
-    def test_apply_grpc_secrets_configuration(self, open, json_load):
+    def test_apply_grpc_secrets_configuration(self):
 
         parsed_data = {'GRPCCLIENT': {'config': {'type': 'secure', 'auth_level': 'server', 'log_level': 'info'}, 'certs': {'client_crt': 'one.crt', 'client_key': 'one.key', 'ca_crt': 'ss.crt', 'grpc_ssl_credential': 'jj.tsl'}}}
 
-        json_load.return_value = parsed_data
-        rc = apply_grpc_secrets_configuration(parsed_data)
-        assert(rc == None)
+        with patch('builtins.open', new_callable=mock_open, read_data= parsed_data) as mock_fd:
+            rc = apply_grpc_secrets_configuration('test')
+            assert(rc == None)

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5358,11 +5358,12 @@ class TestYCableScript(object):
         rc = handle_ycable_enable_disable_tel_notification(fvp_m, "Y_CABLE")
         assert(rc == None)
 
-    def test_apply_grpc_secrets_configuration(self):
+    @patch('builtins.open')
+    @patch('json.load')
+    def test_apply_grpc_secrets_configuration(self, open, json_load):
 
-        parsed_data = {"GRPCCLIENT": {"config":"insecure",
-                                       "auth_level":"server",
-                                       "log_level":"INFO"}}
         parsed_data = {'GRPCCLIENT': {'config': {'type': 'secure', 'auth_level': 'server', 'log_level': 'info'}, 'certs': {'client_crt': 'one.crt', 'client_key': 'one.key', 'ca_crt': 'ss.crt', 'grpc_ssl_credential': 'jj.tsl'}}}
+
+        json_load.return_value = parsed_data
         rc = apply_grpc_secrets_configuration(parsed_data)
         assert(rc == None)

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5360,13 +5360,11 @@ class TestYCableScript(object):
 
 
     @patch('builtins.open')
-    #@patch('json.load')
     def test_apply_grpc_secrets_configuration(self, open):
 
         parsed_data = {'GRPCCLIENT': {'config': {'type': 'secure', 'auth_level': 'server', 'log_level': 'info'}, 'certs': {'client_crt': 'one.crt', 'client_key': 'one.key', 'ca_crt': 'ss.crt', 'grpc_ssl_credential': 'jj.tsl'}}}
 
         mock_file = MagicMock()
-        mock_file.read = MagicMock(return_value=bytes('abcdefgh', 'utf-8'))
         open.return_value = mock_file
         #json_load.return_value = parsed_data
         with patch('json.load') as patched_util:

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5317,6 +5317,7 @@ class TestYCableScript(object):
         assert(rc['nic_lane1_postcursor1'] == 'N/A')
         assert(rc['nic_lane1_postcursor2'] == 'N/A')
 
+    @patch('os.path.isfile', MagicMock(return_value=True))
     def test_get_grpc_credentials(self):
         
         kvp = {}
@@ -5328,6 +5329,7 @@ class TestYCableScript(object):
 
 
     @patch('builtins.open')
+    @patch('os.path.isfile', MagicMock(return_value=True))
     def test_get_grpc_credentials_root(self, open):
         
         kvp = {"ca_crt": "file"}

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5357,3 +5357,12 @@ class TestYCableScript(object):
         fvp_m = {"log_verbosity": "debug"}
         rc = handle_ycable_enable_disable_tel_notification(fvp_m, "Y_CABLE")
         assert(rc == None)
+
+    def test_apply_grpc_secrets_configuration(self):
+
+        parsed_data = {"GRPCCLIENT": {"config":"insecure",
+                                       "auth_level":"server",
+                                       "log_level":"INFO"}}
+        parsed_data = {'GRPCCLIENT': {'config': {'type': 'secure', 'auth_level': 'server', 'log_level': 'info'}, 'certs': {'client_crt': 'one.crt', 'client_key': 'one.key', 'ca_crt': 'ss.crt', 'grpc_ssl_credential': 'jj.tsl'}}}
+        rc = apply_grpc_secrets_configuration(parsed_data)
+        assert(rc == None)

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -429,7 +429,7 @@ def get_grpc_credentials(type, kvp):
             return None
 
         key_file = kvp.get("client_key", None)
-        if key_file is not None and and os.path.isfile(key_file): 
+        if key_file is not None and os.path.isfile(key_file): 
             key = open(key_file, 'rb').read()
         else:
             helper_logger.log_error("grpc credential channel setup no key file for mutual authentication in config_db")

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -1577,8 +1577,8 @@ def delete_ports_status_for_y_cable():
     if read_side != -1:
         asic_index = multi_asic.get_asic_index_from_namespace(DEFAULT_NAMESPACE)
         if os.path.isfile(SECRETS_PATH):
-            grpc_config[asic_id]._del("config")
-            grpc_config[asic_id]._del("certs")
+            grpc_config[asic_index]._del("config")
+            grpc_config[asic_index]._del("certs")
 
     # delete PORTS on Y cable table if ports on Y cable
     logical_port_list = y_cable_platform_sfputil.logical

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -375,7 +375,7 @@ def retry_setup_grpc_channel_for_port(port, asic_index):
 def apply_grpc_secrets_configuration(SECRETS_PATH):
 
 
-    f = open(SECRETS_PATH, 'rb').read()
+    f = open(SECRETS_PATH, 'rb')
     parsed_data = json.load(f)
 
     config_db, grpc_config = {}, {}

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -372,7 +372,11 @@ def retry_setup_grpc_channel_for_port(port, asic_index):
                 grpc_port_stubs[port] = stub
                 return True
 
-def apply_grpc_secrets_configuration(parsed_data):
+def apply_grpc_secrets_configuration(SECRETS_PATH):
+
+
+    with open(SECRETS_PATH, 'r') as f:
+        parsed_data = json.load(f)
 
     config_db, grpc_config = {}, {}
     namespaces = multi_asic.get_front_end_namespaces()
@@ -733,9 +737,7 @@ def setup_grpc_channels(stop_event):
     if read_side == -1:
         read_side = process_loopback_interface_and_get_read_side(loopback_keys)
         if os.path.isfile(SECRETS_PATH):
-            with open(SECRETS_PATH, 'r') as f:
-                parsed_data = json.load(f)
-                apply_grpc_secrets_configuration(parsed_data)
+            apply_grpc_secrets_configuration(SECRETS_PATH)
 
     helper_logger.log_debug("Y_CABLE_DEBUG:while setting up grpc channels read side = {}".format(read_side))
 
@@ -1427,9 +1429,7 @@ def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presen
     if read_side == -1:
         read_side = process_loopback_interface_and_get_read_side(loopback_keys)
         if os.path.isfile(SECRETS_PATH):
-            with open(SECRETS_PATH, 'r') as f:
-                parsed_data = json.load(f)
-                apply_grpc_secrets_configuration(parsed_data)
+            apply_grpc_secrets_configuration(SECRETS_PATH)
 
     # Init PORT_STATUS table if ports are on Y cable
     logical_port_list = y_cable_platform_sfputil.logical
@@ -1493,9 +1493,7 @@ def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, st
     if read_side == -1:
         read_side = process_loopback_interface_and_get_read_side(loopback_keys)
         if os.path.isfile(SECRETS_PATH):
-            with open(SECRETS_PATH, 'r') as f:
-                parsed_data = json.load(f)
-                apply_grpc_secrets_configuration(parsed_data)
+            apply_grpc_secrets_configuration(SECRETS_PATH)
 
 
     # Init PORT_STATUS table if ports are on Y cable and an event is received

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -414,7 +414,7 @@ def apply_grpc_secrets_configuration(SECRETS_PATH):
 def get_grpc_credentials(type, kvp):
 
     root_file = kvp.get("ca_crt", None)
-    if root_file is not None: 
+    if root_file is not None and os.path.isfile(root_file): 
         root_cert = open(root_file, 'rb').read()
     else:
         helper_logger.log_error("grpc credential channel setup no root file in config_db")
@@ -422,14 +422,14 @@ def get_grpc_credentials(type, kvp):
 
     if type == "mutual":
         cert_file = kvp.get("client_crt", None)
-        if cert_file is not None: 
+        if cert_file is not None and os.path.isfile(cert_file): 
             cert_chain = open(cert_file, 'rb').read()
         else:
             helper_logger.log_error("grpc credential channel setup no cert file for mutual authentication in config_db")
             return None
 
         key_file = kvp.get("client_key", None)
-        if key_file is not None: 
+        if key_file is not None and and os.path.isfile(key_file): 
             key = open(key_file, 'rb').read()
         else:
             helper_logger.log_error("grpc credential channel setup no key file for mutual authentication in config_db")

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -375,8 +375,8 @@ def retry_setup_grpc_channel_for_port(port, asic_index):
 def apply_grpc_secrets_configuration(SECRETS_PATH):
 
 
-    with open(SECRETS_PATH, 'r') as f:
-        parsed_data = json.load(f)
+    f = open(SECRETS_PATH, 'rb').read()
+    parsed_data = json.load(f)
 
     config_db, grpc_config = {}, {}
     namespaces = multi_asic.get_front_end_namespaces()


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
This PR adds support for adding the secrets to grpc client in `active-active` configuration via a shared file
`/etc/sonic/grpc_secrets.json`.
Using this file, secrets configuration in populated inside CONFIG_DB,
absence of this file will assume insecure gRPC client. 
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
testing with UT and putting the changes on Arista testbed
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
