### PR TITLE
Remove shell=True

### DIFF
--- a/sonic-pcied/tests/mocked_libs/sonic_platform_base/sonic_pcie/pcie_common.py
+++ b/sonic-pcied/tests/mocked_libs/sonic_platform_base/sonic_pcie/pcie_common.py
@@ -39,14 +39,14 @@ class PcieUtil(PcieBase):
         pciList = []
         p1 = "^(\w+):(\w+)\.(\w)\s(.*)\s*\(*.*\)*"
         p2 = "^.*:.*:.*:(\w+)\s*\(*.*\)*"
-        command1 = "sudo lspci"
-        command2 = "sudo lspci -n"
+        command1 = ["sudo", "lspci"]
+        command2 = ["sudo", "lspci", "-n"]
         # run command 1
-        proc1 = subprocess.Popen(command1, shell=True, universal_newlines=True, stdout=subprocess.PIPE)
+        proc1 = subprocess.Popen(command1, universal_newlines=True, stdout=subprocess.PIPE)
         output1 = proc1.stdout.readlines()
         (out, err) = proc1.communicate()
         # run command 2
-        proc2 = subprocess.Popen(command2, shell=True, universal_newlines=True, stdout=subprocess.PIPE)
+        proc2 = subprocess.Popen(command2, universal_newlines=True, stdout=subprocess.PIPE)
         output2 = proc2.stdout.readlines()
         (out, err) = proc2.communicate()
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -907,7 +907,7 @@ def is_fast_reboot_enabled():
     keys = fastboot_tbl.getKeys()
 
     if "system" in keys:
-        output = subprocess.check_output('sonic-db-cli STATE_DB get "FAST_REBOOT|system"', shell=True, universal_newlines=True)
+        output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'get', "FAST_REBOOT|system"], universal_newlines=True)
         if "1" in output:
             fastboot_enabled = True
 


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
`subprocess()` - use `shell=False`, use list of strings Ref: [https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation](https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation)
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
`subprocess()` - when using with `shell=True` is dangerous. Using subprocess function without a static string can lead to command injection.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
