### PR TITLE
[ycabled] add support for detach mode in 'active-active' topology

### DIFF
--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -64,6 +64,8 @@ GRPC_CLIENT_OPTIONS = [
     ('grpc.http2.max_pings_without_data', 0)
 ]
 
+CONFIG_MUX_STATES = ["active", "standby", "auto", "manual", "detach"]
+
 DEFAULT_PORT_IDS = [0, 1]
 
 SYSLOG_IDENTIFIER = "y_cable_helper"
@@ -297,7 +299,7 @@ def check_mux_cable_port_type(logical_port_name, port_tbl, asic_index):
             val = mux_table_dict.get("state", None)
             cable_type = mux_table_dict.get("cable_type", None)
 
-            if val in ["active", "standby", "auto", "manual"]:
+            if val in CONFIG_MUX_STATES:
                 if cable_type == "active-active":
                     helper_logger.log_debug("Y_CABLE_DEBUG:check_mux_cable_port_type returning True active-active port {}".format(logical_port_name))
                     return (True , "active-active")
@@ -670,7 +672,7 @@ def check_identifier_presence_and_setup_channel(logical_port_name, port_tbl, hw_
                 soc_ipv4 = soc_ipv4_full.split('/')[0]
             cable_type = mux_table_dict.get("cable_type", None)
 
-            if val in ["active", "standby", "auto", "manual"] and cable_type == "active-active":
+            if val in CONFIG_MUX_STATES and cable_type == "active-active":
 
                 # import the module and load the port instance
                 y_cable_presence[:] = [True]
@@ -1191,7 +1193,7 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
 
             val = mux_table_dict.get("state", None)
 
-            if val in ["active", "auto", "manual", "standby"]:
+            if val in CONFIG_MUX_STATES:
 
                 # import the module and load the port instance
                 physical_port_list = logical_port_name_to_physical_port_list(
@@ -1631,7 +1633,7 @@ def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_
         mux_table_dict = dict(fvs)
         if "state" in mux_table_dict:
             val = mux_table_dict.get("state", None)
-            if val in ["active", "auto", "manual", "standby"]:
+            if val in CONFIG_MUX_STATES:
 
                 if mux_tbl.get(asic_index, None) is not None:
                     # fill in the newly found entry


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
This PR adds a support for taking `detach` mode into consideration as a valid CONFIG_DB state for muxcable.
If 'detach' mode is configured it will be treated as a valid and appropriate RPC's will be serviced by ycabled. 
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
UT and deploying changes on testbed
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
