### PR TITLE
[ycabled] move swsscommon API's from subroutines to call them exactly once per task_worker/thread

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -4030,6 +4030,7 @@ class TestYCableScript(object):
         xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
         xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
         xcvrd_show_fw_res_tbl = mock_swsscommon_table
+        mux_tbl = mock_swsscommon_table
 
         asic_index = 0
         task_download_firmware_thread = {}
@@ -4037,7 +4038,7 @@ class TestYCableScript(object):
         fvp = {"firmware_version": "null"}
 
         rc = handle_show_firmware_show_cmd_arg_tbl_notification(
-            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port, mux_tbl)
         assert(rc == -1)
 
     @patch('swsscommon.swsscommon.Table')
@@ -4056,6 +4057,7 @@ class TestYCableScript(object):
         xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
         xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
         xcvrd_show_fw_res_tbl = mock_swsscommon_table
+        mux_tbl = mock_swsscommon_table
 
         asic_index = 0
         task_download_firmware_thread = {}
@@ -4063,7 +4065,7 @@ class TestYCableScript(object):
         fvp = {"down_firmware": "null"}
 
         rc = handle_show_firmware_show_cmd_arg_tbl_notification(
-            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port, mux)
         assert(rc == None)
 
     @patch('swsscommon.swsscommon.Table')
@@ -4086,6 +4088,7 @@ class TestYCableScript(object):
         xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
         xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
         xcvrd_show_fw_res_tbl = mock_swsscommon_table
+        mux_tbl = mock_swsscommon_table
         asic_index = 0
         task_download_firmware_thread = {}
         port = "Ethernet0"
@@ -4119,7 +4122,7 @@ class TestYCableScript(object):
 
             patched_util.get.return_value = PortInstanceHelper()
             rc = handle_show_firmware_show_cmd_arg_tbl_notification(
-                fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+                fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port, mux_tbl)
             assert(rc == None)
 
     @patch('swsscommon.swsscommon.Table')
@@ -4138,6 +4141,7 @@ class TestYCableScript(object):
         xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
         xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
         xcvrd_show_fw_res_tbl = mock_swsscommon_table
+        mux_tbl = mock_swsscommon_table
 
         asic_index = 0
         task_download_firmware_thread = {}
@@ -4145,7 +4149,7 @@ class TestYCableScript(object):
         fvp = {"firmware_version": "null"}
 
         rc = handle_show_firmware_show_cmd_arg_tbl_notification(
-            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port, mux_tbl)
         assert(rc == -1)
 
     @patch('swsscommon.swsscommon.Table')

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -1805,16 +1805,39 @@ class TestYCableScript(object):
         mock_swsscommon_table.return_value = mock_table
 
         mock_logical_port_name = [""]
+        state_db = {}
+        test_db = "TEST_DB"
+        static_tbl = {}
+        mux_tbl = {}
+        port_tbl = {}
+        fvs = [('state', "auto"), ('read_side', 1)]
+        asic_index = 0
+        status = True
+        y_cable_tbl = {}
+        grpc_config = {}
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+        static_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "STATIC_TABLE")
+        static_tbl[asic_index].get.return_value = (status, fvs)
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "MUX_TABLE")
+        mux_tbl[asic_index].get.return_value = (status, fvs)
 
-        def mock_get_asic_id(mock_logical_port_name):
-            return 0
+        port_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        port_tbl[asic_index].get.return_value = (status, fvs)
+        grpc_config[asic_index] = swsscommon.Table(
+            test_db[asic_index], "GRPC_CONFIG")
+
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
             patched_util.logical.return_value = ['Ethernet0', 'Ethernet4']
             patched_util.get_asic_id_for_logical_port.return_value = 0
 
-            rc = delete_ports_status_for_y_cable()
+            rc = delete_ports_status_for_y_cable(y_cable_tbl, static_tbl, mux_tbl, port_tbl, grpc_config)
 
             mock_swsscommon_table.assert_called()
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -1663,6 +1663,7 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_chassis')
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
     @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.process_loopback_interface_and_get_read_side',MagicMock(return_value=0))
     def test_init_ports_status_for_y_cable(self, platform_chassis, platform_sfp, mock_swsscommon_table):
 
         platform_sfp = MagicMock()
@@ -1678,9 +1679,35 @@ class TestYCableScript(object):
         mock_table = MagicMock()
         mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
         mock_swsscommon_table.return_value = mock_table
+        state_db = {}
+        test_db = "TEST_DB"
+        static_tbl = {}
+        mux_tbl = {}
+        port_tbl = {}
+        port_table_keys = {}
+        loopback_keys = {}
+        hw_mux_cable_tbl, hw_mux_cable_tbl_peer = {}, {}
+        y_cable_presence = [True]
+        delete_change_event = [True]
+        fvs = [('state', "auto"), ('read_side', 1)]
+        asic_index = 0
+        status = True
+        y_cable_tbl = {}
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+        static_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "STATIC_TABLE")
+        static_tbl[asic_index].get.return_value = (status, fvs)
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "MUX_TABLE")
+        mux_tbl[asic_index].get.return_value = (status, fvs)
 
-        rc = init_ports_status_for_y_cable(platform_sfp, platform_chassis,
-                                           y_cable_presence,  stop_event=threading.Event())
+        port_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        port_tbl[asic_index].get.return_value = (status, fvs)
+
+        rc = init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presence,  state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, port_table_keys, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, stop_event=threading.Event())
 
         assert(rc == None)
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -192,9 +192,19 @@ class TestYCableScript(object):
                                                                                                'version_peer_inactive': '1.7MS',
                                                                                                'version_peer_next': '1.7MS'}))
     def test_post_port_mux_info_to_db(self):
+        asic_index = 0
         logical_port_name = "Ethernet0"
-        mux_tbl = Table("STATE_DB", "Y_CABLE_INFO_TABLE")
-        rc = post_port_mux_info_to_db(logical_port_name, mux_tbl,'active-standby')
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        rc = post_port_mux_info_to_db(logical_port_name, mux_tbl,asic_index, y_cable_tbl, 'active-standby')
         assert(rc != -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
@@ -704,6 +714,9 @@ class TestYCableScript(object):
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
         read_side = 1
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
             def mock_get():
@@ -712,7 +725,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = mock_get()
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -721,6 +734,9 @@ class TestYCableScript(object):
         asic_index = 0
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
             def mock_read_side():
@@ -731,7 +747,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = 0
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -741,6 +757,9 @@ class TestYCableScript(object):
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
         read_side = 1
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -756,7 +775,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = PortInstanceHelper()
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -766,6 +785,9 @@ class TestYCableScript(object):
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
         read_side = 1
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -779,7 +801,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = PortInstanceHelper()
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -789,6 +811,9 @@ class TestYCableScript(object):
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
         read_side = 2
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -802,7 +827,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = PortInstanceHelper()
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -812,6 +837,9 @@ class TestYCableScript(object):
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
         read_side = 1
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -825,7 +853,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = PortInstanceHelper()
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -835,6 +863,9 @@ class TestYCableScript(object):
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
         read_side = 1
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -848,7 +879,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = PortInstanceHelper()
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0, 1, 2]))
@@ -857,6 +888,9 @@ class TestYCableScript(object):
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
         read_side = 1
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -870,7 +904,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = PortInstanceHelper()
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0, 1, 2]))
@@ -1091,6 +1125,15 @@ class TestYCableScript(object):
         y_cable_tbl = {}
         static_tbl = {}
         mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+        static_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "STATIC_TABLE")
+        static_tbl[asic_index].get.return_value = (status, fvs)
 
         rc = create_tables_and_insert_mux_unknown_entries(
             state_db, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name)
@@ -1562,6 +1605,10 @@ class TestYCableScript(object):
         mux_tbl = {}
         port_tbl = {}
         y_cable_presence = [False]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+        static_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], MUX_CABLE_STATIC_INFO_TABLE)
 
         port_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "PORT_INFO_TABLE")
@@ -1582,17 +1629,27 @@ class TestYCableScript(object):
 
         asic_index = 0
         logical_port_name = "Ethernet0"
-        status = True
-        fvs = [('state', "auto"), ('read_side', 1)]
 
         state_db = {}
         test_db = "TEST_DB"
-        y_cable_tbl = {}
         static_tbl = {}
         mux_tbl = {}
         port_tbl = {}
         y_cable_presence = [True]
         delete_change_event = [True]
+        fvs = [('state', "auto"), ('read_side', 1)]
+        asic_index = 0
+        status = True
+        y_cable_tbl = {}
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+        static_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "STATIC_TABLE")
+        static_tbl[asic_index].get.return_value = (status, fvs)
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "MUX_TABLE")
+        mux_tbl[asic_index].get.return_value = (status, fvs)
 
         port_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "PORT_INFO_TABLE")
@@ -1600,7 +1657,7 @@ class TestYCableScript(object):
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as port_instance:
             rc = check_identifier_presence_and_delete_mux_table_entry(
-                state_db, port_tbl, asic_index, logical_port_name, y_cable_presence,  delete_change_event)
+                state_db, port_tbl, asic_index, logical_port_name, y_cable_presence,  delete_change_event, y_cable_tbl, static_tbl, mux_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_chassis')
@@ -1740,7 +1797,18 @@ class TestYCableScript(object):
 
         state_db = {}
         test_db = "TEST_DB"
+        status = True
         mux_tbl = {}
+        y_cable_tbl = {}
+        static_tbl = {}
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+        static_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "STATIC_TABLE")
+        static_tbl[asic_index].get.return_value = (status, fvs)
+
 
         mux_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], MUX_CABLE_INFO_TABLE)
@@ -1749,33 +1817,39 @@ class TestYCableScript(object):
 
             patched_util.logical.return_value = ['Ethernet0', 'Ethernet4']
             rc = check_identifier_presence_and_update_mux_info_entry(
-                state_db, mux_tbl, asic_index, logical_port_name)
+                state_db, mux_tbl, asic_index, logical_port_name, y_cable_tbl, static_tbl)
+
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
-    def test_get_firmware_dict(self, port_instance):
+    @patch('swsscommon.swsscommon.Table')
+    def test_get_firmware_dict(self, port_instance, mock_swsscommon_table):
 
         port_instance = MagicMock()
         port_instance.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
         port_instance.download_firmware_status = 1
 
+        test_db = "TEST_DB"
         physical_port = 1
         target = "simulated_target"
         side = "a"
         mux_info_dict = {}
         logical_port_name = "Ethernet0"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        mux_tbl = {}
+        asic_index = 0
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        mux_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
 
-            status = True
-            fvs = [('state', "auto"), ('read_side', 1)]
-            Table = MagicMock()
-            Table.get.return_value = (status, fvs)
 
             rc = get_firmware_dict(
-                physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
+                physical_port, port_instance, target, side, mux_info_dict, logical_port_name, mux_tbl)
 
             assert(mux_info_dict['version_a_active'] == None)
             assert(mux_info_dict['version_a_inactive'] == None)
@@ -1793,6 +1867,14 @@ class TestYCableScript(object):
         side = "a"
         mux_info_dict = {}
         logical_port_name = "Ethernet0"
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        mux_tbl = {}
+        asic_index = 0
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        mux_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
@@ -1806,7 +1888,7 @@ class TestYCableScript(object):
                 False, {"read_side": "2"})
 
             rc = get_firmware_dict(
-                physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
+                physical_port, port_instance, target, side, mux_info_dict, logical_port_name, mux_tbl)
 
             assert(mux_info_dict['version_a_active'] == "N/A")
             assert(mux_info_dict['version_a_inactive'] == "N/A")
@@ -1827,6 +1909,14 @@ class TestYCableScript(object):
         side = "a"
         mux_info_dict = {}
         logical_port_name = "Ethernet0"
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        mux_tbl = {}
+        asic_index = 0
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        mux_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
@@ -1838,7 +1928,7 @@ class TestYCableScript(object):
             Table.get.return_value = (status, fvs)
 
             rc = get_firmware_dict(
-                physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
+                physical_port, port_instance, target, side, mux_info_dict, logical_port_name, mux_tbl)
 
             assert(mux_info_dict['version_a_active'] == "N/A")
             assert(mux_info_dict['version_a_inactive'] == "N/A")
@@ -1859,6 +1949,14 @@ class TestYCableScript(object):
         side = "a"
         mux_info_dict = {}
         logical_port_name = "Ethernet0"
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        mux_tbl = {}
+        asic_index = 0
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        mux_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
@@ -1870,7 +1968,7 @@ class TestYCableScript(object):
             Table.get.return_value = (status, fvs)
 
             rc = get_firmware_dict(
-                physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
+                physical_port, port_instance, target, side, mux_info_dict, logical_port_name, mux_tbl)
 
             assert(mux_info_dict['version_a_active'] == "2021")
             assert(mux_info_dict['version_a_inactive'] == "2020")
@@ -1885,6 +1983,15 @@ class TestYCableScript(object):
         swsscommon.Table.return_value.get.return_value = (
             True, {"read_side": "1"})
         platform_sfputil.get_asic_id_for_logical_port = 0
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -1936,7 +2043,7 @@ class TestYCableScript(object):
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
 
-                rc = get_muxcable_info(physical_port, logical_port_name)
+                rc = get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
                 assert(rc['tor_active'] == 'active')
                 assert(rc['mux_direction'] == 'self')
@@ -1951,6 +2058,16 @@ class TestYCableScript(object):
         platform_sfputil.get_asic_id_for_logical_port = 0
         swsscommon.Table.return_value.get.return_value = (
             True, {"read_side": "2"})
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 2)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -2002,7 +2119,7 @@ class TestYCableScript(object):
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
 
-                rc = get_muxcable_info(physical_port, logical_port_name)
+                rc = get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
                 assert(rc['tor_active'] == 'standby')
                 assert(rc['mux_direction'] == 'peer')
@@ -2015,6 +2132,16 @@ class TestYCableScript(object):
 
         logical_port_name = "Ethernet20"
         platform_sfputil.get_asic_id_for_logical_port = 0
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -2066,7 +2193,7 @@ class TestYCableScript(object):
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
 
-                rc = get_muxcable_info(physical_port, logical_port_name)
+                rc = get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
                 assert(rc['tor_active'] == 'unknown')
                 assert(rc['mux_direction'] == 'unknown')
@@ -2081,6 +2208,16 @@ class TestYCableScript(object):
         platform_sfputil.get_asic_id_for_logical_port = 0
         swsscommon.Table.return_value.get.return_value = (
             True, {"read_side": "2"})
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 2)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -2132,7 +2269,7 @@ class TestYCableScript(object):
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
 
-                rc = get_muxcable_info(physical_port, logical_port_name)
+                rc = get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
                 assert(rc['tor_active'] == 'unknown')
                 assert(rc['mux_direction'] == 'unknown')
@@ -2145,6 +2282,16 @@ class TestYCableScript(object):
 
         logical_port_name = "Ethernet20"
         platform_sfputil.get_asic_id_for_logical_port = 0
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -2196,7 +2343,7 @@ class TestYCableScript(object):
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
 
-                rc = get_muxcable_info(physical_port, logical_port_name)
+                rc = get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
                 assert(rc['tor_active'] == 'unknown')
                 assert(rc['mux_direction'] == 'unknown')
@@ -2211,6 +2358,16 @@ class TestYCableScript(object):
         platform_sfputil.get_asic_id_for_logical_port = 0
         swsscommon.Table.return_value.get.return_value = (
             True, {"read_side": "2"})
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 2)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -2261,7 +2418,7 @@ class TestYCableScript(object):
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
 
-                rc = get_muxcable_info(physical_port, logical_port_name)
+                rc = get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
                 assert(rc['tor_active'] == 'unknown')
                 assert(rc['mux_direction'] == 'unknown')
@@ -4065,7 +4222,7 @@ class TestYCableScript(object):
         fvp = {"down_firmware": "null"}
 
         rc = handle_show_firmware_show_cmd_arg_tbl_notification(
-            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port, mux)
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port, mux_tbl)
         assert(rc == None)
 
     @patch('swsscommon.swsscommon.Table')

--- a/sonic-ycabled/tests/test_ycable.py
+++ b/sonic-ycabled/tests/test_ycable.py
@@ -160,8 +160,18 @@ class TestYcableScript(object):
                                                                                                'version_peer_next': '1.7MS'}))
     def test_post_port_mux_info_to_db(self):
         logical_port_name = "Ethernet0"
-        mux_tbl = Table("STATE_DB", y_cable_helper.MUX_CABLE_INFO_TABLE)
-        rc = post_port_mux_info_to_db(logical_port_name, mux_tbl, 'active-standby')
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        rc = post_port_mux_info_to_db(logical_port_name, mux_tbl,asic_index, y_cable_tbl, 'active-standby')
         assert(rc != -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -118,7 +118,7 @@ class YcableInfoUpdateTask(object):
 
                 if not detect_port_in_error_status(logical_port_name, self.table_helper.get_status_tbl()[asic_index]):
                     if y_cable_presence[0] is True:
-                        y_cable_helper.check_identifier_presence_and_update_mux_info_entry(self.table_helper.get_state_db(), self.table_helper.get.mux_tbl(), asic_index, logical_port_name, self.table_helper.get_y_cable_tbl(), self.table_helper.get_port_tbl())
+                        y_cable_helper.check_identifier_presence_and_update_mux_info_entry(self.table_helper.get_state_db(), self.table_helper.get_mux_tbl(), asic_index, logical_port_name, self.table_helper.get_y_cable_tbl(), self.table_helper.get_port_tbl())
 
         helper_logger.log_info("Stop DOM monitoring loop")
 

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -162,12 +162,19 @@ class YcableStateUpdateTask(object):
         self.task_process = None
         self.task_stopping_event = threading.Event()
         self.sfp_insert_events = {}
+        self.state_db, self.status_tbl= {}, {}
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.status_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
+
 
     def task_worker(self, stopping_event, sfp_error_event, y_cable_presence):
         helper_logger.log_info("Start Ycable monitoring loop")
 
         # Connect to STATE_DB and listen to ycable transceiver status update tables
-        state_db, status_tbl= {}, {}
 
         sel = swsscommon.Select()
 
@@ -175,10 +182,7 @@ class YcableStateUpdateTask(object):
         namespaces = multi_asic.get_front_end_namespaces()
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-            state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
-            status_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
-            sel.addSelectable(status_tbl[asic_id])
+            sel.addSelectable(self.status_tbl[asic_id])
 
         while True:
 
@@ -203,7 +207,7 @@ class YcableStateUpdateTask(object):
             asic_index = multi_asic.get_asic_index_from_namespace(namespace)
 
             while True:
-                (port, op, fvp) = status_tbl[asic_index].pop()
+                (port, op, fvp) = self.status_tbl[asic_index].pop()
                 if not port:
                     break
 
@@ -242,6 +246,41 @@ class DaemonYcable(daemon_base.DaemonBase):
         self.stop_event = threading.Event()
         self.sfp_error_event = threading.Event()
         self.y_cable_presence = [False]
+        self.config_db, self.state_db ,self.metadata_tbl = {}, {}, {}
+        self.port_tbl, self.y_cable_tbl = {}, {}
+        self.static_tbl, self.mux_tbl = {}, {}
+        self.port_table_keys = {}
+        self.xcvrd_log_tbl = {}
+        self.loopback_tbl= {}
+        self.loopback_keys = {}
+        self.hw_mux_cable_tbl = {}
+        self.hw_mux_cable_tbl_peer = {}
+
+        fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'notice')])
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
+            self.metadata_tbl[asic_id] = swsscommon.Table(
+                self.config_db[asic_id], "DEVICE_METADATA")
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
+            self.port_table_keys[asic_id] = self.port_tbl[asic_id].getKeys()
+            self.xcvrd_log_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "XCVRD_LOG")
+            self.xcvrd_log_tbl[asic_id].set("Y_CABLE", fvs_updated)
+            self.loopback_tbl[asic_id] = swsscommon.Table(
+                self.config_db[asic_id], "LOOPBACK_INTERFACE")
+            self.loopback_keys[asic_id] = self.loopback_tbl[asic_id].getKeys()
+            self.hw_mux_cable_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            self.hw_mux_cable_tbl_peer[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
+            self.y_cable_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            self.static_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
+            self.mux_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], MUX_CABLE_INFO_TABLE)
 
     # Signal handler
     def signal_handler(self, sig, frame):
@@ -262,20 +301,13 @@ class DaemonYcable(daemon_base.DaemonBase):
         global platform_chassis
 
         self.log_info("Start daemon init...")
-        config_db, metadata_tbl, metadata_dict = {}, {}, {}
         is_vs = False
 
-        namespaces = multi_asic.get_front_end_namespaces()
-        for namespace in namespaces:
-            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-            config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
-            metadata_tbl[asic_id] = swsscommon.Table(
-                config_db[asic_id], "DEVICE_METADATA")
 
-        (status, fvs) = metadata_tbl[0].get("localhost")
+        (status, fvs) = self.metadata_tbl[0].get("localhost")
 
         if status is False:
-            helper_logger.log_debug("Could not retreive fieldvalue pairs for {}, inside config_db table {}".format('localhost', metadata_tbl[0].getTableName()))
+            helper_logger.log_debug("Could not retreive fieldvalue pairs for {}, inside config_db table {}".format('localhost', self.metadata_tbl[0].getTableName()))
             return
 
         else:
@@ -330,14 +362,7 @@ class DaemonYcable(daemon_base.DaemonBase):
             self.log_error("Failed to read port info: {}".format(str(e)), True)
             sys.exit(PORT_CONFIG_LOAD_ERROR)
 
-        # Connect to STATE_DB and create ycable tables
-        state_db = {}
-
-        # Get the namespaces in the platform
-        namespaces = multi_asic.get_front_end_namespaces()
-        for namespace in namespaces:
-            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-            state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+        # create ycable tables
 
         """
         # TODO need to decide if we need warm start capability in this ycabled daemon
@@ -353,7 +378,7 @@ class DaemonYcable(daemon_base.DaemonBase):
 
         # Init port y_cable status table
         y_cable_helper.init_ports_status_for_y_cable(
-            platform_sfputil, platform_chassis, self.y_cable_presence, self.stop_event, is_vs)
+            platform_sfputil, platform_chassis, self.y_cable_presence, self.state_db , self.port_tbl, self.y_cable_tbl, self.static_tbl, self.mux_tbl, self.port_table_keys,  self.loopback_keys , self.hw_mux_cable_tbl, self.hw_mux_cable_tbl_peer, self.stop_event, is_vs)
 
     # Deinitialize daemon
     def deinit(self):

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -255,6 +255,7 @@ class DaemonYcable(daemon_base.DaemonBase):
         self.loopback_keys = {}
         self.hw_mux_cable_tbl = {}
         self.hw_mux_cable_tbl_peer = {}
+        self.grpc_config = {}
 
         fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'notice')])
         namespaces = multi_asic.get_front_end_namespaces()
@@ -281,6 +282,7 @@ class DaemonYcable(daemon_base.DaemonBase):
                 self.state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
             self.mux_tbl[asic_id] = swsscommon.Table(
                 self.state_db[asic_id], MUX_CABLE_INFO_TABLE)
+            self.grpc_config[asic_id] = swsscommon.Table(self.config_db[asic_id], "GRPCCLIENT")
 
     # Signal handler
     def signal_handler(self, sig, frame):
@@ -394,7 +396,7 @@ class DaemonYcable(daemon_base.DaemonBase):
                 continue
 
         if self.y_cable_presence[0] is True:
-            y_cable_helper.delete_ports_status_for_y_cable()
+            y_cable_helper.delete_ports_status_for_y_cable(self.y_cable_tbl, self.static_tbl, self.mux_tbl, self.port_tbl, self.grpc_config)
 
         global_values = globals()
         val = global_values.get('platform_chassis')

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -55,9 +55,6 @@ PORT_CONFIG_LOAD_ERROR = 2
 NOT_IMPLEMENTED_ERROR = 3
 SFP_SYSTEM_ERROR = 4
 
-MUX_CABLE_STATIC_INFO_TABLE = "MUX_CABLE_STATIC_INFO"
-MUX_CABLE_INFO_TABLE = "MUX_CABLE_INFO"
-
 # Global platform specific sfputil class instance
 platform_sfputil = None
 # Global chassis object based on new platform api

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -317,7 +317,7 @@ class DaemonYcable(daemon_base.DaemonBase):
 
         # Init port y_cable status table
         y_cable_helper.init_ports_status_for_y_cable(
-            platform_sfputil, platform_chassis, self.y_cable_presence, self.table_helper.get_state_db , self.table_helper.get_port_tbl(), self.table_helper.get_y_cable_tbl(), self.table_helper.get_static_tbl(), self.table_helper.get_mux_tbl(), self.table_helper.port_table_keys,  self.table_helper.loopback_keys , self.table_helper.get_hw_mux_cable_tbl(), self.table_helper.get_hw_mux_cable_tbl_peer(), self.stop_event, is_vs)
+            platform_sfputil, platform_chassis, self.y_cable_presence, self.table_helper.get_state_db(), self.table_helper.get_port_tbl(), self.table_helper.get_y_cable_tbl(), self.table_helper.get_static_tbl(), self.table_helper.get_mux_tbl(), self.table_helper.port_table_keys,  self.table_helper.loopback_keys , self.table_helper.get_hw_mux_cable_tbl(), self.table_helper.get_hw_mux_cable_tbl_peer(), self.stop_event, is_vs)
 
     # Deinitialize daemon
     def deinit(self):

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -243,10 +243,10 @@ class DaemonYcable(daemon_base.DaemonBase):
         is_vs = False
 
 
-        (status, fvs) = self.table_helper.metadata_tbl()[0].get("localhost")
+        (status, fvs) = self.table_helper.get_metadata_tbl()[0].get("localhost")
 
         if status is False:
-            helper_logger.log_debug("Could not retreive fieldvalue pairs for {}, inside config_db table {}".format('localhost', self.table_helper.metadata_tbl()[0].getTableName()))
+            helper_logger.log_debug("Could not retreive fieldvalue pairs for {}, inside config_db table {}".format('localhost', self.table_helper.get_metadata_tbl()[0].getTableName()))
             return
 
         else:

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -116,9 +116,9 @@ class YcableInfoUpdateTask(object):
                     logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
                     continue
 
-                if not detect_port_in_error_status(logical_port_name, self.table_helper.get_status_tbl[asic_index]):
+                if not detect_port_in_error_status(logical_port_name, self.table_helper.get_status_tbl()[asic_index]):
                     if y_cable_presence[0] is True:
-                        y_cable_helper.check_identifier_presence_and_update_mux_info_entry(self.table_helper.get_state_db, self.table_helper.get.mux_tbl, asic_index, logical_port_name, self.table_helper.get_y_cable_tbl, self.table_helper.get_port_tbl)
+                        y_cable_helper.check_identifier_presence_and_update_mux_info_entry(self.table_helper.get_state_db(), self.table_helper.get.mux_tbl(), asic_index, logical_port_name, self.table_helper.get_y_cable_tbl(), self.table_helper.get_port_tbl())
 
         helper_logger.log_info("Stop DOM monitoring loop")
 
@@ -155,7 +155,7 @@ class YcableStateUpdateTask(object):
         namespaces = multi_asic.get_front_end_namespaces()
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-            sel.addSelectable(self.table_helper.get_sub_status_tbl[asic_id])
+            sel.addSelectable(self.table_helper.get_sub_status_tbl()[asic_id])
 
         while True:
 
@@ -180,7 +180,7 @@ class YcableStateUpdateTask(object):
             asic_index = multi_asic.get_asic_index_from_namespace(namespace)
 
             while True:
-                (port, op, fvp) = self.table_helper.get_sub_status_tbl[asic_index].pop()
+                (port, op, fvp) = self.table_helper.get_sub_status_tbl()[asic_index].pop()
                 if not port:
                     break
 
@@ -243,10 +243,10 @@ class DaemonYcable(daemon_base.DaemonBase):
         is_vs = False
 
 
-        (status, fvs) = self.table_helper.metadata_tbl[0].get("localhost")
+        (status, fvs) = self.table_helper.metadata_tbl()[0].get("localhost")
 
         if status is False:
-            helper_logger.log_debug("Could not retreive fieldvalue pairs for {}, inside config_db table {}".format('localhost', self.table_helper.metadata_tbl[0].getTableName()))
+            helper_logger.log_debug("Could not retreive fieldvalue pairs for {}, inside config_db table {}".format('localhost', self.table_helper.metadata_tbl()[0].getTableName()))
             return
 
         else:
@@ -317,7 +317,7 @@ class DaemonYcable(daemon_base.DaemonBase):
 
         # Init port y_cable status table
         y_cable_helper.init_ports_status_for_y_cable(
-            platform_sfputil, platform_chassis, self.y_cable_presence, self.table_helper.get_state_db , self.table_helper.get_port_tbl, self.table_helper.get_y_cable_tbl, self.table_helper.get_static_tbl, self.table_helper.get_mux_tbl, self.table_helper.port_table_keys,  self.table_helper.loopback_keys , self.table_helper.get_hw_mux_cable_tbl, self.table_helper.get_hw_mux_cable_tbl_peer, self.stop_event, is_vs)
+            platform_sfputil, platform_chassis, self.y_cable_presence, self.table_helper.get_state_db , self.table_helper.get_port_tbl(), self.table_helper.get_y_cable_tbl(), self.table_helper.get_static_tbl(), self.table_helper.get_mux_tbl(), self.table_helper.port_table_keys,  self.table_helper.loopback_keys , self.table_helper.get_hw_mux_cable_tbl(), self.table_helper.get_hw_mux_cable_tbl_peer(), self.stop_event, is_vs)
 
     # Deinitialize daemon
     def deinit(self):
@@ -333,7 +333,7 @@ class DaemonYcable(daemon_base.DaemonBase):
                 continue
 
         if self.y_cable_presence[0] is True:
-            y_cable_helper.delete_ports_status_for_y_cable(self.table_helper.get_y_cable_tbl, self.table_helper.get_static_tbl, self.table_helper.get_mux_tbl, self.table_helper.get_port_tbl, self.table_helper.get_grpc_config_tbl)
+            y_cable_helper.delete_ports_status_for_y_cable(self.table_helper.get_y_cable_tbl(), self.table_helper.get_static_tbl(), self.table_helper.get_mux_tbl(), self.table_helper.get_port_tbl(), self.table_helper.get_grpc_config_tbl())
 
         global_values = globals()
         val = global_values.get('platform_chassis')

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -48,7 +48,6 @@ SFP_STATUS_ERR_ENUM = Enum('SFP_STATUS_ERR_ENUM', ['SFP_STATUS_ERR_I2C_STUCK', '
 # Convert the error code to string and store them in a set for convenience
 errors_block_eeprom_reading = set(str(error_code.value) for error_code in SFP_STATUS_ERR_ENUM)
 
-TRANSCEIVER_STATUS_TABLE = 'TRANSCEIVER_STATUS'
 
 SFPUTIL_LOAD_ERROR = 1
 PORT_CONFIG_LOAD_ERROR = 2
@@ -244,10 +243,10 @@ class DaemonYcable(daemon_base.DaemonBase):
         is_vs = False
 
 
-        (status, fvs) = self.table_helper.get_metadata_tbl[0].get("localhost")
+        (status, fvs) = self.table_helper.metadata_tbl[0].get("localhost")
 
         if status is False:
-            helper_logger.log_debug("Could not retreive fieldvalue pairs for {}, inside config_db table {}".format('localhost', self.table_helper.get_metadata_tbl[0].getTableName()))
+            helper_logger.log_debug("Could not retreive fieldvalue pairs for {}, inside config_db table {}".format('localhost', self.table_helper.metadata_tbl[0].getTableName()))
             return
 
         else:

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -107,13 +107,20 @@ class YcableInfoUpdateTask(object):
         state_db = {}
         mux_tbl = {}
         status_tbl = {}
+        y_cable_tbl, mux_tbl = {}, {}
 
         # Get the namespaces in the platform
         namespaces = multi_asic.get_front_end_namespaces()
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
+            port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "MUX_CABLE")
             status_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
+            y_cable_tbl[asic_id] = swsscommon.Table(
+                state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            mux_tbl[asic_id] = swsscommon.Table(
+                state_db[asic_id], MUX_CABLE_INFO_TABLE)
 
         time.sleep(0.1)
         # Start loop to update ycable info in DB periodically
@@ -128,7 +135,7 @@ class YcableInfoUpdateTask(object):
 
                 if not detect_port_in_error_status(logical_port_name, status_tbl[asic_index]):
                     if y_cable_presence[0] is True:
-                        y_cable_helper.check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_index, logical_port_name)
+                        y_cable_helper.check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_index, logical_port_name, y_cable_tbl, port_tbl)
 
         helper_logger.log_info("Stop DOM monitoring loop")
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -1487,27 +1487,14 @@ def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, st
                 break
 
 
-def delete_ports_status_for_y_cable():
+def delete_ports_status_for_y_cable(y_cable_tbl, static_tbl, mux_tbl, port_tbl, grpc_config):
 
-    state_db, config_db, port_tbl, y_cable_tbl = {}, {}, {}, {}
     y_cable_tbl_keys = {}
-    static_tbl, mux_tbl = {}, {}
-    grpc_config = {}
+
     namespaces = multi_asic.get_front_end_namespaces()
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-        config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
-        state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
-        y_cable_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
         y_cable_tbl_keys[asic_id] = y_cable_tbl[asic_id].getKeys()
-        static_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
-        mux_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], MUX_CABLE_INFO_TABLE)
-        port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "MUX_CABLE")
-        grpc_config[asic_id] = swsscommon.Table(config_db[asic_id], "GRPCCLIENT")
-
 
     if read_side != -1:
         asic_index = multi_asic.get_asic_index_from_namespace(DEFAULT_NAMESPACE)

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -2150,7 +2150,7 @@ def post_port_mux_info_to_db(logical_port_name, mux_tbl, asic_index, y_cable_tbl
                  ('version_nic_inactive', str(mux_info_dict["version_nic_inactive"])),
                  ('version_nic_next', str(mux_info_dict["version_nic_next"]))
                  ])
-            table.set(logical_port_name, fvs)
+            mux_tbl[asic_index].set(logical_port_name, fvs)
         else:
             return -1
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -998,13 +998,9 @@ def update_tor_active_side(read_side, state, logical_port_name):
         return (-1, -1)
 
 
-def update_appdb_port_mux_cable_response_table(logical_port_name, asic_index, appl_db, read_side):
+def update_appdb_port_mux_cable_response_table(logical_port_name, asic_index, appl_db, read_side, y_cable_response_tbl):
 
     status = None
-    y_cable_response_tbl = {}
-
-    y_cable_response_tbl[asic_index] = swsscommon.Table(
-        appl_db[asic_index], "MUX_CABLE_RESPONSE_TABLE")
     physical_port_list = logical_port_name_to_physical_port_list(
         logical_port_name)
 
@@ -3542,6 +3538,7 @@ class YCableTableUpdateTask(object):
         port_tbl, port_table_keys = {}, {}
         fwd_state_command_tbl, fwd_state_response_tbl, mux_cable_command_tbl = {}, {}, {}
         mux_metrics_tbl = {}
+        y_cable_response_tbl = {}
 
         sel = swsscommon.Select()
 
@@ -3570,6 +3567,8 @@ class YCableTableUpdateTask(object):
                 appl_db[asic_id], "FORWARDING_STATE_RESPONSE")
             hw_mux_cable_tbl_peer[asic_id] = swsscommon.Table(
                 state_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
+            y_cable_response_tbl[asic_id] = swsscommon.Table(
+                appl_db[asic_id], "MUX_CABLE_RESPONSE_TABLE")
             hw_mux_cable_tbl_keys[asic_id] = hw_mux_cable_tbl[asic_id].getKeys()
             port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "MUX_CABLE")
             port_table_keys[asic_id] = port_tbl[asic_id].getKeys()
@@ -3699,7 +3698,7 @@ class YCableTableUpdateTask(object):
                                     continue
                                 mux_port_dict = dict(fv)
                                 read_side = mux_port_dict.get("read_side")
-                                update_appdb_port_mux_cable_response_table(port_m, asic_index, appl_db, int(read_side))
+                                update_appdb_port_mux_cable_response_table(port_m, asic_index, appl_db, int(read_side), y_cable_response_tbl)
 
             while True:
                 (port_m, op_m, fvp_m) = fwd_state_command_tbl[asic_index].pop()

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -1152,18 +1152,6 @@ def read_y_cable_and_update_statedb_port_tbl(logical_port_name, mux_config_tbl):
 
 def create_tables_and_insert_mux_unknown_entries(state_db, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name):
 
-    namespaces = multi_asic.get_front_end_namespaces()
-    for namespace in namespaces:
-        asic_id = multi_asic.get_asic_index_from_namespace(
-            namespace)
-        state_db[asic_id] = daemon_base.db_connect(
-            "STATE_DB", namespace)
-        y_cable_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
-        static_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
-        mux_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], MUX_CABLE_INFO_TABLE)
     # fill the newly found entry
     read_y_cable_and_update_statedb_port_tbl(
         logical_port_name, y_cable_tbl[asic_index])
@@ -1279,18 +1267,6 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
                             else:
                                 # first create the state db y cable table and then fill in the entry
                                 y_cable_presence[:] = [True]
-                                namespaces = multi_asic.get_front_end_namespaces()
-                                for namespace in namespaces:
-                                    asic_id = multi_asic.get_asic_index_from_namespace(
-                                        namespace)
-                                    state_db[asic_id] = daemon_base.db_connect(
-                                        "STATE_DB", namespace)
-                                    y_cable_tbl[asic_id] = swsscommon.Table(
-                                        state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
-                                    static_tbl[asic_id] = swsscommon.Table(
-                                        state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
-                                    mux_tbl[asic_id] = swsscommon.Table(
-                                        state_db[asic_id], MUX_CABLE_INFO_TABLE)
                                 # fill the newly found entry
                                 read_y_cable_and_update_statedb_port_tbl(
                                     logical_port_name, y_cable_tbl[asic_index])
@@ -1417,6 +1393,12 @@ def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presen
             state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
         hw_mux_cable_tbl_peer[asic_id] = swsscommon.Table(
             state_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
+        y_cable_tbl[asic_id] = swsscommon.Table(
+            state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+        static_tbl[asic_id] = swsscommon.Table(
+            state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
+        mux_tbl[asic_id] = swsscommon.Table(
+            state_db[asic_id], MUX_CABLE_INFO_TABLE)
 
     if read_side == -1:
         read_side = process_loopback_interface_and_get_read_side(loopback_keys)
@@ -1441,7 +1423,7 @@ def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presen
             (status, cable_type) = check_mux_cable_port_type(logical_port_name, port_tbl, asic_index)
             if status and cable_type == "active-standby":
                 check_identifier_presence_and_update_mux_table_entry(
-                    state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name, y_cable_presence)
+                    state_db, port_tbl, hw_mux_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name, y_cable_presence)
             if status and cable_type == "active-active":
                 check_identifier_presence_and_setup_channel(
                     logical_port_name, port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence)
@@ -1481,6 +1463,12 @@ def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, st
             state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
         hw_mux_cable_tbl_peer[asic_id] = swsscommon.Table(
             state_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
+        y_cable_tbl[asic_id] = swsscommon.Table(
+            state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+        static_tbl[asic_id] = swsscommon.Table(
+            state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
+        mux_tbl[asic_id] = swsscommon.Table(
+            state_db[asic_id], MUX_CABLE_INFO_TABLE)
 
     if read_side == -1:
         read_side = process_loopback_interface_and_get_read_side(loopback_keys)

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -1344,50 +1344,18 @@ def check_identifier_presence_and_delete_mux_table_entry(state_db, port_tbl, asi
                         "Error: Retreived multiple ports for a Y cable port {} while delete entries".format(logical_port_name))
 
 
-def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presence, stop_event=threading.Event(), is_vs=False):
+def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presence, state_db ,port_tbl, y_cable_tbl, static_tbl, mux_tbl, port_table_keys,  loopback_keys , hw_mux_cable_tbl, hw_mux_cable_tbl_peer, stop_event=threading.Event(), is_vs=False):
     global y_cable_platform_sfputil
     global y_cable_platform_chassis
     global y_cable_port_instances
     global y_cable_is_platform_vs
     global read_side
     # Connect to CONFIG_DB and create port status table inside state_db
-    config_db, state_db, port_tbl, y_cable_tbl = {}, {}, {}, {}
-    static_tbl, mux_tbl = {}, {}
-    port_table_keys = {}
-    xcvrd_log_tbl = {}
-    loopback_tbl= {}
-    loopback_keys = {}
-    hw_mux_cable_tbl = {}
-    hw_mux_cable_tbl_peer = {}
 
     y_cable_platform_sfputil = platform_sfp
     y_cable_platform_chassis = platform_chassis
     y_cable_is_platform_vs = is_vs
 
-    fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'notice')])
-    # Get the namespaces in the platform
-    namespaces = multi_asic.get_front_end_namespaces()
-    for namespace in namespaces:
-        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-        config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
-        port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "MUX_CABLE")
-        port_table_keys[asic_id] = port_tbl[asic_id].getKeys()
-        xcvrd_log_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "XCVRD_LOG")
-        xcvrd_log_tbl[asic_id].set("Y_CABLE", fvs_updated)
-        loopback_tbl[asic_id] = swsscommon.Table(
-            config_db[asic_id], "LOOPBACK_INTERFACE")
-        loopback_keys[asic_id] = loopback_tbl[asic_id].getKeys()
-        state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
-        hw_mux_cable_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
-        hw_mux_cable_tbl_peer[asic_id] = swsscommon.Table(
-            state_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
-        y_cable_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
-        static_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
-        mux_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], MUX_CABLE_INFO_TABLE)
 
     if read_side == -1:
         read_side = process_loopback_interface_and_get_read_side(loopback_keys)

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3749,7 +3749,7 @@ class YCableTableUpdateTask(object):
                         fvp_m, self.hw_mux_cable_tbl, self.fwd_state_response_tbl, asic_index, port_m, self.appl_db)
 
             while True:
-                (port_n, op_n, fvp_n) = status_tbl_peer[asic_index].pop()
+                (port_n, op_n, fvp_n) = self.status_tbl_peer[asic_index].pop()
                 if not port_n:
                     break
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -1624,13 +1624,6 @@ def get_firmware_dict(physical_port, port_instance, target, side, mux_info_dict,
         # if there is a firmware download in progress, retreive the last known firmware
         mux_firmware_dict = {}
 
-        namespaces = multi_asic.get_front_end_namespaces()
-        for namespace in namespaces:
-            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-            state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
-            mux_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], MUX_CABLE_INFO_TABLE)
-
         asic_index = y_cable_platform_sfputil.get_asic_id_for_logical_port(
             logical_port_name)
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3746,7 +3746,7 @@ class YCableTableUpdateTask(object):
                     break
 
                 if fvp:
-                    handle_show_firmware_show_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_show_fw_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_fw_rsp_tbl, self.cli_table_helper.xcvrd_show_fw_res_tbl, asic_index, port)
+                    handle_show_firmware_show_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_show_fw_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_fw_rsp_tbl, self.cli_table_helper.xcvrd_show_fw_res_tbl, asic_index, port, self.cli_table_helper.mux_tbl)
                     break
 
             while True:

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3433,21 +3433,171 @@ class YCableTableUpdateTask(object):
         self.task_cli_thread = None
         self.task_download_firmware_thread = {}
         self.task_stopping_event = threading.Event()
+        self.appl_db, self.state_db, self.config_db, self.status_tbl, self.status_tbl_peer = {}, {}, {}, {}, {}
+        self.hw_mux_cable_tbl, self.hw_mux_cable_tbl_peer = {}, {}
+        self.hw_mux_cable_tbl_keys = {}
+        self.port_tbl, self.port_table_keys = {}, {}
+        self.fwd_state_command_tbl, self.fwd_state_response_tbl, self.mux_cable_command_tbl = {}, {}, {}
+        self.mux_metrics_tbl = {}
+        self.y_cable_response_tbl = {}
+        self.xcvrd_log_tbl = {}
+        self.xcvrd_down_fw_cmd_tbl, self.xcvrd_down_fw_rsp_tbl, self.xcvrd_down_fw_cmd_sts_tbl = {}, {}, {}
+        self.xcvrd_down_fw_status_cmd_tbl, self.xcvrd_down_fw_status_rsp_tbl, self.xcvrd_down_fw_status_cmd_sts_tbl = {}, {}, {}
+        self.xcvrd_acti_fw_cmd_tbl, self.xcvrd_acti_fw_cmd_arg_tbl, self.xcvrd_acti_fw_rsp_tbl, self.xcvrd_acti_fw_cmd_sts_tbl = {}, {}, {}, {}
+        self.xcvrd_roll_fw_cmd_tbl, self.xcvrd_roll_fw_rsp_tbl, self.xcvrd_roll_fw_cmd_sts_tbl = {}, {}, {}
+        self.xcvrd_show_fw_cmd_tbl, self.xcvrd_show_fw_rsp_tbl, self.xcvrd_show_fw_cmd_sts_tbl, self.xcvrd_show_fw_res_tbl = {}, {}, {}, {}
+        self.xcvrd_show_hwmode_dir_cmd_tbl, self.xcvrd_show_hwmode_dir_rsp_tbl, self.xcvrd_show_hwmode_dir_res_tbl, self.xcvrd_show_hwmode_dir_cmd_sts_tbl = {}, {}, {}, {}
+        self.xcvrd_show_hwmode_swmode_cmd_tbl, self.xcvrd_show_hwmode_swmode_rsp_tbl, self.xcvrd_show_hwmode_swmode_cmd_sts_tbl = {}, {}, {}
+        self.xcvrd_config_hwmode_state_cmd_tbl, self.xcvrd_config_hwmode_state_rsp_tbl , self.xcvrd_config_hwmode_state_cmd_sts_tbl= {}, {}, {}
+        self.xcvrd_config_hwmode_swmode_cmd_tbl, self.xcvrd_config_hwmode_swmode_rsp_tbl , self.xcvrd_config_hwmode_swmode_cmd_sts_tbl= {}, {}, {}
+        self.xcvrd_config_prbs_cmd_tbl, self.xcvrd_config_prbs_cmd_arg_tbl, self.xcvrd_config_prbs_rsp_tbl , self.xcvrd_config_prbs_cmd_sts_tbl= {}, {}, {}, {}
+        self.xcvrd_config_loop_cmd_tbl, self.xcvrd_config_loop_cmd_arg_tbl, self.xcvrd_config_loop_rsp_tbl , self.xcvrd_config_loop_cmd_sts_tbl= {}, {}, {}, {}
+        self.xcvrd_show_event_cmd_tbl, self.xcvrd_show_event_rsp_tbl , self.xcvrd_show_event_cmd_sts_tbl, self.xcvrd_show_event_res_tbl= {}, {}, {}, {}
+        self.xcvrd_show_fec_cmd_tbl, self.xcvrd_show_fec_rsp_tbl , self.xcvrd_show_fec_cmd_sts_tbl, self.xcvrd_show_fec_res_tbl= {}, {}, {}, {}
+        self.xcvrd_show_ber_cmd_tbl, self.xcvrd_show_ber_cmd_arg_tbl, self.xcvrd_show_ber_rsp_tbl , self.xcvrd_show_ber_cmd_sts_tbl, self.xcvrd_show_ber_res_tbl= {}, {}, {}, {}, {}
+
+
+        sel = swsscommon.Select()
 
         if multi_asic.is_multi_asic():
             # Load the namespace details first from the database_global.json file.
             swsscommon.SonicDBConfig.initializeGlobalConfig()
 
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            # Open a handle to the Application database, in all namespaces
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
+            self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.status_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], swsscommon.APP_HW_MUX_CABLE_TABLE_NAME)
+            self.mux_cable_command_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], swsscommon.APP_MUX_CABLE_COMMAND_TABLE_NAME)
+            self.mux_metrics_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_MUX_METRICS_TABLE_NAME)
+            self.hw_mux_cable_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            # TODO add definition inside app DB
+            self.status_tbl_peer[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "HW_FORWARDING_STATE_PEER")
+            self.fwd_state_command_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "FORWARDING_STATE_COMMAND")
+            self.fwd_state_response_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "FORWARDING_STATE_RESPONSE")
+            self.hw_mux_cable_tbl_peer[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
+            self.y_cable_response_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "MUX_CABLE_RESPONSE_TABLE")
+            self.hw_mux_cable_tbl_keys[asic_id] = self.hw_mux_cable_tbl[asic_id].getKeys()
+            self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
+            self.port_table_keys[asic_id] = self.port_tbl[asic_id].getKeys()
+            self.xcvrd_log_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.config_db[asic_id], "XCVRD_LOG")
+            self.xcvrd_show_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_SHOW_FW_CMD")
+            self.xcvrd_show_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_SHOW_FW_CMD")
+            self.xcvrd_show_fw_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_FW_RSP")
+            self.xcvrd_show_fw_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_FW_RES")
+            self.xcvrd_down_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_DOWN_FW_CMD")
+            self.xcvrd_down_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_DOWN_FW_CMD")
+            self.xcvrd_down_fw_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_DOWN_FW_RSP")
+            self.xcvrd_down_fw_status_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_DOWN_FW_STATUS_CMD")
+            self.xcvrd_down_fw_status_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_DOWN_FW_STATUS_RSP")
+            self.xcvrd_acti_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_ACTI_FW_CMD")
+            self.xcvrd_acti_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_ACTI_FW_CMD")
+            self.xcvrd_acti_fw_cmd_arg_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_ACTI_FW_CMD_ARG")
+            self.xcvrd_acti_fw_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_ACTI_FW_RSP")
+            self.xcvrd_roll_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_ROLL_FW_CMD")
+            self.xcvrd_roll_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_ROLL_FW_CMD")
+            self.xcvrd_roll_fw_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_ROLL_FW_RSP")
+            self.xcvrd_show_hwmode_dir_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_CMD")
+            self.xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_CMD")
+            self.xcvrd_show_hwmode_dir_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_RSP")
+            self.xcvrd_show_hwmode_dir_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_RES")
+            self.xcvrd_config_hwmode_state_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_CMD")
+            self.xcvrd_config_hwmode_state_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_CMD")
+            self.xcvrd_config_hwmode_state_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_RSP")
+            self.xcvrd_config_hwmode_swmode_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_CMD")
+            self.xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_CMD")
+            self.xcvrd_config_hwmode_swmode_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_RSP")
+            self.xcvrd_show_hwmode_swmode_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_CMD")
+            self.xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_CMD")
+            self.xcvrd_show_hwmode_swmode_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_RSP")
+            self.xcvrd_config_prbs_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD")
+            self.xcvrd_config_prbs_cmd_arg_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD_ARG")
+            self.xcvrd_config_prbs_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD")
+            self.xcvrd_config_prbs_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_CONFIG_PRBS_RSP")
+            self.xcvrd_config_loop_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD")
+            self.xcvrd_config_loop_cmd_arg_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD_ARG")
+            self.xcvrd_config_loop_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD")
+            self.xcvrd_config_loop_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_CONFIG_LOOP_RSP")
+            self.xcvrd_show_event_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_EVENT_LOG_CMD")
+            self.xcvrd_show_event_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_EVENT_LOG_CMD")
+            self.xcvrd_show_event_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_EVENT_LOG_RSP")
+            self.xcvrd_show_event_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_EVENT_LOG_RES")
+            self.xcvrd_show_fec_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_GET_FEC_CMD")
+            self.xcvrd_show_fec_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_GET_FEC_CMD")
+            self.xcvrd_show_fec_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_GET_FEC_RSP")
+            self.xcvrd_show_fec_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_GET_FEC_RES")
+            self.xcvrd_show_ber_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_GET_BER_CMD")
+            self.xcvrd_show_ber_cmd_arg_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_GET_BER_CMD_ARG")
+            self.xcvrd_show_ber_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_GET_BER_CMD")
+            self.xcvrd_show_ber_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_GET_BER_RSP")
+            self.xcvrd_show_ber_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_GET_BER_RES")
+
     def task_worker(self):
 
         # Connect to STATE_DB and APPL_DB and get both the HW_MUX_STATUS_TABLE info
-        appl_db, state_db, config_db, status_tbl, status_tbl_peer = {}, {}, {}, {}, {}
-        hw_mux_cable_tbl, hw_mux_cable_tbl_peer = {}, {}
-        hw_mux_cable_tbl_keys = {}
-        port_tbl, port_table_keys = {}, {}
-        fwd_state_command_tbl, fwd_state_response_tbl, mux_cable_command_tbl = {}, {}, {}
-        mux_metrics_tbl = {}
-        y_cable_response_tbl = {}
 
         sel = swsscommon.Select()
 
@@ -3456,35 +3606,10 @@ class YCableTableUpdateTask(object):
         for namespace in namespaces:
             # Open a handle to the Application database, in all namespaces
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-            appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
-            config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
-            state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
-            status_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], swsscommon.APP_HW_MUX_CABLE_TABLE_NAME)
-            mux_cable_command_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], swsscommon.APP_MUX_CABLE_COMMAND_TABLE_NAME)
-            mux_metrics_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], swsscommon.STATE_MUX_METRICS_TABLE_NAME)
-            hw_mux_cable_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
-            # TODO add definition inside app DB
-            status_tbl_peer[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "HW_FORWARDING_STATE_PEER")
-            fwd_state_command_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "FORWARDING_STATE_COMMAND")
-            fwd_state_response_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "FORWARDING_STATE_RESPONSE")
-            hw_mux_cable_tbl_peer[asic_id] = swsscommon.Table(
-                state_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
-            y_cable_response_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "MUX_CABLE_RESPONSE_TABLE")
-            hw_mux_cable_tbl_keys[asic_id] = hw_mux_cable_tbl[asic_id].getKeys()
-            port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "MUX_CABLE")
-            port_table_keys[asic_id] = port_tbl[asic_id].getKeys()
-            sel.addSelectable(status_tbl[asic_id])
-            sel.addSelectable(status_tbl_peer[asic_id])
-            sel.addSelectable(fwd_state_command_tbl[asic_id])
-            sel.addSelectable(mux_cable_command_tbl[asic_id])
+            sel.addSelectable(self.status_tbl[asic_id])
+            sel.addSelectable(self.status_tbl_peer[asic_id])
+            sel.addSelectable(self.fwd_state_command_tbl[asic_id])
+            sel.addSelectable(self.mux_cable_command_tbl[asic_id])
 
 
         # Listen indefinitely for changes to the HW_MUX_CABLE_TABLE in the Application DB's
@@ -3513,7 +3638,7 @@ class YCableTableUpdateTask(object):
             asic_index = multi_asic.get_asic_index_from_namespace(namespace)
 
             while True:
-                (port, op, fvp) = status_tbl[asic_index].pop()
+                (port, op, fvp) = self.status_tbl[asic_index].pop()
                 if not port:
                     break
 
@@ -3529,7 +3654,7 @@ class YCableTableUpdateTask(object):
                     if port not in hw_mux_cable_tbl_keys[asic_index]:
                         continue
 
-                    (status, cable_type) = check_mux_cable_port_type(port, port_tbl, asic_index)
+                    (status, cable_type) = check_mux_cable_port_type(port, self.port_tbl, asic_index)
 
                     if status:
 
@@ -3540,10 +3665,10 @@ class YCableTableUpdateTask(object):
                                 # got a state change
                                 new_status = fvp_dict["state"]
                                 requested_status = new_status
-                                (status, fvs) = hw_mux_cable_tbl[asic_index].get(port)
+                                (status, fvs) = self.hw_mux_cable_tbl[asic_index].get(port)
                                 if status is False:
                                     helper_logger.log_warning("Could not retreive fieldvalue pairs for {}, inside state_db table {}".format(
-                                        port, hw_mux_cable_tbl[asic_index].getTableName()))
+                                        port, self.hw_mux_cable_tbl[asic_index].getTableName()))
                                     continue
                                 mux_port_dict = dict(fvs)
                                 old_status = mux_port_dict.get("state", None)
@@ -3561,12 +3686,12 @@ class YCableTableUpdateTask(object):
                                 time_end = datetime.datetime.utcnow().strftime("%Y-%b-%d %H:%M:%S.%f")
                                 fvs_metrics = swsscommon.FieldValuePairs([('xcvrd_switch_{}_start'.format(new_status), str(time_start)),
                                                                           ('xcvrd_switch_{}_end'.format(new_status), str(time_end))])
-                                mux_metrics_tbl[asic_index].set(port, fvs_metrics)
+                                self.mux_metrics_tbl[asic_index].set(port, fvs_metrics)
 
                                 fvs_updated = swsscommon.FieldValuePairs([('state', new_status),
                                                                           ('read_side', str(read_side)),
                                                                           ('active_side', str(active_side))])
-                                hw_mux_cable_tbl[asic_index].set(port, fvs_updated)
+                                self.hw_mux_cable_tbl[asic_index].set(port, fvs_updated)
                             else:
                                 helper_logger.log_info("Got a change event on port {} of table {} that does not contain state".format(
                                     port, swsscommon.APP_HW_MUX_CABLE_TABLE_NAME))
@@ -3575,9 +3700,9 @@ class YCableTableUpdateTask(object):
 
                             if fvp:
                                 handle_hw_mux_cable_table_grpc_notification(
-                                    fvp, hw_mux_cable_tbl, asic_index, mux_metrics_tbl, False, port)
+                                    fvp, self.hw_mux_cable_tbl, asic_index, self.mux_metrics_tbl, False, port)
             while True:
-                (port_m, op_m, fvp_m) = mux_cable_command_tbl[asic_index].pop()
+                (port_m, op_m, fvp_m) = self.mux_cable_command_tbl[asic_index].pop()
 
                 if not port_m:
                     break
@@ -3585,7 +3710,7 @@ class YCableTableUpdateTask(object):
 
                 if fvp_m:
 
-                    if port_m not in hw_mux_cable_tbl_keys[asic_index]:
+                    if port_m not in self.hw_mux_cable_tbl_keys[asic_index]:
                         continue
 
                     fvp_dict = dict(fvp_m)
@@ -3600,67 +3725,47 @@ class YCableTableUpdateTask(object):
                             probe_identifier = fvp_dict["command"]
 
                             if probe_identifier == "probe":
-                                (status, fv) = hw_mux_cable_tbl[asic_index].get(port_m)
+                                (status, fv) = self.hw_mux_cable_tbl[asic_index].get(port_m)
                                 if status is False:
                                     helper_logger.log_warning("Could not retreive fieldvalue pairs for {}, inside state_db table {}".format(
-                                        port_m, hw_mux_cable_tbl[asic_index].getTableName()))
+                                        port_m, self.hw_mux_cable_tbl[asic_index].getTableName()))
                                     continue
                                 mux_port_dict = dict(fv)
                                 read_side = mux_port_dict.get("read_side")
-                                update_appdb_port_mux_cable_response_table(port_m, asic_index, appl_db, int(read_side), y_cable_response_tbl)
+                                update_appdb_port_mux_cable_response_table(port_m, asic_index, self.appl_db, int(read_side), self.y_cable_response_tbl)
 
             while True:
-                (port_m, op_m, fvp_m) = fwd_state_command_tbl[asic_index].pop()
+                (port_m, op_m, fvp_m) = self.fwd_state_command_tbl[asic_index].pop()
 
                 if not port_m:
                     break
 
                 helper_logger.log_debug("Y_CABLE_DEBUG: received a probe for Forwarding state using gRPC port status {} {}".format(port_m, threading.currentThread().getName()))
-                (status, cable_type) = check_mux_cable_port_type(port_m, port_tbl, asic_index)
+                (status, cable_type) = check_mux_cable_port_type(port_m, self.port_tbl, asic_index)
 
                 if status is False or cable_type != "active-active":
                     break
 
                 if fvp_m:
                     handle_fwd_state_command_grpc_notification(
-                        fvp_m, hw_mux_cable_tbl, fwd_state_response_tbl, asic_index, port_m, appl_db)
+                        fvp_m, self.hw_mux_cable_tbl, self.fwd_state_response_tbl, asic_index, port_m, self.appl_db)
 
             while True:
                 (port_n, op_n, fvp_n) = status_tbl_peer[asic_index].pop()
                 if not port_n:
                     break
 
-                (status, cable_type) = check_mux_cable_port_type(port_n, port_tbl, asic_index)
+                (status, cable_type) = check_mux_cable_port_type(port_n, self.port_tbl, asic_index)
 
                 if status is False or cable_type != "active-active":
                     break
 
                 if fvp_n:
                     handle_hw_mux_cable_table_grpc_notification(
-                        fvp_n, hw_mux_cable_tbl_peer, asic_index, mux_metrics_tbl, True, port_n)
+                        fvp_n, self.hw_mux_cable_tbl_peer, asic_index, self.mux_metrics_tbl, True, port_n)
 
 
     def task_cli_worker(self):
-
-        # Connect to STATE_DB and APPL_DB and get both the HW_MUX_STATUS_TABLE info
-        appl_db, config_db , state_db, y_cable_tbl = {}, {}, {}, {}
-        xcvrd_log_tbl = {}
-        xcvrd_down_fw_cmd_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_down_fw_cmd_sts_tbl = {}, {}, {}
-        xcvrd_down_fw_status_cmd_tbl, xcvrd_down_fw_status_rsp_tbl, xcvrd_down_fw_status_cmd_sts_tbl = {}, {}, {}
-        xcvrd_acti_fw_cmd_tbl, xcvrd_acti_fw_cmd_arg_tbl, xcvrd_acti_fw_rsp_tbl, xcvrd_acti_fw_cmd_sts_tbl = {}, {}, {}, {}
-        xcvrd_roll_fw_cmd_tbl, xcvrd_roll_fw_rsp_tbl, xcvrd_roll_fw_cmd_sts_tbl = {}, {}, {}
-        xcvrd_show_fw_cmd_tbl, xcvrd_show_fw_rsp_tbl, xcvrd_show_fw_cmd_sts_tbl, xcvrd_show_fw_res_tbl = {}, {}, {}, {}
-        xcvrd_show_hwmode_dir_cmd_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl = {}, {}, {}, {}
-        xcvrd_show_hwmode_swmode_cmd_tbl, xcvrd_show_hwmode_swmode_rsp_tbl, xcvrd_show_hwmode_swmode_cmd_sts_tbl = {}, {}, {}
-        xcvrd_config_hwmode_state_cmd_tbl, xcvrd_config_hwmode_state_rsp_tbl , xcvrd_config_hwmode_state_cmd_sts_tbl= {}, {}, {}
-        xcvrd_config_hwmode_swmode_cmd_tbl, xcvrd_config_hwmode_swmode_rsp_tbl , xcvrd_config_hwmode_swmode_cmd_sts_tbl= {}, {}, {}
-        xcvrd_config_prbs_cmd_tbl, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_rsp_tbl , xcvrd_config_prbs_cmd_sts_tbl= {}, {}, {}, {}
-        xcvrd_config_loop_cmd_tbl, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_rsp_tbl , xcvrd_config_loop_cmd_sts_tbl= {}, {}, {}, {}
-        xcvrd_show_event_cmd_tbl, xcvrd_show_event_rsp_tbl , xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_res_tbl= {}, {}, {}, {}
-        xcvrd_show_fec_cmd_tbl, xcvrd_show_fec_rsp_tbl , xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl= {}, {}, {}, {}
-        xcvrd_show_ber_cmd_tbl, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl , xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl= {}, {}, {}, {}, {}
-        port_tbl, port_table_keys = {}, {}
-        mux_tbl = {}
 
 
         sel = swsscommon.Select()
@@ -3671,130 +3776,21 @@ class YCableTableUpdateTask(object):
         for namespace in namespaces:
             # Open a handle to the Application database, in all namespaces
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-            appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
-            config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
-            state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
-            xcvrd_log_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                config_db[asic_id], "XCVRD_LOG")
-            xcvrd_show_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_SHOW_FW_CMD")
-            xcvrd_show_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_SHOW_FW_CMD")
-            xcvrd_show_fw_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_SHOW_FW_RSP")
-            xcvrd_show_fw_res_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_SHOW_FW_RES")
-            xcvrd_down_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_DOWN_FW_CMD")
-            xcvrd_down_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_DOWN_FW_CMD")
-            xcvrd_down_fw_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_DOWN_FW_RSP")
-            xcvrd_down_fw_status_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_DOWN_FW_STATUS_CMD")
-            xcvrd_down_fw_status_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_DOWN_FW_STATUS_RSP")
-            xcvrd_acti_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_ACTI_FW_CMD")
-            xcvrd_acti_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_ACTI_FW_CMD")
-            xcvrd_acti_fw_cmd_arg_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_ACTI_FW_CMD_ARG")
-            xcvrd_acti_fw_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_ACTI_FW_RSP")
-            xcvrd_roll_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_ROLL_FW_CMD")
-            xcvrd_roll_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_ROLL_FW_CMD")
-            xcvrd_roll_fw_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_ROLL_FW_RSP")
-            xcvrd_show_hwmode_dir_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_CMD")
-            xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_CMD")
-            xcvrd_show_hwmode_dir_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_RSP")
-            xcvrd_show_hwmode_dir_res_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_RES")
-            xcvrd_config_hwmode_state_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_CMD")
-            xcvrd_config_hwmode_state_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_CMD")
-            xcvrd_config_hwmode_state_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_RSP")
-            xcvrd_config_hwmode_swmode_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_CMD")
-            xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_CMD")
-            xcvrd_config_hwmode_swmode_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_RSP")
-            xcvrd_show_hwmode_swmode_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_CMD")
-            xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_CMD")
-            xcvrd_show_hwmode_swmode_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_RSP")
-            xcvrd_config_prbs_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD")
-            xcvrd_config_prbs_cmd_arg_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD_ARG")
-            xcvrd_config_prbs_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD")
-            xcvrd_config_prbs_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_CONFIG_PRBS_RSP")
-            xcvrd_config_loop_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD")
-            xcvrd_config_loop_cmd_arg_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD_ARG")
-            xcvrd_config_loop_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD")
-            xcvrd_config_loop_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_CONFIG_LOOP_RSP")
-            xcvrd_show_event_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_EVENT_LOG_CMD")
-            xcvrd_show_event_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_EVENT_LOG_CMD")
-            xcvrd_show_event_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_EVENT_LOG_RSP")
-            xcvrd_show_event_res_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_EVENT_LOG_RES")
-            xcvrd_show_fec_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_GET_FEC_CMD")
-            xcvrd_show_fec_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_GET_FEC_CMD")
-            xcvrd_show_fec_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_GET_FEC_RSP")
-            xcvrd_show_fec_res_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_GET_FEC_RES")
-            xcvrd_show_ber_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_GET_BER_CMD")
-            xcvrd_show_ber_cmd_arg_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_GET_BER_CMD_ARG")
-            xcvrd_show_ber_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_GET_BER_CMD")
-            xcvrd_show_ber_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_GET_BER_RSP")
-            xcvrd_show_ber_res_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_GET_BER_RES")
-            mux_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], MUX_CABLE_INFO_TABLE)
-            port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "MUX_CABLE")
-            port_table_keys[asic_id] = port_tbl[asic_id].getKeys()
-            sel.addSelectable(xcvrd_log_tbl[asic_id])
-            sel.addSelectable(xcvrd_down_fw_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_down_fw_status_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_acti_fw_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_roll_fw_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_show_fw_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_show_hwmode_dir_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_config_hwmode_state_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_show_hwmode_swmode_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_config_hwmode_swmode_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_config_prbs_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_config_loop_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_show_event_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_show_fec_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_show_ber_cmd_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_log_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_down_fw_cmd_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_down_fw_status_cmd_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_acti_fw_cmd_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_roll_fw_cmd_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_show_fw_cmd_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_show_hwmode_dir_cmd_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_config_hwmode_state_cmd_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_show_hwmode_swmode_cmd_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_config_hwmode_swmode_cmd_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_config_prbs_cmd_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_config_loop_cmd_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_show_event_cmd_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_show_fec_cmd_tbl[asic_id])
+            sel.addSelectable(self.xcvrd_show_ber_cmd_tbl[asic_id])
 
         # Listen indefinitely for changes to the XCVRD_CMD_TABLE in the Application DB's
         while True:
@@ -3822,7 +3818,7 @@ class YCableTableUpdateTask(object):
             asic_index = multi_asic.get_asic_index_from_namespace(namespace)
 
             while True:
-                (key, op_m, fvp_m) = xcvrd_log_tbl[asic_index].pop()
+                (key, op_m, fvp_m) = self.xcvrd_log_tbl[asic_index].pop()
 
                 if not key:
                     break
@@ -3834,140 +3830,140 @@ class YCableTableUpdateTask(object):
 
             while True:
                 # show muxcable hwmode state <port>
-                (port, op, fvp) = xcvrd_show_hwmode_dir_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.xcvrd_show_hwmode_dir_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+                    handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, self.port_tbl, self.xcvrd_show_hwmode_dir_cmd_sts_tbl, self.xcvrd_show_hwmode_dir_rsp_tbl, self.xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
                     break
 
             while True:
                 # Config muxcable hwmode state <active/standby> <port>
-                (port, op, fvp) = xcvrd_config_hwmode_state_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.xcvrd_config_hwmode_state_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_config_hwmode_state_cmd_arg_tbl_notification(fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
+                    handle_config_hwmode_state_cmd_arg_tbl_notification(fvp, self.xcvrd_config_hwmode_state_cmd_sts_tbl,  self.xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
                     break
 
 
             while True:
                 # Config muxcable hwmode setswitchmode <auto/manual> <port>
-                (port, op, fvp) = xcvrd_show_hwmode_swmode_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.xcvrd_show_hwmode_swmode_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_show_hwmode_swmode_cmd_arg_tbl_notification(fvp, xcvrd_show_hwmode_swmode_cmd_sts_tbl, xcvrd_show_hwmode_swmode_rsp_tbl, asic_index, port)
+                    handle_show_hwmode_swmode_cmd_arg_tbl_notification(fvp, self.xcvrd_show_hwmode_swmode_cmd_sts_tbl, self.xcvrd_show_hwmode_swmode_rsp_tbl, asic_index, port)
                     break
 
             while True:
                 # Config muxcable hwmode setswitchmode <auto/manual> <port>
-                (port, op, fvp) = xcvrd_config_hwmode_swmode_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.xcvrd_config_hwmode_swmode_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                   handle_config_mux_switchmode_arg_tbl_notification(fvp, xcvrd_config_hwmode_swmode_cmd_sts_tbl, xcvrd_config_hwmode_swmode_rsp_tbl, asic_index, port)
+                   handle_config_mux_switchmode_arg_tbl_notification(fvp, self.xcvrd_config_hwmode_swmode_cmd_sts_tbl, self.xcvrd_config_hwmode_swmode_rsp_tbl, asic_index, port)
                    break
 
             while True:
-                (port, op, fvp) = xcvrd_down_fw_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.xcvrd_down_fw_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_config_firmware_down_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, self.task_download_firmware_thread)
+                    handle_config_firmware_down_cmd_arg_tbl_notification(fvp, self.xcvrd_down_fw_cmd_sts_tbl, self.xcvrd_down_fw_rsp_tbl, asic_index, port, self.task_download_firmware_thread)
                     break
 
             while True:
-                (port, op, fvp) = xcvrd_show_fw_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.xcvrd_show_fw_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_show_firmware_show_cmd_arg_tbl_notification(fvp, xcvrd_show_fw_cmd_sts_tbl, xcvrd_show_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+                    handle_show_firmware_show_cmd_arg_tbl_notification(fvp, self.xcvrd_show_fw_cmd_sts_tbl, self.xcvrd_show_fw_rsp_tbl, self.xcvrd_show_fw_res_tbl, asic_index, port)
                     break
 
             while True:
-                (port, op, fvp) = xcvrd_acti_fw_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.xcvrd_acti_fw_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_config_firmware_acti_cmd_arg_tbl_notification(fvp, xcvrd_acti_fw_cmd_sts_tbl, xcvrd_acti_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
+                    handle_config_firmware_acti_cmd_arg_tbl_notification(fvp, self.xcvrd_acti_fw_cmd_sts_tbl, self.xcvrd_acti_fw_rsp_tbl, self.xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
                     break
 
 
             while True:
-                (port, op, fvp) = xcvrd_roll_fw_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.xcvrd_roll_fw_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_config_firmware_roll_cmd_arg_tbl_notification(fvp, xcvrd_roll_fw_cmd_sts_tbl, xcvrd_roll_fw_rsp_tbl, asic_index, port)
+                    handle_config_firmware_roll_cmd_arg_tbl_notification(fvp, self.xcvrd_roll_fw_cmd_sts_tbl, self.xcvrd_roll_fw_rsp_tbl, asic_index, port)
                     break
 
             while True:
-                (port, op, fvp) = xcvrd_config_prbs_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.xcvrd_config_prbs_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+                    handle_config_prbs_cmd_arg_tbl_notification(fvp, self.xcvrd_config_prbs_cmd_arg_tbl, self.xcvrd_config_prbs_cmd_sts_tbl, self.xcvrd_config_prbs_rsp_tbl, asic_index, port)
                     break
 
             while True:
-                (port, op, fvp) = xcvrd_config_loop_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.xcvrd_config_loop_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_config_loop_cmd_arg_tbl_notification(fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
+                    handle_config_loop_cmd_arg_tbl_notification(fvp, self.xcvrd_config_loop_cmd_arg_tbl, self.xcvrd_config_loop_cmd_sts_tbl, self.xcvrd_config_loop_rsp_tbl, asic_index, port)
                     break
 
             while True:
-                (port, op, fvp) = xcvrd_show_event_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.xcvrd_show_event_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
 
-                    handle_show_event_cmd_arg_tbl_notification(fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
+                    handle_show_event_cmd_arg_tbl_notification(fvp, self.xcvrd_show_event_cmd_sts_tbl, self.xcvrd_show_event_rsp_tbl, self.xcvrd_show_event_res_tbl, asic_index, port)
                     break
 
             while True:
-                (port, op, fvp) = xcvrd_show_fec_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.xcvrd_show_fec_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
 
-                    handle_get_fec_cmd_arg_tbl_notification(fvp,xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
+                    handle_get_fec_cmd_arg_tbl_notification(fvp, self.xcvrd_show_fec_rsp_tbl, self.xcvrd_show_fec_cmd_sts_tbl, self.xcvrd_show_fec_res_tbl, asic_index, port)
                     break
 
             while True:
-                (port, op, fvp) = xcvrd_show_ber_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.xcvrd_show_ber_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+                    handle_show_ber_cmd_arg_tbl_notification(fvp, self.xcvrd_show_ber_cmd_arg_tbl, self.xcvrd_show_ber_rsp_tbl, self.xcvrd_show_ber_cmd_sts_tbl, self.xcvrd_show_ber_res_tbl, asic_index, port)
 
                     break
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3457,8 +3457,6 @@ class YCableTableUpdateTask(object):
         self.xcvrd_show_ber_cmd_tbl, self.xcvrd_show_ber_cmd_arg_tbl, self.xcvrd_show_ber_rsp_tbl , self.xcvrd_show_ber_cmd_sts_tbl, self.xcvrd_show_ber_res_tbl= {}, {}, {}, {}, {}
 
 
-        sel = swsscommon.Select()
-
         if multi_asic.is_multi_asic():
             # Load the namespace details first from the database_global.json file.
             swsscommon.SonicDBConfig.initializeGlobalConfig()
@@ -3489,7 +3487,6 @@ class YCableTableUpdateTask(object):
                 self.state_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
             self.y_cable_response_tbl[asic_id] = swsscommon.Table(
                 self.appl_db[asic_id], "MUX_CABLE_RESPONSE_TABLE")
-            self.hw_mux_cable_tbl_keys[asic_id] = self.hw_mux_cable_tbl[asic_id].getKeys()
             self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
             self.port_table_keys[asic_id] = self.port_tbl[asic_id].getKeys()
             self.xcvrd_log_tbl[asic_id] = swsscommon.SubscriberStateTable(
@@ -3606,6 +3603,7 @@ class YCableTableUpdateTask(object):
         for namespace in namespaces:
             # Open a handle to the Application database, in all namespaces
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.hw_mux_cable_tbl_keys[asic_id] = self.hw_mux_cable_tbl[asic_id].getKeys()
             sel.addSelectable(self.status_tbl[asic_id])
             sel.addSelectable(self.status_tbl_peer[asic_id])
             sel.addSelectable(self.fwd_state_command_tbl[asic_id])
@@ -3651,7 +3649,7 @@ class YCableTableUpdateTask(object):
                     # This check might be redundant, to check, the presence of this Port in keys
                     # in logical_port_list but keep for now for coherency
                     # also skip checking in logical_port_list inside sfp_util
-                    if port not in hw_mux_cable_tbl_keys[asic_index]:
+                    if port not in self.hw_mux_cable_tbl_keys[asic_index]:
                         continue
 
                     (status, cable_type) = check_mux_cable_port_type(port, self.port_tbl, asic_index)
@@ -3715,7 +3713,7 @@ class YCableTableUpdateTask(object):
 
                     fvp_dict = dict(fvp_m)
 
-                    (status, cable_type) = check_mux_cable_port_type(port_m, port_tbl, asic_index)
+                    (status, cable_type) = check_mux_cable_port_type(port_m, self.port_tbl, asic_index)
 
                     if status:
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
@@ -8,6 +8,9 @@ from sonic_py_common import daemon_base
 from sonic_py_common import multi_asic
 from swsscommon import swsscommon
 
+MUX_CABLE_STATIC_INFO_TABLE = "MUX_CABLE_STATIC_INFO"
+MUX_CABLE_INFO_TABLE = "MUX_CABLE_INFO"
+
 class YcableInfoUpdateTableHelper(object):
     def __init__(self):
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
@@ -1,0 +1,156 @@
+"""
+    y_cable_table_helper.py
+    helper utlities configuring y_cable tables for ycabled daemon
+"""
+
+
+from swsscommon import swsscommon
+
+class YcableInfoUpdateTableHelper(object):
+    def __init__(self):
+
+        self.state_db = {}
+        self.config_db = {}
+        self.port_tbl = {}
+        self.status_tbl = {}
+        self.y_cable_tbl = {} 
+        self.mux_tbl = {}
+
+        # Get the namespaces in the platform
+        fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'notice')])
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
+            self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
+            self.status_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
+            self.y_cable_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            self.mux_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], MUX_CABLE_INFO_TABLE)
+
+    def get_state_db(self):
+        return self.state_db
+
+    def get_config_db(self):
+        return self.config_db
+
+    def get_port_tbl(self):
+        return self.port_tbl
+
+    def get_status_tbl(self):
+        return self.status_tbl
+
+    def get_y_cable_tbl(self):
+        return self.y_cable_tbl
+
+    def get_mux_tbl(self):
+        return self.mux_tbl
+
+
+class YcableStateUpdateTableHelper(object):
+    def __init__(self):
+
+        self.state_db = {}
+        self.sub_status_tbl = {}
+
+        # Get the namespaces in the platform
+        fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'notice')])
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.sub_status_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
+
+
+
+    def get_sub_status_tbl(self):
+        return self.sub_status_tbl
+
+
+
+class DaemonYcableTableHelper(object):
+    def __init__(self):
+
+        self.state_db = {}
+        self.config_db = {}
+        self.port_tbl = {}
+        self.y_cable_tbl = {} 
+        self.metadata_tbl = {}
+        self.static_tbl, self.mux_tbl = {}, {}
+        self.port_table_keys = {}
+        self.xcvrd_log_tbl = {}
+        self.loopback_tbl= {}
+        self.loopback_keys = {}
+        self.hw_mux_cable_tbl = {}
+        self.hw_mux_cable_tbl_peer = {}
+        self.grpc_config_tbl = {}
+
+        # Get the namespaces in the platform
+        fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'notice')])
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
+            self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
+            self.y_cable_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            self.mux_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], MUX_CABLE_INFO_TABLE)
+            self.metadata_tbl[asic_id] = swsscommon.Table(
+                self.config_db[asic_id], "DEVICE_METADATA")
+            self.port_table_keys[asic_id] = self.port_tbl[asic_id].getKeys()
+            self.xcvrd_log_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "XCVRD_LOG")
+            self.xcvrd_log_tbl[asic_id].set("Y_CABLE", fvs_updated)
+            self.loopback_tbl[asic_id] = swsscommon.Table(
+                self.config_db[asic_id], "LOOPBACK_INTERFACE")
+            self.loopback_keys[asic_id] = self.loopback_tbl[asic_id].getKeys()
+            self.hw_mux_cable_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            self.hw_mux_cable_tbl_peer[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
+            self.static_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
+            self.grpc_config_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "GRPCCLIENT")
+
+
+    def get_state_db(self):
+        return self.state_db
+
+    def get_config_db(self):
+        return self.config_db
+
+    def get_port_tbl(self):
+        return self.port_tbl
+
+    def get_y_cable_tbl(self):
+        return self.y_cable_tbl
+
+    def get_mux_tbl(self):
+        return self.mux_tbl
+
+    def get_metadata_tbl(self):
+        return self.metadata_tbl
+
+    def get_xcvrd_log_tbl(self):
+        return self.xcvrd_log_tbl
+
+    def get_loopback_tbl(self):
+        return self.loopback_tbl
+
+    def get_hw_mux_cable_tbl(self):
+        return self.hw_mux_cable_tbl
+
+    def get_hw_mux_cable_tbl_peer(self):
+        return self.hw_mux_cable_tbl_peer
+
+    def get_static_tbl(self):
+        return self.static_tbl
+
+    def get_grpc_config_tbl(self):
+        return self.grpc_config_tbl
+
+

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
@@ -247,6 +247,8 @@ class YcableCliUpdateTableHelper(object):
 
         self.appl_db, self.state_db, self.config_db = {}, {}, {}
         self.xcvrd_log_tbl = {}
+        self.port_tbl = {}
+        self.mux_tbl = {}
         self.xcvrd_down_fw_cmd_tbl, self.xcvrd_down_fw_rsp_tbl, self.xcvrd_down_fw_cmd_sts_tbl = {}, {}, {}
         self.xcvrd_down_fw_status_cmd_tbl, self.xcvrd_down_fw_status_rsp_tbl, self.xcvrd_down_fw_status_cmd_sts_tbl = {}, {}, {}
         self.xcvrd_acti_fw_cmd_tbl, self.xcvrd_acti_fw_cmd_arg_tbl, self.xcvrd_acti_fw_rsp_tbl, self.xcvrd_acti_fw_cmd_sts_tbl = {}, {}, {}, {}
@@ -373,6 +375,9 @@ class YcableCliUpdateTableHelper(object):
                 self.state_db[asic_id], "XCVRD_GET_BER_RSP")
             self.xcvrd_show_ber_res_tbl[asic_id] = swsscommon.Table(
                 self.state_db[asic_id], "XCVRD_GET_BER_RES")
+            self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
+            self.mux_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], MUX_CABLE_INFO_TABLE)
 
     def get_state_db(self):
         return self.state_db

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
@@ -4,6 +4,8 @@
 """
 
 
+from sonic_py_common import daemon_base
+from sonic_py_common import multi_asic
 from swsscommon import swsscommon
 
 class YcableInfoUpdateTableHelper(object):

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
@@ -158,3 +158,229 @@ class DaemonYcableTableHelper(object):
         return self.grpc_config_tbl
 
 
+class YcableTableUpdateTableHelper(object):
+    def __init__(self):
+
+        self.appl_db, self.state_db, self.config_db, self.status_tbl, self.status_tbl_peer = {}, {}, {}, {}, {}
+        self.hw_mux_cable_tbl, self.hw_mux_cable_tbl_peer = {}, {}
+        self.hw_mux_cable_tbl_keys = {}
+        self.port_tbl, self.port_table_keys = {}, {}
+        self.fwd_state_command_tbl, self.fwd_state_response_tbl, self.mux_cable_command_tbl = {}, {}, {}
+        self.mux_metrics_tbl = {}
+        self.y_cable_response_tbl = {}
+
+
+        if multi_asic.is_multi_asic():
+            # Load the namespace details first from the database_global.json file.
+            swsscommon.SonicDBConfig.initializeGlobalConfig()
+
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            # Open a handle to the Application database, in all namespaces
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
+            self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.status_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], swsscommon.APP_HW_MUX_CABLE_TABLE_NAME)
+            self.mux_cable_command_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], swsscommon.APP_MUX_CABLE_COMMAND_TABLE_NAME)
+            self.mux_metrics_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_MUX_METRICS_TABLE_NAME)
+            self.hw_mux_cable_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            # TODO add definition inside app DB
+            self.status_tbl_peer[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "HW_FORWARDING_STATE_PEER")
+            self.fwd_state_command_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "FORWARDING_STATE_COMMAND")
+            self.fwd_state_response_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "FORWARDING_STATE_RESPONSE")
+            self.hw_mux_cable_tbl_peer[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
+            self.y_cable_response_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "MUX_CABLE_RESPONSE_TABLE")
+            self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
+            self.port_table_keys[asic_id] = self.port_tbl[asic_id].getKeys()
+
+    def get_state_db(self):
+        return self.state_db
+
+    def get_config_db(self):
+        return self.config_db
+
+    def get_appl_db(self):
+        return self.appl_db
+
+    def get_status_tbl(self):
+        return self.status_tbl
+
+    def get_status_tbl_peer(self):
+        return self.status_tbl_peer
+
+    def get_mux_cable_command_tbl(self):
+        return self.mux_cable_command_tbl
+
+    def get_mux_metrics_tbl(self):
+        return self.mux_metrics_tbl
+
+    def get_hw_mux_cable_tbl(self):
+        return self.hw_mux_cable_tbl
+
+    def get_hw_mux_cable_tbl_peer(self):
+        return self.hw_mux_cable_tbl_peer
+
+    def get_fwd_state_command_tbl(self):
+        return self.fwd_state_command_tbl
+
+    def get_fwd_state_response_tbl(self):
+        return self.fwd_state_response_tbl
+
+    def get_y_cable_response_tbl(self):
+        return self.y_cable_response_tbl
+
+    def get_port_tbl(self):
+        return self.port_tbl
+
+class YcableCliUpdateTableHelper(object):
+    def __init__(self):
+
+        self.appl_db, self.state_db, self.config_db = {}, {}, {}
+        self.xcvrd_log_tbl = {}
+        self.xcvrd_down_fw_cmd_tbl, self.xcvrd_down_fw_rsp_tbl, self.xcvrd_down_fw_cmd_sts_tbl = {}, {}, {}
+        self.xcvrd_down_fw_status_cmd_tbl, self.xcvrd_down_fw_status_rsp_tbl, self.xcvrd_down_fw_status_cmd_sts_tbl = {}, {}, {}
+        self.xcvrd_acti_fw_cmd_tbl, self.xcvrd_acti_fw_cmd_arg_tbl, self.xcvrd_acti_fw_rsp_tbl, self.xcvrd_acti_fw_cmd_sts_tbl = {}, {}, {}, {}
+        self.xcvrd_roll_fw_cmd_tbl, self.xcvrd_roll_fw_rsp_tbl, self.xcvrd_roll_fw_cmd_sts_tbl = {}, {}, {}
+        self.xcvrd_show_fw_cmd_tbl, self.xcvrd_show_fw_rsp_tbl, self.xcvrd_show_fw_cmd_sts_tbl, self.xcvrd_show_fw_res_tbl = {}, {}, {}, {}
+        self.xcvrd_show_hwmode_dir_cmd_tbl, self.xcvrd_show_hwmode_dir_rsp_tbl, self.xcvrd_show_hwmode_dir_res_tbl, self.xcvrd_show_hwmode_dir_cmd_sts_tbl = {}, {}, {}, {}
+        self.xcvrd_show_hwmode_swmode_cmd_tbl, self.xcvrd_show_hwmode_swmode_rsp_tbl, self.xcvrd_show_hwmode_swmode_cmd_sts_tbl = {}, {}, {}
+        self.xcvrd_config_hwmode_state_cmd_tbl, self.xcvrd_config_hwmode_state_rsp_tbl , self.xcvrd_config_hwmode_state_cmd_sts_tbl= {}, {}, {}
+        self.xcvrd_config_hwmode_swmode_cmd_tbl, self.xcvrd_config_hwmode_swmode_rsp_tbl , self.xcvrd_config_hwmode_swmode_cmd_sts_tbl= {}, {}, {}
+        self.xcvrd_config_prbs_cmd_tbl, self.xcvrd_config_prbs_cmd_arg_tbl, self.xcvrd_config_prbs_rsp_tbl , self.xcvrd_config_prbs_cmd_sts_tbl= {}, {}, {}, {}
+        self.xcvrd_config_loop_cmd_tbl, self.xcvrd_config_loop_cmd_arg_tbl, self.xcvrd_config_loop_rsp_tbl , self.xcvrd_config_loop_cmd_sts_tbl= {}, {}, {}, {}
+        self.xcvrd_show_event_cmd_tbl, self.xcvrd_show_event_rsp_tbl , self.xcvrd_show_event_cmd_sts_tbl, self.xcvrd_show_event_res_tbl= {}, {}, {}, {}
+        self.xcvrd_show_fec_cmd_tbl, self.xcvrd_show_fec_rsp_tbl , self.xcvrd_show_fec_cmd_sts_tbl, self.xcvrd_show_fec_res_tbl= {}, {}, {}, {}
+        self.xcvrd_show_ber_cmd_tbl, self.xcvrd_show_ber_cmd_arg_tbl, self.xcvrd_show_ber_rsp_tbl , self.xcvrd_show_ber_cmd_sts_tbl, self.xcvrd_show_ber_res_tbl= {}, {}, {}, {}, {}
+
+
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            # Open a handle to the Application database, in all namespaces
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
+            self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+
+            self.xcvrd_log_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.config_db[asic_id], "XCVRD_LOG")
+            self.xcvrd_show_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_SHOW_FW_CMD")
+            self.xcvrd_show_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_SHOW_FW_CMD")
+            self.xcvrd_show_fw_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_FW_RSP")
+            self.xcvrd_show_fw_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_FW_RES")
+            self.xcvrd_down_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_DOWN_FW_CMD")
+            self.xcvrd_down_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_DOWN_FW_CMD")
+            self.xcvrd_down_fw_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_DOWN_FW_RSP")
+            self.xcvrd_down_fw_status_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_DOWN_FW_STATUS_CMD")
+            self.xcvrd_down_fw_status_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_DOWN_FW_STATUS_RSP")
+            self.xcvrd_acti_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_ACTI_FW_CMD")
+            self.xcvrd_acti_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_ACTI_FW_CMD")
+            self.xcvrd_acti_fw_cmd_arg_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_ACTI_FW_CMD_ARG")
+            self.xcvrd_acti_fw_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_ACTI_FW_RSP")
+            self.xcvrd_roll_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_ROLL_FW_CMD")
+            self.xcvrd_roll_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_ROLL_FW_CMD")
+            self.xcvrd_roll_fw_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_ROLL_FW_RSP")
+            self.xcvrd_show_hwmode_dir_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_CMD")
+            self.xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_CMD")
+            self.xcvrd_show_hwmode_dir_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_RSP")
+            self.xcvrd_show_hwmode_dir_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_RES")
+            self.xcvrd_config_hwmode_state_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_CMD")
+            self.xcvrd_config_hwmode_state_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_CMD")
+            self.xcvrd_config_hwmode_state_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_RSP")
+            self.xcvrd_config_hwmode_swmode_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_CMD")
+            self.xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_CMD")
+            self.xcvrd_config_hwmode_swmode_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_RSP")
+            self.xcvrd_show_hwmode_swmode_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_CMD")
+            self.xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_CMD")
+            self.xcvrd_show_hwmode_swmode_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_RSP")
+            self.xcvrd_config_prbs_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD")
+            self.xcvrd_config_prbs_cmd_arg_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD_ARG")
+            self.xcvrd_config_prbs_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD")
+            self.xcvrd_config_prbs_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_CONFIG_PRBS_RSP")
+            self.xcvrd_config_loop_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD")
+            self.xcvrd_config_loop_cmd_arg_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD_ARG")
+            self.xcvrd_config_loop_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD")
+            self.xcvrd_config_loop_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_CONFIG_LOOP_RSP")
+            self.xcvrd_show_event_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_EVENT_LOG_CMD")
+            self.xcvrd_show_event_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_EVENT_LOG_CMD")
+            self.xcvrd_show_event_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_EVENT_LOG_RSP")
+            self.xcvrd_show_event_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_EVENT_LOG_RES")
+            self.xcvrd_show_fec_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_GET_FEC_CMD")
+            self.xcvrd_show_fec_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_GET_FEC_CMD")
+            self.xcvrd_show_fec_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_GET_FEC_RSP")
+            self.xcvrd_show_fec_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_GET_FEC_RES")
+            self.xcvrd_show_ber_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_GET_BER_CMD")
+            self.xcvrd_show_ber_cmd_arg_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_GET_BER_CMD_ARG")
+            self.xcvrd_show_ber_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_GET_BER_CMD")
+            self.xcvrd_show_ber_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_GET_BER_RSP")
+            self.xcvrd_show_ber_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_GET_BER_RES")
+
+    def get_state_db(self):
+        return self.state_db
+
+    def get_config_db(self):
+        return self.config_db
+
+    def get_appl_db(self):
+        return self.appl_db
+
+

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
@@ -10,6 +10,7 @@ from swsscommon import swsscommon
 
 MUX_CABLE_STATIC_INFO_TABLE = "MUX_CABLE_STATIC_INFO"
 MUX_CABLE_INFO_TABLE = "MUX_CABLE_INFO"
+TRANSCEIVER_STATUS_TABLE = 'TRANSCEIVER_STATUS'
 
 class YcableInfoUpdateTableHelper(object):
     def __init__(self):
@@ -22,7 +23,6 @@ class YcableInfoUpdateTableHelper(object):
         self.mux_tbl = {}
 
         # Get the namespaces in the platform
-        fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'notice')])
         namespaces = multi_asic.get_front_end_namespaces()
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
@@ -61,7 +61,6 @@ class YcableStateUpdateTableHelper(object):
         self.sub_status_tbl = {}
 
         # Get the namespaces in the platform
-        fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'notice')])
         namespaces = multi_asic.get_front_end_namespaces()
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)


### PR DESCRIPTION
This PR attempts for ycabled to have all 
```swsscommon.Table and daemon_base.db_connect```
as just a single call in the thread instance for all task_workers

For example all swsscommon calls to open Tables are moved as class object varables, which are reused when needed instead of opening the Table again in subroutines.
```
self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
```
This would help in avoiding unforeseen redis-errors
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Deploying changes on testbed and UT
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
