### PR TITLE
Add new fields to status/dom_sensor/pm tables in STATE_DB for CMIS/C-CMIS

### DIFF
--- a/sonic-xcvrd/tests/mock_swsscommon.py
+++ b/sonic-xcvrd/tests/mock_swsscommon.py
@@ -14,6 +14,19 @@ class Table:
             self.mock_keys.remove(key)
         pass
 
+    def hdel(self, key, field):
+        if key not in self.mock_dict:
+            return
+
+        # swsscommon.FieldValuePairs
+        fvs = self.mock_dict[key]
+        for i, fv in enumerate(fvs):
+            if fv[0] == field:
+                del fvs[i]
+                break
+        if self.get_size_for_key(key) == 0:
+            self._del(key)
+
     def set(self, key, fvs):
         self.mock_dict[key] = fvs
         self.mock_keys.append(key)
@@ -21,17 +34,14 @@ class Table:
 
     def get(self, key):
         if key in self.mock_dict:
-            return self.mock_dict[key]
-        return None
+            return True, self.mock_dict[key]
+        return False, None
 
     def get_size(self):
         return (len(self.mock_dict))
-    
+
+    def get_size_for_key(self, key):
+        return len(self.mock_dict[key])
+
     def getKeys(self):
         return self.mock_keys
-
-
-class FieldValuePairs:
-    def __init__(self, fvs):
-        self.fv_dict = dict(fvs)
-        pass

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -812,7 +812,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.post_port_dom_threshold_info_to_db')
     @patch('xcvrd.xcvrd.post_port_dom_info_to_db')
     @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')
-    @patch('xcvrd.xcvrd.update_port_transceiver_status_table')
+    @patch('xcvrd.xcvrd.update_port_transceiver_status_table_sw')
     def test_SfpStateUpdateTask_task_worker(self, mock_updata_status, mock_post_sfp_info, mock_post_dom_info, mock_post_dom_th, mock_update_media_setting, mock_del_dom, mock_change_event, mock_mapping_event, mock_os_kill):
         port_mapping = PortMapping()
         retry_eeprom_set = set()
@@ -906,7 +906,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.post_port_dom_threshold_info_to_db')
     @patch('xcvrd.xcvrd.post_port_dom_info_to_db')
     @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')
-    @patch('xcvrd.xcvrd.update_port_transceiver_status_table')
+    @patch('xcvrd.xcvrd.update_port_transceiver_status_table_sw')
     def test_SfpStateUpdateTask_on_add_logical_port(self, mock_updata_status, mock_post_sfp_info, mock_post_dom_info, mock_post_dom_th, mock_update_media_setting, mock_get_presence, mock_table_helper):
         class MockTable:
             pass

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1173,6 +1173,20 @@ class TestXcvrdScript(object):
         assert not _wrapper_get_transceiver_dom_threshold_info(1)
 
     @patch('xcvrd.xcvrd.platform_chassis')
+    def test_wrapper_get_transceiver_status(self, mock_chassis):
+        mock_object = MagicMock()
+        mock_object.get_transceiver_status= MagicMock(return_value=True)
+        mock_chassis.get_sfp = MagicMock(return_value=mock_object)
+        from xcvrd.xcvrd import _wrapper_get_transceiver_status
+        assert _wrapper_get_transceiver_status(1)
+
+        mock_object.get_transceiver_status = MagicMock(return_value=False)
+        assert not _wrapper_get_transceiver_status(1)
+
+        mock_chassis.get_sfp = MagicMock(side_effect=NotImplementedError)
+        assert _wrapper_get_transceiver_status(1) == {}
+
+    @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd.platform_sfputil')
     def test_wrapper_get_transceiver_change_event(self, mock_sfputil, mock_chassis):
         mock_chassis.get_change_event = MagicMock(return_value=(True, {'sfp': 1, 'sfp_error': 'N/A'}))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -863,7 +863,7 @@ def update_port_transceiver_status_table_hw(logical_port_name, port_mapping,
                 return SFP_EEPROM_NOT_READY
 
         except NotImplementedError:
-            helper_logger.log_error("This functionality is currently not implemented for this platform")
+            helper_logger.log_error("get_transceiver_status is currently not implemented for this platform")
             sys.exit(NOT_IMPLEMENTED_ERROR)
 
 # Delete port from SFP status table

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -883,7 +883,8 @@ def update_port_transceiver_status_table_hw(logical_port_name, port_mapping,
 
 
 def delete_port_from_status_table_sw(logical_port_name, status_tbl):
-    status_tbl._del(logical_port_name)
+    for f in TRANSCEIVER_STATUS_TABLE_SW_FIELDS:
+        status_tbl.hdel(logical_port_name, f)
 
 # Delete port from SFP status table for HW fields which are fetched from EEPROM
 
@@ -894,7 +895,7 @@ def delete_port_from_status_table_hw(logical_port_name, port_mapping, status_tbl
         if not found:
             return
         status_dict = dict(fvs)
-        for f, _ in status_dict:
+        for f in status_dict.keys():
             if f in TRANSCEIVER_STATUS_TABLE_SW_FIELDS:
                 continue
             status_tbl.hdel(physical_port_name, f)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2000,7 +2000,8 @@ class SfpStateUpdateTask(object):
                                     # In this case EEPROM is not accessible. The DOM info will be removed since it can be out-of-date.
                                     # The interface info remains in the DB since it is static.
                                     if sfp_status_helper.is_error_block_eeprom_reading(error_bits):
-                                        del_port_sfp_dom_info_from_db(logical_port, self.port_mapping,
+                                        del_port_sfp_dom_info_from_db(logical_port,
+                                                                      self.port_mapping,
                                                                       None,
                                                                       self.xcvr_table_helper.get_dom_tbl(asic_index),
                                                                       self.xcvr_table_helper.get_pm_tbl(asic_index))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -558,28 +558,23 @@ def post_port_pm_info_to_db(logical_port_name, port_mapping, table, stop_event=t
         if not _wrapper_get_presence(physical_port):
             continue
 
-        try:
-            if pm_info_cache is not None and physical_port in pm_info_cache:
-                # If cache is enabled and pm info is in cache, just read from cache, no need read from EEPROM
-                pm_info_dict = pm_info_cache[physical_port]
-            else:
-                pm_info_dict = _wrapper_get_transceiver_pm(physical_port)
-                if pm_info_cache is not None:
-                    # If cache is enabled, put dom information to cache
-                    pm_info_cache[physical_port] = pm_info_dict
-            if pm_info_dict is not None:
-                # ignore if empty
-                if not pm_info_dict:
-                    continue
-                beautify_pm_info_dict(pm_info_dict, physical_port)
-                fvs = swsscommon.FieldValuePairs([(k, v) for k, v in pm_info_dict.items()])
-                table.set(physical_port_name, fvs)
-            else:
-                return SFP_EEPROM_NOT_READY
-
-        except NotImplementedError:
-            helper_logger.log_error("get_transceiver_pm is currently not implemented for this platform")
-            sys.exit(NOT_IMPLEMENTED_ERROR)
+        if pm_info_cache is not None and physical_port in pm_info_cache:
+            # If cache is enabled and pm info is in cache, just read from cache, no need read from EEPROM
+            pm_info_dict = pm_info_cache[physical_port]
+        else:
+            pm_info_dict = _wrapper_get_transceiver_pm(physical_port)
+            if pm_info_cache is not None:
+                # If cache is enabled, put dom information to cache
+                pm_info_cache[physical_port] = pm_info_dict
+        if pm_info_dict is not None:
+            # Skip if empty (i.e. get_transceiver_pm API is not applicable for this xcvr)
+            if not pm_info_dict:
+                continue
+            beautify_pm_info_dict(pm_info_dict, physical_port)
+            fvs = swsscommon.FieldValuePairs([(k, v) for k, v in pm_info_dict.items()])
+            table.set(physical_port_name, fvs)
+        else:
+            return SFP_EEPROM_NOT_READY
 
 # Update port dom/sfp info in db
 
@@ -886,25 +881,23 @@ def update_port_transceiver_status_table_hw(logical_port_name, port_mapping,
         if not _wrapper_get_presence(physical_port):
             continue
 
-        try:
-            if transceiver_status_cache is not None and physical_port in transceiver_status_cache:
-                # If cache is enabled and status info is in cache, just read from cache, no need read from EEPROM
-                transceiver_status_dict = transceiver_status_cache[physical_port]
-            else:
-                transceiver_status_dict = _wrapper_get_transceiver_status(physical_port)
-                if transceiver_status_cache is not None:
-                    # If cache is enabled, put status info to cache
-                    transceiver_status_cache[physical_port] = transceiver_status_dict
-            if transceiver_status_dict is not None:
-                beautify_transceiver_status_dict(transceiver_status_dict, physical_port)
-                fvs = swsscommon.FieldValuePairs([(k, v) for k, v in transceiver_status_dict.items()])
-                table.set(physical_port_name, fvs)
-            else:
-                return SFP_EEPROM_NOT_READY
-
-        except NotImplementedError:
-            helper_logger.log_error("get_transceiver_status is currently not implemented for this platform")
-            sys.exit(NOT_IMPLEMENTED_ERROR)
+        if transceiver_status_cache is not None and physical_port in transceiver_status_cache:
+            # If cache is enabled and status info is in cache, just read from cache, no need read from EEPROM
+            transceiver_status_dict = transceiver_status_cache[physical_port]
+        else:
+            transceiver_status_dict = _wrapper_get_transceiver_status(physical_port)
+            if transceiver_status_cache is not None:
+                # If cache is enabled, put status info to cache
+                transceiver_status_cache[physical_port] = transceiver_status_dict
+        if transceiver_status_dict is not None:
+            # Skip if empty (i.e. get_transceiver_status API is not applicable for this xcvr)
+            if not transceiver_status_dict:
+                continue
+            beautify_transceiver_status_dict(transceiver_status_dict, physical_port)
+            fvs = swsscommon.FieldValuePairs([(k, v) for k, v in transceiver_status_dict.items()])
+            table.set(physical_port_name, fvs)
+        else:
+            return SFP_EEPROM_NOT_READY
 
 # Delete port from SFP status table
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2394,7 +2394,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
 class XcvrTableHelper:
     def __init__(self, namespaces):
         self.int_tbl, self.dom_tbl, self.dom_threshold_tbl, self.status_tbl, self.app_port_tbl, \
-		self.cfg_port_tbl, self.state_port_tbl, self.pm_tbl = {}, {}, {}, {}, {}, {}, {}
+		self.cfg_port_tbl, self.state_port_tbl, self.pm_tbl = {}, {}, {}, {}, {}, {}, {}, {}
         self.state_db = {}
         self.cfg_db = {}
         for namespace in namespaces:

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -861,12 +861,12 @@ def update_port_transceiver_status_table_hw(logical_port_name, port_mapping,
 
         try:
             if transceiver_status_cache is not None and physical_port in transceiver_status_cache:
-                # If cache is enabled and dom information is in cache, just read from cache, no need read from EEPROM
+                # If cache is enabled and status info is in cache, just read from cache, no need read from EEPROM
                 transceiver_status_dict = transceiver_status_cache[physical_port]
             else:
                 transceiver_status_dict = _wrapper_get_transceiver_status(physical_port)
                 if transceiver_status_cache is not None:
-                    # If cache is enabled, put dom information to cache
+                    # If cache is enabled, put status info to cache
                     transceiver_status_cache[physical_port] = transceiver_status_dict
             if transceiver_status_dict is not None:
                 beautify_transceiver_status_dict(transceiver_status_dict, physical_port)
@@ -2145,7 +2145,7 @@ class SfpStateUpdateTask(object):
                     post_port_dom_threshold_info_to_db(port_change_event.port_name, self.port_mapping, dom_tbl)
                     update_port_transceiver_status_table_hw(port_change_event.port_name,
                                                             self.port_mapping,
-                                                            self.xcvr_table_helper.get_status_tbl(port_change_event.asic_id))
+                                                            status_tbl)
                     notify_media_setting(port_change_event.port_name, transceiver_dict, self.xcvr_table_helper.get_app_port_tbl(port_change_event.asic_id), self.port_mapping)
             else:
                 status = sfp_status_helper.SFP_STATUS_REMOVED if not status else status


### PR DESCRIPTION
Add new fields to status/dom_sensor/pm tables in STATE_DB for CMIS/C-CMIS

#### Description
1. Add all the fields that are supported by c_cmis [get_transceiver_bulk_status](https://github.com/sonic-net/sonic-platform-common/blob/b26aa5ef79fca95064d0baf3b1beed8d56d212f8/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py#L302) API but not currently present to dom_sensor table.
2. Add new fields (provided by [cmis.py:get_transceiver_status() API](https://github.com/sonic-net/sonic-platform-common/blob/86bab38c723eb4ebbfa16feed66344d1b3ffd46e/sonic_platform_base/sonic_xcvr/api/public/cmis.py#L1548) and [c_cmis.py:get_transceiver_status() API](https://github.com/sonic-net/sonic-platform-common/blob/86bab38c723eb4ebbfa16feed66344d1b3ffd46e/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py#L565) ) to status table(TRANSCEIVER_STATUS). 
following SW fields(non-eeprom-fetched) are already present in today's status table:
```
status                       = 1*255VCHAR                       ; code of the module status (plug in, plug out)
error                        = 1*255VCHAR                       ; module error (N/A or a string consisting of error descriptions joined by "|", like "error1 | error2" )
```
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;following HW fields (eeprom-fetched) are added per [this HLD](https://github.com/sonic-net/SONiC/blob/a5675ea78a7cb6d4d1dfdc780fbf2183d7a41a89/doc/platform_api/CMIS_and_C-CMIS_support_for_ZR.md#214-transceiver-status-table) (this is just snippet, refer to HLD for complete list):
```
module_state                 = 1*255VCHAR                       ; current module state (ModuleLowPwr, ModulePwrUp, ModuleReady, ModulePwrDn, Fault)
module_fault_cause           = 1*255VCHAR                       ; reason of entering the module fault state
datapath_firmware_fault      = BOOLEAN                          ; datapath (DSP) firmware fault
module_firmware_fault        = BOOLEAN                          ; module firmware fault
module_state_changed         = BOOLEAN                          ; module state changed
datapath_hostlane1           = 1*255VCHAR                       ; data path state indicator on host lane 1
......
rxsigpowerhighwarning_flag   = BOOLEAN                          ; rxsigpower high warning flag
rxsigpowerlowwarning_flag    = BOOLEAN                          ; rxsigpower low warning flag
```
3. Add pm related fields to a newly created table TRANSCEIVER_PM in STATE_DB. (DB schema is defined in this [HLD](https://github.com/sonic-net/SONiC/blob/master/doc/platform_api/CMIS_and_C-CMIS_support_for_ZR.md#215-transceiver-pm-table)
4. Add corresponding DB update/delete handling along the xcvrd flow.
5. Add/modify test cases on test_xcvrd.py to cover newly added code.

Here's the entire DB schema of [status tbl](https://github.com/sonic-net/SONiC/blob/a5675ea78a7cb6d4d1dfdc780fbf2183d7a41a89/doc/platform_api/CMIS_and_C-CMIS_support_for_ZR.md#214-transceiver-status-table) and [dom_sensor tbl](https://github.com/sonic-net/SONiC/blob/a5675ea78a7cb6d4d1dfdc780fbf2183d7a41a89/doc/platform_api/CMIS_and_C-CMIS_support_for_ZR.md#212-transceiver-dom-sensor-table), according to the new HLD from PR https://github.com/sonic-net/SONiC/pull/1076


#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Verified on CMIS/C-CMIS optics, interfaces come up fine, and new fields show up in DB

UT output for dom_sensor table:
[dom_sensor_tbl_ut_output.txt](https://github.com/sonic-net/sonic-platform-daemons/files/9805375/dom_sensor_tbl_ut_output.txt)

UT output for status table:
[status_tbl_ut_output.txt](https://github.com/sonic-net/sonic-platform-daemons/files/9805349/status_tbl_ut_output.txt)

UT output for status table in xcvrd restart case:
[xcvrd_restart_test.txt](https://github.com/sonic-net/sonic-platform-daemons/files/9892550/xcvrd_restart_test.txt)

UT output for pm table:
[pm_table_output.txt](https://github.com/sonic-net/sonic-platform-daemons/files/9957822/pm_table_output.txt)

UT output for pm table in xcvrd restart case:
[xcvrd_restart_test_pm_tbl.txt](https://github.com/sonic-net/sonic-platform-daemons/files/9957826/xcvrd_restart_test_pm_tbl.txt)

UT result for test_xcvrd.py:
[ut_w_coverage.txt](https://github.com/sonic-net/sonic-platform-daemons/files/9957863/ut_w_coverage.txt)


#### Additional Information (Optional)

> **Note**
> Please don't merge this PR until the dependency PR https://github.com/sonic-net/sonic-platform-common/pull/315 gets merged.
