### PR TITLE
[ycabled] add some exception catching logic to some vendor specific API's

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -568,6 +568,23 @@ class TestYCableScript(object):
 
         assert(rc == (-1, -1))
 
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    def test_update_tor_active_side_with_read_update_with_exception(self):
+        read_side = -1
+        state = "active"
+        logical_port_name = "Ethernet0"
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+
+            mock_toggle_object = MagicMock()
+            mock_toggle_object.toggle_mux_to_tor_b.return_value = True
+            mock_toggle_object.get_read_side.return_value = NotImplementedError
+            patched_util.get.return_value = mock_toggle_object
+
+            rc = update_tor_active_side(read_side, state, logical_port_name)
+
+        assert(rc == (-1, -1))
+
     def test_get_mux_cable_info_without_presence(self):
 
         rc = get_muxcable_info_without_presence()

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -578,7 +578,7 @@ class TestYCableScript(object):
 
             mock_toggle_object = MagicMock()
             mock_toggle_object.toggle_mux_to_tor_b.return_value = True
-            mock_toggle_object.get_read_side.return_value =  MagicMock(
+            mock_toggle_object.get_read_side =  MagicMock(
                                 side_effect=NotImplementedError)
             patched_util.get.return_value = mock_toggle_object
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -578,7 +578,8 @@ class TestYCableScript(object):
 
             mock_toggle_object = MagicMock()
             mock_toggle_object.toggle_mux_to_tor_b.return_value = True
-            mock_toggle_object.get_read_side.return_value = NotImplementedError
+            mock_toggle_object.get_read_side.return_value =  MagicMock(
+                                side_effect=NotImplementedError)
             patched_util.get.return_value = mock_toggle_object
 
             rc = update_tor_active_side(read_side, state, logical_port_name)

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -895,7 +895,11 @@ def toggle_mux_tor_direction_and_update_read_side(state, logical_port_name, phys
         helper_logger.log_error("Error: Could not get port instance for read side for while processing a toggle Y cable port {} {}".format(physical_port, threading.currentThread().getName()))
         return (-1, -1)
 
-    read_side = port_instance.get_read_side()
+    try:
+        read_side = port_instance.get_read_side()
+    except Exception as e:
+        read_side = None
+        helper_logger.log_warning("Failed to execute the get_read_side API for port {} due to {} from update_read_side".format(logical_port_name,repr(e)))
 
     if read_side is None or read_side is port_instance.EEPROM_ERROR or read_side < 0:
         helper_logger.log_error(
@@ -1962,7 +1966,13 @@ def get_muxcable_info(physical_port, logical_port_name):
                 mux_info_dict["link_status_peer"] = "down"
 
     with y_cable_port_locks[physical_port]:
-        if port_instance.is_link_active(port_instance.TARGET_NIC):
+        try:
+            link_state_tor_nic = port_instance.is_link_active(port_instance.TARGET_NIC)
+        except Exception as e:
+            link_state_tor_nic = False
+            helper_logger.log_warning("Failed to execute the is_link_active NIC side API for port {} due to {}".format(physical_port,repr(e)))
+
+        if link_state_tor_nic:
             mux_info_dict["link_status_nic"] = "up"
         else:
             mux_info_dict["link_status_nic"] = "down"


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->
This PR adds a try/catch block for some abstract muxcable API's. In particular the exception logic is added for all the API's where there is a possibility for exceptions to be passed by Vendor API's implementation, in this regard ycabled will have all abstract muxcable API's covered by exception logic with this PR.
If the exception is caught it will be just logged and daemon will resume its normal operation.

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Unit-tests and deploying changes on testbed
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
