### PR TITLE
[ycabled] move swsscommon API's from subroutines to call them exactly once per task_worker/thread

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -192,9 +192,19 @@ class TestYCableScript(object):
                                                                                                'version_peer_inactive': '1.7MS',
                                                                                                'version_peer_next': '1.7MS'}))
     def test_post_port_mux_info_to_db(self):
+        asic_index = 0
         logical_port_name = "Ethernet0"
-        mux_tbl = Table("STATE_DB", "Y_CABLE_INFO_TABLE")
-        rc = post_port_mux_info_to_db(logical_port_name, mux_tbl)
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        rc = post_port_mux_info_to_db(logical_port_name, mux_tbl,asic_index, y_cable_tbl)
         assert(rc != -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
@@ -704,6 +714,9 @@ class TestYCableScript(object):
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
         read_side = 1
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
             def mock_get():
@@ -712,7 +725,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = mock_get()
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -721,6 +734,9 @@ class TestYCableScript(object):
         asic_index = 0
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
             def mock_read_side():
@@ -731,7 +747,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = 0
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -741,6 +757,9 @@ class TestYCableScript(object):
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
         read_side = 1
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -756,7 +775,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = PortInstanceHelper()
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -766,6 +785,9 @@ class TestYCableScript(object):
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
         read_side = 1
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -779,7 +801,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = PortInstanceHelper()
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -789,6 +811,9 @@ class TestYCableScript(object):
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
         read_side = 2
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -802,7 +827,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = PortInstanceHelper()
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -812,6 +837,9 @@ class TestYCableScript(object):
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
         read_side = 1
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -825,7 +853,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = PortInstanceHelper()
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -835,6 +863,9 @@ class TestYCableScript(object):
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
         read_side = 1
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -848,7 +879,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = PortInstanceHelper()
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0, 1, 2]))
@@ -857,6 +888,9 @@ class TestYCableScript(object):
         appl_db = "TEST_DB"
         logical_port_name = "Ethernet0"
         read_side = 1
+        mux_response_tbl = {}
+        mux_response_tbl[asic_index] = swsscommon.Table(
+            appl_db[asic_index], "STATEDB_PORT_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -870,7 +904,7 @@ class TestYCableScript(object):
             patched_util.get.return_value = PortInstanceHelper()
 
             rc = update_appdb_port_mux_cable_response_table(
-                logical_port_name, asic_index, appl_db, read_side)
+                logical_port_name, asic_index, appl_db, read_side, mux_response_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0, 1, 2]))
@@ -1091,6 +1125,15 @@ class TestYCableScript(object):
         y_cable_tbl = {}
         static_tbl = {}
         mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+        static_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "STATIC_TABLE")
+        static_tbl[asic_index].get.return_value = (status, fvs)
 
         rc = create_tables_and_insert_mux_unknown_entries(
             state_db, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name)
@@ -1562,6 +1605,10 @@ class TestYCableScript(object):
         mux_tbl = {}
         port_tbl = {}
         y_cable_presence = [False]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+        static_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], MUX_CABLE_STATIC_INFO_TABLE)
 
         port_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "PORT_INFO_TABLE")
@@ -1582,17 +1629,27 @@ class TestYCableScript(object):
 
         asic_index = 0
         logical_port_name = "Ethernet0"
-        status = True
-        fvs = [('state', "auto"), ('read_side', 1)]
 
         state_db = {}
         test_db = "TEST_DB"
-        y_cable_tbl = {}
         static_tbl = {}
         mux_tbl = {}
         port_tbl = {}
         y_cable_presence = [True]
         delete_change_event = [True]
+        fvs = [('state', "auto"), ('read_side', 1)]
+        asic_index = 0
+        status = True
+        y_cable_tbl = {}
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+        static_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "STATIC_TABLE")
+        static_tbl[asic_index].get.return_value = (status, fvs)
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "MUX_TABLE")
+        mux_tbl[asic_index].get.return_value = (status, fvs)
 
         port_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "PORT_INFO_TABLE")
@@ -1600,12 +1657,13 @@ class TestYCableScript(object):
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as port_instance:
             rc = check_identifier_presence_and_delete_mux_table_entry(
-                state_db, port_tbl, asic_index, logical_port_name, y_cable_presence,  delete_change_event)
+                state_db, port_tbl, asic_index, logical_port_name, y_cable_presence,  delete_change_event, y_cable_tbl, static_tbl, mux_tbl)
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_chassis')
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
     @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.process_loopback_interface_and_get_read_side',MagicMock(return_value=0))
     def test_init_ports_status_for_y_cable(self, platform_chassis, platform_sfp, mock_swsscommon_table):
 
         platform_sfp = MagicMock()
@@ -1621,9 +1679,35 @@ class TestYCableScript(object):
         mock_table = MagicMock()
         mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
         mock_swsscommon_table.return_value = mock_table
+        state_db = {}
+        test_db = "TEST_DB"
+        static_tbl = {}
+        mux_tbl = {}
+        port_tbl = {}
+        port_table_keys = {}
+        loopback_keys = {}
+        hw_mux_cable_tbl, hw_mux_cable_tbl_peer = {}, {}
+        y_cable_presence = [True]
+        delete_change_event = [True]
+        fvs = [('state', "auto"), ('read_side', 1)]
+        asic_index = 0
+        status = True
+        y_cable_tbl = {}
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+        static_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "STATIC_TABLE")
+        static_tbl[asic_index].get.return_value = (status, fvs)
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "MUX_TABLE")
+        mux_tbl[asic_index].get.return_value = (status, fvs)
 
-        rc = init_ports_status_for_y_cable(platform_sfp, platform_chassis,
-                                           y_cable_presence,  stop_event=threading.Event())
+        port_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        port_tbl[asic_index].get.return_value = (status, fvs)
+
+        rc = init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presence,  state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, port_table_keys, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, stop_event=threading.Event())
 
         assert(rc == None)
 
@@ -1721,16 +1805,39 @@ class TestYCableScript(object):
         mock_swsscommon_table.return_value = mock_table
 
         mock_logical_port_name = [""]
+        state_db = {}
+        test_db = "TEST_DB"
+        static_tbl = {}
+        mux_tbl = {}
+        port_tbl = {}
+        fvs = [('state', "auto"), ('read_side', 1)]
+        asic_index = 0
+        status = True
+        y_cable_tbl = {}
+        grpc_config = {}
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+        static_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "STATIC_TABLE")
+        static_tbl[asic_index].get.return_value = (status, fvs)
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "MUX_TABLE")
+        mux_tbl[asic_index].get.return_value = (status, fvs)
 
-        def mock_get_asic_id(mock_logical_port_name):
-            return 0
+        port_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        port_tbl[asic_index].get.return_value = (status, fvs)
+        grpc_config[asic_index] = swsscommon.Table(
+            test_db[asic_index], "GRPC_CONFIG")
+
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
             patched_util.logical.return_value = ['Ethernet0', 'Ethernet4']
             patched_util.get_asic_id_for_logical_port.return_value = 0
 
-            rc = delete_ports_status_for_y_cable()
+            rc = delete_ports_status_for_y_cable(y_cable_tbl, static_tbl, mux_tbl, port_tbl, grpc_config)
 
             mock_swsscommon_table.assert_called()
 
@@ -1740,7 +1847,18 @@ class TestYCableScript(object):
 
         state_db = {}
         test_db = "TEST_DB"
+        status = True
         mux_tbl = {}
+        y_cable_tbl = {}
+        static_tbl = {}
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+        static_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "STATIC_TABLE")
+        static_tbl[asic_index].get.return_value = (status, fvs)
+
 
         mux_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], MUX_CABLE_INFO_TABLE)
@@ -1749,33 +1867,39 @@ class TestYCableScript(object):
 
             patched_util.logical.return_value = ['Ethernet0', 'Ethernet4']
             rc = check_identifier_presence_and_update_mux_info_entry(
-                state_db, mux_tbl, asic_index, logical_port_name)
+                state_db, mux_tbl, asic_index, logical_port_name, y_cable_tbl, static_tbl)
+
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
-    def test_get_firmware_dict(self, port_instance):
+    @patch('swsscommon.swsscommon.Table')
+    def test_get_firmware_dict(self, port_instance, mock_swsscommon_table):
 
         port_instance = MagicMock()
         port_instance.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
         port_instance.download_firmware_status = 1
 
+        test_db = "TEST_DB"
         physical_port = 1
         target = "simulated_target"
         side = "a"
         mux_info_dict = {}
         logical_port_name = "Ethernet0"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        mux_tbl = {}
+        asic_index = 0
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        mux_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
 
-            status = True
-            fvs = [('state', "auto"), ('read_side', 1)]
-            Table = MagicMock()
-            Table.get.return_value = (status, fvs)
 
             rc = get_firmware_dict(
-                physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
+                physical_port, port_instance, target, side, mux_info_dict, logical_port_name, mux_tbl)
 
             assert(mux_info_dict['version_a_active'] == None)
             assert(mux_info_dict['version_a_inactive'] == None)
@@ -1793,6 +1917,14 @@ class TestYCableScript(object):
         side = "a"
         mux_info_dict = {}
         logical_port_name = "Ethernet0"
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        mux_tbl = {}
+        asic_index = 0
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        mux_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
@@ -1806,7 +1938,7 @@ class TestYCableScript(object):
                 False, {"read_side": "2"})
 
             rc = get_firmware_dict(
-                physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
+                physical_port, port_instance, target, side, mux_info_dict, logical_port_name, mux_tbl)
 
             assert(mux_info_dict['version_a_active'] == "N/A")
             assert(mux_info_dict['version_a_inactive'] == "N/A")
@@ -1827,6 +1959,14 @@ class TestYCableScript(object):
         side = "a"
         mux_info_dict = {}
         logical_port_name = "Ethernet0"
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        mux_tbl = {}
+        asic_index = 0
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        mux_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
@@ -1838,7 +1978,7 @@ class TestYCableScript(object):
             Table.get.return_value = (status, fvs)
 
             rc = get_firmware_dict(
-                physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
+                physical_port, port_instance, target, side, mux_info_dict, logical_port_name, mux_tbl)
 
             assert(mux_info_dict['version_a_active'] == "N/A")
             assert(mux_info_dict['version_a_inactive'] == "N/A")
@@ -1859,6 +1999,14 @@ class TestYCableScript(object):
         side = "a"
         mux_info_dict = {}
         logical_port_name = "Ethernet0"
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        mux_tbl = {}
+        asic_index = 0
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        mux_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
@@ -1870,7 +2018,7 @@ class TestYCableScript(object):
             Table.get.return_value = (status, fvs)
 
             rc = get_firmware_dict(
-                physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
+                physical_port, port_instance, target, side, mux_info_dict, logical_port_name, mux_tbl)
 
             assert(mux_info_dict['version_a_active'] == "2021")
             assert(mux_info_dict['version_a_inactive'] == "2020")
@@ -1885,6 +2033,15 @@ class TestYCableScript(object):
         swsscommon.Table.return_value.get.return_value = (
             True, {"read_side": "1"})
         platform_sfputil.get_asic_id_for_logical_port = 0
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -1936,7 +2093,7 @@ class TestYCableScript(object):
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
 
-                rc = get_muxcable_info(physical_port, logical_port_name)
+                rc = get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
                 assert(rc['tor_active'] == 'active')
                 assert(rc['mux_direction'] == 'self')
@@ -1951,6 +2108,16 @@ class TestYCableScript(object):
         platform_sfputil.get_asic_id_for_logical_port = 0
         swsscommon.Table.return_value.get.return_value = (
             True, {"read_side": "2"})
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 2)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -2002,7 +2169,7 @@ class TestYCableScript(object):
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
 
-                rc = get_muxcable_info(physical_port, logical_port_name)
+                rc = get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
                 assert(rc['tor_active'] == 'standby')
                 assert(rc['mux_direction'] == 'peer')
@@ -2015,6 +2182,16 @@ class TestYCableScript(object):
 
         logical_port_name = "Ethernet20"
         platform_sfputil.get_asic_id_for_logical_port = 0
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -2066,7 +2243,7 @@ class TestYCableScript(object):
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
 
-                rc = get_muxcable_info(physical_port, logical_port_name)
+                rc = get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
                 assert(rc['tor_active'] == 'unknown')
                 assert(rc['mux_direction'] == 'unknown')
@@ -2081,6 +2258,16 @@ class TestYCableScript(object):
         platform_sfputil.get_asic_id_for_logical_port = 0
         swsscommon.Table.return_value.get.return_value = (
             True, {"read_side": "2"})
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 2)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -2132,7 +2319,7 @@ class TestYCableScript(object):
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
 
-                rc = get_muxcable_info(physical_port, logical_port_name)
+                rc = get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
                 assert(rc['tor_active'] == 'unknown')
                 assert(rc['mux_direction'] == 'unknown')
@@ -2145,6 +2332,16 @@ class TestYCableScript(object):
 
         logical_port_name = "Ethernet20"
         platform_sfputil.get_asic_id_for_logical_port = 0
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -2196,7 +2393,7 @@ class TestYCableScript(object):
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
 
-                rc = get_muxcable_info(physical_port, logical_port_name)
+                rc = get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
                 assert(rc['tor_active'] == 'unknown')
                 assert(rc['mux_direction'] == 'unknown')
@@ -2211,6 +2408,16 @@ class TestYCableScript(object):
         platform_sfputil.get_asic_id_for_logical_port = 0
         swsscommon.Table.return_value.get.return_value = (
             True, {"read_side": "2"})
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 2)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -2261,7 +2468,7 @@ class TestYCableScript(object):
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
 
-                rc = get_muxcable_info(physical_port, logical_port_name)
+                rc = get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
                 assert(rc['tor_active'] == 'unknown')
                 assert(rc['mux_direction'] == 'unknown')
@@ -4030,6 +4237,7 @@ class TestYCableScript(object):
         xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
         xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
         xcvrd_show_fw_res_tbl = mock_swsscommon_table
+        mux_tbl = mock_swsscommon_table
 
         asic_index = 0
         task_download_firmware_thread = {}
@@ -4037,7 +4245,7 @@ class TestYCableScript(object):
         fvp = {"firmware_version": "null"}
 
         rc = handle_show_firmware_show_cmd_arg_tbl_notification(
-            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port, mux_tbl)
         assert(rc == -1)
 
     @patch('swsscommon.swsscommon.Table')
@@ -4056,6 +4264,7 @@ class TestYCableScript(object):
         xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
         xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
         xcvrd_show_fw_res_tbl = mock_swsscommon_table
+        mux_tbl = mock_swsscommon_table
 
         asic_index = 0
         task_download_firmware_thread = {}
@@ -4063,7 +4272,7 @@ class TestYCableScript(object):
         fvp = {"down_firmware": "null"}
 
         rc = handle_show_firmware_show_cmd_arg_tbl_notification(
-            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port, mux_tbl)
         assert(rc == None)
 
     @patch('swsscommon.swsscommon.Table')
@@ -4086,6 +4295,7 @@ class TestYCableScript(object):
         xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
         xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
         xcvrd_show_fw_res_tbl = mock_swsscommon_table
+        mux_tbl = mock_swsscommon_table
         asic_index = 0
         task_download_firmware_thread = {}
         port = "Ethernet0"
@@ -4119,7 +4329,7 @@ class TestYCableScript(object):
 
             patched_util.get.return_value = PortInstanceHelper()
             rc = handle_show_firmware_show_cmd_arg_tbl_notification(
-                fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+                fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port, mux_tbl)
             assert(rc == None)
 
     @patch('swsscommon.swsscommon.Table')
@@ -4138,6 +4348,7 @@ class TestYCableScript(object):
         xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
         xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
         xcvrd_show_fw_res_tbl = mock_swsscommon_table
+        mux_tbl = mock_swsscommon_table
 
         asic_index = 0
         task_download_firmware_thread = {}
@@ -4145,7 +4356,7 @@ class TestYCableScript(object):
         fvp = {"firmware_version": "null"}
 
         rc = handle_show_firmware_show_cmd_arg_tbl_notification(
-            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port, mux_tbl)
         assert(rc == -1)
 
     @patch('swsscommon.swsscommon.Table')

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -1706,7 +1706,7 @@ class TestYCableScript(object):
             test_db[asic_index], "PORT_INFO_TABLE")
         port_tbl[asic_index].get.return_value = (status, fvs)
 
-        rc = init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presence,  state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, port_table_keys, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, stop_event=threading.Event())
+        rc = init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presence,  state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, port_table_keys, hw_mux_cable_tbl, stop_event=threading.Event())
 
         assert(rc == None)
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -1663,7 +1663,6 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_chassis')
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.process_loopback_interface_and_get_read_side',MagicMock(return_value=0))
     def test_init_ports_status_for_y_cable(self, platform_chassis, platform_sfp, mock_swsscommon_table):
 
         platform_sfp = MagicMock()

--- a/sonic-ycabled/tests/test_ycable.py
+++ b/sonic-ycabled/tests/test_ycable.py
@@ -160,8 +160,18 @@ class TestYcableScript(object):
                                                                                                'version_peer_next': '1.7MS'}))
     def test_post_port_mux_info_to_db(self):
         logical_port_name = "Ethernet0"
-        mux_tbl = Table("STATE_DB", y_cable_helper.MUX_CABLE_INFO_TABLE)
-        rc = post_port_mux_info_to_db(logical_port_name, mux_tbl)
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        rc = post_port_mux_info_to_db(logical_port_name, mux_tbl,asic_index, y_cable_tbl)
         assert(rc != -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -317,7 +317,7 @@ class DaemonYcable(daemon_base.DaemonBase):
 
         # Init port y_cable status table
         y_cable_helper.init_ports_status_for_y_cable(
-            platform_sfputil, platform_chassis, self.y_cable_presence, self.table_helper.get_state_db(), self.table_helper.get_port_tbl(), self.table_helper.get_y_cable_tbl(), self.table_helper.get_static_tbl(), self.table_helper.get_mux_tbl(), self.table_helper.port_table_keys,  self.table_helper.loopback_keys , self.table_helper.get_hw_mux_cable_tbl(), self.table_helper.get_hw_mux_cable_tbl_peer(), self.stop_event, is_vs)
+            platform_sfputil, platform_chassis, self.y_cable_presence, self.table_helper.get_state_db(), self.table_helper.get_port_tbl(), self.table_helper.get_y_cable_tbl(), self.table_helper.get_static_tbl(), self.table_helper.get_mux_tbl(), self.table_helper.port_table_keys, self.table_helper.get_hw_mux_cable_tbl(), self.stop_event, is_vs)
 
     # Deinitialize daemon
     def deinit(self):

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -17,6 +17,13 @@ from sonic_y_cable import y_cable_vendor_mapping
 from swsscommon import swsscommon
 
 
+from . import y_cable_table_helper
+
+if sys.version_info.major == 3:
+    UNICODE_TYPE = str
+else:
+    UNICODE_TYPE = unicode
+
 SELECT_TIMEOUT = 1000
 
 y_cable_platform_sfputil = None
@@ -426,13 +433,9 @@ def update_tor_active_side(read_side, state, logical_port_name):
         return (-1, -1)
 
 
-def update_appdb_port_mux_cable_response_table(logical_port_name, asic_index, appl_db, read_side):
+def update_appdb_port_mux_cable_response_table(logical_port_name, asic_index, appl_db, read_side, y_cable_response_tbl):
 
     status = None
-    y_cable_response_tbl = {}
-
-    y_cable_response_tbl[asic_index] = swsscommon.Table(
-        appl_db[asic_index], "MUX_CABLE_RESPONSE_TABLE")
     physical_port_list = logical_port_name_to_physical_port_list(
         logical_port_name)
 
@@ -584,18 +587,6 @@ def read_y_cable_and_update_statedb_port_tbl(logical_port_name, mux_config_tbl):
 
 def create_tables_and_insert_mux_unknown_entries(state_db, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name):
 
-    namespaces = multi_asic.get_front_end_namespaces()
-    for namespace in namespaces:
-        asic_id = multi_asic.get_asic_index_from_namespace(
-            namespace)
-        state_db[asic_id] = daemon_base.db_connect(
-            "STATE_DB", namespace)
-        y_cable_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
-        static_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
-        mux_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], MUX_CABLE_INFO_TABLE)
     # fill the newly found entry
     read_y_cable_and_update_statedb_port_tbl(
         logical_port_name, y_cable_tbl[asic_index])
@@ -619,7 +610,7 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
 
             val = mux_table_dict.get("state", None)
 
-            if val in ["active", "auto", "manual", "standby"]:
+            if val in CONFIG_MUX_STATES:
 
                 # import the module and load the port instance
                 physical_port_list = logical_port_name_to_physical_port_list(
@@ -711,23 +702,12 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
                             else:
                                 # first create the state db y cable table and then fill in the entry
                                 y_cable_presence[:] = [True]
-                                namespaces = multi_asic.get_front_end_namespaces()
-                                for namespace in namespaces:
-                                    asic_id = multi_asic.get_asic_index_from_namespace(
-                                        namespace)
-                                    state_db[asic_id] = daemon_base.db_connect(
-                                        "STATE_DB", namespace)
-                                    y_cable_tbl[asic_id] = swsscommon.Table(
-                                        state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
-                                    static_tbl[asic_id] = swsscommon.Table(
-                                        state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
-                                    mux_tbl[asic_id] = swsscommon.Table(
-                                        state_db[asic_id], MUX_CABLE_INFO_TABLE)
                                 # fill the newly found entry
                                 read_y_cable_and_update_statedb_port_tbl(
                                     logical_port_name, y_cable_tbl[asic_index])
                                 post_port_mux_info_to_db(
                                     logical_port_name, mux_tbl[asic_index])
+                                    logical_port_name,  mux_tbl, asic_index, y_cable_tbl)
                                 post_port_mux_static_info_to_db(
                                     logical_port_name, static_tbl[asic_index])
                         else:
@@ -754,10 +734,7 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
                 "Could not retreive state value inside mux_info_dict for {}, inside MUX_CABLE table".format(logical_port_name))
 
 
-def check_identifier_presence_and_delete_mux_table_entry(state_db, port_tbl, asic_index, logical_port_name, y_cable_presence, delete_change_event):
-
-    y_cable_tbl = {}
-    static_tbl, mux_tbl = {}, {}
+def check_identifier_presence_and_delete_mux_table_entry(state_db, port_tbl, asic_index, logical_port_name, y_cable_presence, delete_change_event, y_cable_tbl, static_tbl, mux_tbl):
 
     # if there is No Y cable do not do anything here
     if y_cable_presence[0] is False:
@@ -775,14 +752,6 @@ def check_identifier_presence_and_delete_mux_table_entry(state_db, port_tbl, asi
         if "state" in mux_table_dict:
             if y_cable_presence[0] is True:
                 # delete this entry in the y cable table found and update the delete event
-                namespaces = multi_asic.get_front_end_namespaces()
-                for namespace in namespaces:
-                    asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-                    state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
-                    y_cable_tbl[asic_id] = swsscommon.Table(state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
-                    static_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
-                    mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
-                # fill the newly found entry
                 #We dont delete the values here, rather just update the values in state DB
                 (status, fvs) = y_cable_tbl[asic_index].get(logical_port_name)
                 if status is False:
@@ -811,7 +780,7 @@ def check_identifier_presence_and_delete_mux_table_entry(state_db, port_tbl, asi
                         "Error: Retreived multiple ports for a Y cable port {} while delete entries".format(logical_port_name))
 
 
-def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presence, stop_event=threading.Event(), is_vs=False):
+def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presence, state_db ,port_tbl, y_cable_tbl, static_tbl, mux_tbl, port_table_keys,  loopback_keys , hw_mux_cable_tbl, hw_mux_cable_tbl_peer, stop_event=threading.Event(), is_vs=False):
     global y_cable_platform_sfputil
     global y_cable_platform_chassis
     global y_cable_port_instances
@@ -826,16 +795,6 @@ def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presen
     y_cable_platform_chassis = platform_chassis
     y_cable_is_platform_vs = is_vs
 
-    fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'notice')])
-    # Get the namespaces in the platform
-    namespaces = multi_asic.get_front_end_namespaces()
-    for namespace in namespaces:
-        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-        config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
-        port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "MUX_CABLE")
-        port_table_keys[asic_id] = port_tbl[asic_id].getKeys()
-        xcvrd_log_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "XCVRD_LOG")
-        xcvrd_log_tbl[asic_id].set("Y_CABLE", fvs_updated)
 
     # Init PORT_STATUS table if ports are on Y cable
     logical_port_list = y_cable_platform_sfputil.logical
@@ -897,14 +856,14 @@ def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, st
             elif value == SFP_STATUS_REMOVED:
                 helper_logger.log_info("Got SFP deleted ycable event")
                 check_identifier_presence_and_delete_mux_table_entry(
-                    state_db, port_tbl, asic_index, logical_port_name, y_cable_presence, delete_change_event)
+                    state_db, port_tbl, asic_index, logical_port_name, y_cable_presence, delete_change_event, y_cable_tbl, static_tbl, mux_tbl)
             else:
                 try:
                     # Now that the value is in bitmap format, let's convert it to number
                     event_bits = int(value)
                     if event_bits in errors_block_eeprom_reading:
                         check_identifier_presence_and_delete_mux_table_entry(
-                            state_db, port_tbl, asic_index, logical_port_name, y_cable_presence, delete_change_event)
+                            state_db, port_tbl, asic_index, logical_port_name, y_cable_presence, delete_change_event, y_cable_tbl, static_tbl, mux_tbl)
                 except (TypeError, ValueError) as e:
                     helper_logger.log_error("Got unrecognized event {}, ignored".format(value))
 
@@ -927,24 +886,10 @@ def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, st
                 break
 
 
-def delete_ports_status_for_y_cable():
+def delete_ports_status_for_y_cable(y_cable_tbl, static_tbl, mux_tbl, port_tbl, grpc_config):
 
-    state_db, config_db, port_tbl, y_cable_tbl = {}, {}, {}, {}
     y_cable_tbl_keys = {}
-    static_tbl, mux_tbl = {}, {}
-    namespaces = multi_asic.get_front_end_namespaces()
-    for namespace in namespaces:
-        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-        config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
-        state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
-        y_cable_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
-        y_cable_tbl_keys[asic_id] = y_cable_tbl[asic_id].getKeys()
-        static_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
-        mux_tbl[asic_id] = swsscommon.Table(
-            state_db[asic_id], MUX_CABLE_INFO_TABLE)
-        port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "MUX_CABLE")
+
 
     # delete PORTS on Y cable table if ports on Y cable
     logical_port_list = y_cable_platform_sfputil.logical
@@ -976,20 +921,13 @@ def delete_ports_status_for_y_cable():
                     "Error: Retreived multiple ports for a Y cable port {} while deleting entries".format(logical_port_name))
 
 
-def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_index, logical_port_name):
+def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_index, logical_port_name, y_cable_tbl, port_tbl):
 
     global disable_telemetry
 
     if disable_telemetry == True:
        return
 
-    # Get the namespaces in the platform
-    config_db, port_tbl = {}, {}
-    namespaces = multi_asic.get_front_end_namespaces()
-    for namespace in namespaces:
-        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-        config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
-        port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "MUX_CABLE")
 
     (status, fvs) = port_tbl[asic_index].get(logical_port_name)
 
@@ -1002,11 +940,11 @@ def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_
         mux_table_dict = dict(fvs)
         if "state" in mux_table_dict:
             val = mux_table_dict.get("state", None)
-            if val in ["active", "auto", "manual", "standby"]:
+            if val in CONFIG_MUX_STATES:
 
                 if mux_tbl.get(asic_index, None) is not None:
                     # fill in the newly found entry
-                    post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
+                    post_port_mux_info_to_db(logical_port_name,  mux_tbl, asic_index, y_cable_tbl)
 
                 else:
                     # first create the state db y cable table and then fill in the entry
@@ -1015,27 +953,19 @@ def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_
                         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
                         mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
                     # fill the newly found entry
-                    post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
+                    post_port_mux_info_to_db(logical_port_name,  mux_tbl, asic_index, y_cable_tbl)
             else:
                 helper_logger.log_warning(
                     "Could not retreive active or auto value for state kvp for {}, inside MUX_CABLE table".format(logical_port_name))
 
 
-def get_firmware_dict(physical_port, port_instance, target, side, mux_info_dict, logical_port_name):
+def get_firmware_dict(physical_port, port_instance, target, side, mux_info_dict, logical_port_name, mux_tbl):
 
     result = {}
     if port_instance.download_firmware_status == port_instance.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS:
 
         # if there is a firmware download in progress, retreive the last known firmware
-        state_db, mux_tbl = {}, {}
         mux_firmware_dict = {}
-
-        namespaces = multi_asic.get_front_end_namespaces()
-        for namespace in namespaces:
-            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-            state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
-            mux_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], MUX_CABLE_INFO_TABLE)
 
         asic_index = y_cable_platform_sfputil.get_asic_id_for_logical_port(
             logical_port_name)
@@ -1150,10 +1080,9 @@ def get_muxcable_info_without_presence():
 
     return mux_info_dict
 
-def get_muxcable_info(physical_port, logical_port_name):
+def get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl):
 
     mux_info_dict = {}
-    y_cable_tbl, state_db = {}, {}
 
     port_instance = y_cable_port_instances.get(physical_port)
     if port_instance is None:
@@ -1163,14 +1092,7 @@ def get_muxcable_info(physical_port, logical_port_name):
     if port_instance.download_firmware_status == port_instance.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS:
         helper_logger.log_warning("Warning: posting mux cable info while a download firmware in progress {}".format(logical_port_name))
 
-    namespaces = multi_asic.get_front_end_namespaces()
-    for namespace in namespaces:
-        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-        state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
-        y_cable_tbl[asic_id] = swsscommon.Table(state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
 
-    asic_index = y_cable_platform_sfputil.get_asic_id_for_logical_port(
-        logical_port_name)
     if asic_index is None:
         helper_logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
         return -1
@@ -1348,13 +1270,13 @@ def get_muxcable_info(physical_port, logical_port_name):
         else:
             mux_info_dict["link_status_nic"] = "down"
 
-    get_firmware_dict(physical_port, port_instance, port_instance.TARGET_NIC, "nic", mux_info_dict, logical_port_name)
+    get_firmware_dict(physical_port, port_instance, port_instance.TARGET_NIC, "nic", mux_info_dict, logical_port_name, mux_tbl)
     if read_side == 1:
-        get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_A, "self", mux_info_dict, logical_port_name)
-        get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_B, "peer", mux_info_dict, logical_port_name)
+        get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_A, "self", mux_info_dict, logical_port_name, mux_tbl)
+        get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_B, "peer", mux_info_dict, logical_port_name, mux_tbl)
     else:
-        get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_A, "peer", mux_info_dict, logical_port_name)
-        get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_B, "self", mux_info_dict, logical_port_name)
+        get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_A, "peer", mux_info_dict, logical_port_name, mux_tbl)
+        get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_B, "self", mux_info_dict, logical_port_name, mux_tbl)
 
     with y_cable_port_locks[physical_port]:
         try:
@@ -1521,7 +1443,7 @@ def get_muxcable_static_info(physical_port, logical_port_name):
     return mux_static_info_dict
 
 
-def post_port_mux_info_to_db(logical_port_name, table):
+def post_port_mux_info_to_db(logical_port_name, mux_tbl, asic_index, y_cable_tbl):
 
     physical_port_list = logical_port_name_to_physical_port_list(logical_port_name)
     if physical_port_list is None:
@@ -1538,7 +1460,7 @@ def post_port_mux_info_to_db(logical_port_name, table):
             helper_logger.log_warning("Error: trying to post mux info without presence of port {}".format(logical_port_name))
             mux_info_dict = get_muxcable_info_without_presence()
         else:
-            mux_info_dict = get_muxcable_info(physical_port, logical_port_name)
+            mux_info_dict = get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
         if mux_info_dict is not None and mux_info_dict != -1:
             #transceiver_dict[physical_port] = port_info_dict
@@ -1571,7 +1493,7 @@ def post_port_mux_info_to_db(logical_port_name, table):
                  ('version_nic_inactive', str(mux_info_dict["version_nic_inactive"])),
                  ('version_nic_next', str(mux_info_dict["version_nic_next"]))
                  ])
-            table.set(logical_port_name, fvs)
+            mux_tbl[asic_index].set(logical_port_name, fvs)
         else:
             return -1
 
@@ -2257,7 +2179,7 @@ def handle_config_mux_switchmode_arg_tbl_notification(fvp, xcvrd_config_hwmode_s
             helper_logger.log_error("Error: Incorrect input param for cli cmd config mux hwmode setswitchmode logical port {}".format(port))
             set_result_and_delete_port('result', 'False', xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
 
-def handle_show_firmware_show_cmd_arg_tbl_notification(fvp, xcvrd_show_fw_cmd_sts_tbl, xcvrd_show_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port):
+def handle_show_firmware_show_cmd_arg_tbl_notification(fvp, xcvrd_show_fw_cmd_sts_tbl, xcvrd_show_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port, mux_tbl):
         fvp_dict = dict(fvp)
 
         mux_info_dict = {}
@@ -2306,13 +2228,13 @@ def handle_show_firmware_show_cmd_arg_tbl_notification(fvp, xcvrd_show_fw_cmd_st
                 return -1
 
 
-            get_firmware_dict(physical_port, port_instance, port_instance.TARGET_NIC, "nic", mux_info_dict, port)
+            get_firmware_dict(physical_port, port_instance, port_instance.TARGET_NIC, "nic", mux_info_dict, port, mux_tbl)
             if read_side == port_instance.TARGET_TOR_A:
-                get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_A, "self", mux_info_dict, port)
-                get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_B, "peer", mux_info_dict, port)
+                get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_A, "self", mux_info_dict, port, mux_tbl)
+                get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_B, "peer", mux_info_dict, port, mux_tbl)
             else:
-                get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_A, "peer", mux_info_dict, port)
-                get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_B, "self", mux_info_dict, port)
+                get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_A, "peer", mux_info_dict, port, mux_tbl)
+                get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_B, "self", mux_info_dict, port, mux_tbl)
 
             status = 'True'
             set_show_firmware_fields(port, mux_info_dict, xcvrd_show_fw_res_tbl[asic_index])
@@ -2580,10 +2502,6 @@ def handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, xcvrd_show_hwmode_dir
             set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
             return -1
 
-        set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
-    else:
-        helper_logger.log_warning("Error: Wrong input param for cli command show mux hwmode muxdirection logical port {}".format(port))
-        set_result_and_delete_port('state', 'unknown', xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
 
 def handle_ycable_enable_disable_tel_notification(fvp_m, key):
 
@@ -2622,42 +2540,25 @@ class YCableTableUpdateTask(object):
         self.task_cli_thread = None
         self.task_download_firmware_thread = {}
         self.task_stopping_event = threading.Event()
+        self.hw_mux_cable_tbl_keys = {}
 
-        if multi_asic.is_multi_asic():
-            # Load the namespace details first from the database_global.json file.
-            swsscommon.SonicDBConfig.initializeGlobalConfig()
-
+        self.table_helper =  y_cable_table_helper.YcableTableUpdateTableHelper()
+        self.cli_table_helper =  y_cable_table_helper.YcableCliUpdateTableHelper()
+       
     def task_worker(self):
 
         # Connect to STATE_DB and APPL_DB and get both the HW_MUX_STATUS_TABLE info
-        appl_db, state_db, config_db, status_tbl, y_cable_tbl = {}, {}, {}, {}, {}
-        y_cable_tbl_keys = {}
-        mux_cable_command_tbl, y_cable_command_tbl = {}, {}
-        mux_metrics_tbl = {}
-
-        sel = swsscommon.Select()
 
         # Get the namespaces in the platform
         namespaces = multi_asic.get_front_end_namespaces()
         for namespace in namespaces:
             # Open a handle to the Application database, in all namespaces
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-            appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
-            config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
-            status_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], swsscommon.APP_HW_MUX_CABLE_TABLE_NAME)
-            mux_cable_command_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], swsscommon.APP_MUX_CABLE_COMMAND_TABLE_NAME)
-            y_cable_command_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], swsscommon.APP_MUX_CABLE_COMMAND_TABLE_NAME)
-            state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
-            y_cable_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
-            mux_metrics_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], swsscommon.STATE_MUX_METRICS_TABLE_NAME)
-            y_cable_tbl_keys[asic_id] = y_cable_tbl[asic_id].getKeys()
-            sel.addSelectable(status_tbl[asic_id])
-            sel.addSelectable(mux_cable_command_tbl[asic_id])
+            self.hw_mux_cable_tbl_keys[asic_id] = self.table_helper.get_hw_mux_cable_tbl()[asic_id].getKeys()
+            sel.addSelectable(self.table_helper.get_status_tbl()[asic_id])
+            sel.addSelectable(self.table_helper.get_status_tbl_peer()[asic_id])
+            sel.addSelectable(self.table_helper.get_fwd_state_command_tbl()[asic_id])
+            sel.addSelectable(self.table_helper.get_mux_cable_command_tbl()[asic_id])
 
 
         # Listen indefinitely for changes to the HW_MUX_CABLE_TABLE in the Application DB's
@@ -2686,7 +2587,7 @@ class YCableTableUpdateTask(object):
             asic_index = multi_asic.get_asic_index_from_namespace(namespace)
 
             while True:
-                (port, op, fvp) = status_tbl[asic_index].pop()
+                (port, op, fvp) = self.table_helper.get_status_tbl()[asic_index].pop()
                 if not port:
                     break
 
@@ -2699,48 +2600,52 @@ class YCableTableUpdateTask(object):
                     # This check might be redundant, to check, the presence of this Port in keys
                     # in logical_port_list but keep for now for coherency
                     # also skip checking in logical_port_list inside sfp_util
-                    if port not in y_cable_tbl_keys[asic_index]:
+                    if port not in self.hw_mux_cable_tbl_keys[asic_index]:
                         continue
 
-                    fvp_dict = dict(fvp)
+                    (status, cable_type) = check_mux_cable_port_type(port, self.table_helper.get_port_tbl(), asic_index)
 
-                    if "state" in fvp_dict:
-                        # got a state change
-                        new_status = fvp_dict["state"]
-                        requested_status = new_status
-                        (status, fvs) = y_cable_tbl[asic_index].get(port)
-                        if status is False:
-                            helper_logger.log_warning("Could not retreive fieldvalue pairs for {}, inside state_db table {}".format(
-                                port, y_cable_tbl[asic_index].getTableName()))
-                            continue
-                        mux_port_dict = dict(fvs)
-                        old_status = mux_port_dict.get("state", None)
-                        read_side = mux_port_dict.get("read_side", None)
-                        # Now whatever is the state requested, toggle the mux appropriately
-                        helper_logger.log_debug("Y_CABLE_DEBUG: xcvrd trying to transition port {} from {} to {} read side {}".format(port, old_status, new_status, read_side))
-                        (active_side, read_side) = update_tor_active_side(read_side, new_status, port)
-                        if active_side == -1:
-                            helper_logger.log_warning("ERR: Got a change event for toggle but could not toggle the mux-direction for port {} state from {} to {}, writing unknown".format(
-                                port, old_status, new_status))
-                            new_status = 'unknown'
+                    if status:
 
-                        helper_logger.log_debug("Y_CABLE_DEBUG: xcvrd successful to transition port {} from {} to {} and write back to the DB {}".format(port, old_status, new_status, threading.currentThread().getName()))
-                        helper_logger.log_notice("Got a change event for toggle the mux-direction active side for port {} state requested {} from old state {} to new state {} read_side  {} thread id {}".format(port, requested_status, old_status, new_status, read_side, threading.currentThread().getName()))
-                        time_end = datetime.datetime.utcnow().strftime("%Y-%b-%d %H:%M:%S.%f")
-                        fvs_metrics = swsscommon.FieldValuePairs([('xcvrd_switch_{}_start'.format(new_status), str(time_start)),
-                                                                  ('xcvrd_switch_{}_end'.format(new_status), str(time_end))])
-                        mux_metrics_tbl[asic_index].set(port, fvs_metrics)
+                        fvp_dict = dict(fvp)
 
-                        fvs_updated = swsscommon.FieldValuePairs([('state', new_status),
-                                                                  ('read_side', str(read_side)),
-                                                                  ('active_side', str(active_side))])
-                        y_cable_tbl[asic_index].set(port, fvs_updated)
-                    else:
-                        helper_logger.log_info("Got a change event on port {} of table {} that does not contain state".format(
-                            port, swsscommon.APP_HW_MUX_CABLE_TABLE_NAME))
+                        if "state" in fvp_dict:
+                            # got a state change
+                            new_status = fvp_dict["state"]
+                            requested_status = new_status
+                            (status, fvs) = self.table_helper.get_hw_mux_cable_tbl()[asic_index].get(port)
+                            if status is False:
+                                helper_logger.log_warning("Could not retreive fieldvalue pairs for {}, inside state_db table {}".format(
+                                    port, self.table_helper.get_hw_mux_cable_tbl()[asic_index].getTableName()))
+                                continue
+                            mux_port_dict = dict(fvs)
+                            old_status = mux_port_dict.get("state", None)
+                            read_side = mux_port_dict.get("read_side", None)
+                            # Now whatever is the state requested, toggle the mux appropriately
+                            helper_logger.log_debug("Y_CABLE_DEBUG: xcvrd trying to transition port {} from {} to {} read side {}".format(port, old_status, new_status, read_side))
+                            (active_side, read_side) = update_tor_active_side(read_side, new_status, port)
+                            if active_side == -1:
+                                helper_logger.log_warning("ERR: Got a change event for toggle but could not toggle the mux-direction for port {} state from {} to {}, writing unknown".format(
+                                    port, old_status, new_status))
+                                new_status = 'unknown'
+
+                            helper_logger.log_debug("Y_CABLE_DEBUG: xcvrd successful to transition port {} from {} to {} and write back to the DB {}".format(port, old_status, new_status, threading.currentThread().getName()))
+                            helper_logger.log_notice("Got a change event for toggle the mux-direction active side for port {} state requested {} from old state {} to new state {} read_side  {} thread id {}".format(port, requested_status, old_status, new_status, read_side, threading.currentThread().getName()))
+                            time_end = datetime.datetime.utcnow().strftime("%Y-%b-%d %H:%M:%S.%f")
+                            fvs_metrics = swsscommon.FieldValuePairs([('xcvrd_switch_{}_start'.format(new_status), str(time_start)),
+                                                                      ('xcvrd_switch_{}_end'.format(new_status), str(time_end))])
+                            self.table_helper.get_mux_metrics_tbl()[asic_index].set(port, fvs_metrics)
+
+                            fvs_updated = swsscommon.FieldValuePairs([('state', new_status),
+                                                                      ('read_side', str(read_side)),
+                                                                      ('active_side', str(active_side))])
+                            self.table_helper.get_hw_mux_cable_tbl()[asic_index].set(port, fvs_updated)
+                        else:
+                            helper_logger.log_info("Got a change event on port {} of table {} that does not contain state".format(
+                                port, swsscommon.APP_HW_MUX_CABLE_TABLE_NAME))
 
             while True:
-                (port_m, op_m, fvp_m) = mux_cable_command_tbl[asic_index].pop()
+                (port_m, op_m, fvp_m) = self.table_helper.get_mux_cable_command_tbl()[asic_index].pop()
 
                 if not port_m:
                     break
@@ -2765,29 +2670,12 @@ class YCableTableUpdateTask(object):
                                 continue
                             mux_port_dict = dict(fv)
                             read_side = mux_port_dict.get("read_side")
-                            update_appdb_port_mux_cable_response_table(port_m, asic_index, appl_db, int(read_side))
 
+                            update_appdb_port_mux_cable_response_table(port_m, asic_index, self.appl_db, int(read_side), self.table_helper.get_y_cable_response_tbl())
 
 
     def task_cli_worker(self):
 
-        # Connect to STATE_DB and APPL_DB and get both the HW_MUX_STATUS_TABLE info
-        appl_db, config_db , state_db, y_cable_tbl = {}, {}, {}, {}
-        xcvrd_log_tbl = {}
-        xcvrd_down_fw_cmd_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_down_fw_cmd_sts_tbl = {}, {}, {}
-        xcvrd_down_fw_status_cmd_tbl, xcvrd_down_fw_status_rsp_tbl, xcvrd_down_fw_status_cmd_sts_tbl = {}, {}, {}
-        xcvrd_acti_fw_cmd_tbl, xcvrd_acti_fw_cmd_arg_tbl, xcvrd_acti_fw_rsp_tbl, xcvrd_acti_fw_cmd_sts_tbl = {}, {}, {}, {}
-        xcvrd_roll_fw_cmd_tbl, xcvrd_roll_fw_rsp_tbl, xcvrd_roll_fw_cmd_sts_tbl = {}, {}, {}
-        xcvrd_show_fw_cmd_tbl, xcvrd_show_fw_rsp_tbl, xcvrd_show_fw_cmd_sts_tbl, xcvrd_show_fw_res_tbl = {}, {}, {}, {}
-        xcvrd_show_hwmode_dir_cmd_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl = {}, {}, {}, {}
-        xcvrd_show_hwmode_swmode_cmd_tbl, xcvrd_show_hwmode_swmode_rsp_tbl, xcvrd_show_hwmode_swmode_cmd_sts_tbl = {}, {}, {}
-        xcvrd_config_hwmode_state_cmd_tbl, xcvrd_config_hwmode_state_rsp_tbl , xcvrd_config_hwmode_state_cmd_sts_tbl= {}, {}, {}
-        xcvrd_config_hwmode_swmode_cmd_tbl, xcvrd_config_hwmode_swmode_rsp_tbl , xcvrd_config_hwmode_swmode_cmd_sts_tbl= {}, {}, {}
-        xcvrd_config_prbs_cmd_tbl, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_rsp_tbl , xcvrd_config_prbs_cmd_sts_tbl= {}, {}, {}, {}
-        xcvrd_config_loop_cmd_tbl, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_rsp_tbl , xcvrd_config_loop_cmd_sts_tbl= {}, {}, {}, {}
-        xcvrd_show_event_cmd_tbl, xcvrd_show_event_rsp_tbl , xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_res_tbl= {}, {}, {}, {}
-        xcvrd_show_fec_cmd_tbl, xcvrd_show_fec_rsp_tbl , xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl= {}, {}, {}, {}
-        xcvrd_show_ber_cmd_tbl, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl , xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl= {}, {}, {}, {}, {}
 
         sel = swsscommon.Select()
 
@@ -2797,126 +2685,21 @@ class YCableTableUpdateTask(object):
         for namespace in namespaces:
             # Open a handle to the Application database, in all namespaces
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-            appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
-            config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
-            state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
-            xcvrd_log_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                config_db[asic_id], "XCVRD_LOG")
-            xcvrd_show_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_SHOW_FW_CMD")
-            xcvrd_show_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_SHOW_FW_CMD")
-            xcvrd_show_fw_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_SHOW_FW_RSP")
-            xcvrd_show_fw_res_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_SHOW_FW_RES")
-            xcvrd_down_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_DOWN_FW_CMD")
-            xcvrd_down_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_DOWN_FW_CMD")
-            xcvrd_down_fw_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_DOWN_FW_RSP")
-            xcvrd_down_fw_status_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_DOWN_FW_STATUS_CMD")
-            xcvrd_down_fw_status_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_DOWN_FW_STATUS_RSP")
-            xcvrd_acti_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_ACTI_FW_CMD")
-            xcvrd_acti_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_ACTI_FW_CMD")
-            xcvrd_acti_fw_cmd_arg_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_ACTI_FW_CMD_ARG")
-            xcvrd_acti_fw_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_ACTI_FW_RSP")
-            xcvrd_roll_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_ROLL_FW_CMD")
-            xcvrd_roll_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_ROLL_FW_CMD")
-            xcvrd_roll_fw_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_ROLL_FW_RSP")
-            xcvrd_show_hwmode_dir_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_CMD")
-            xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_CMD")
-            xcvrd_show_hwmode_dir_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_RSP")
-            xcvrd_show_hwmode_dir_res_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_RES")
-            xcvrd_config_hwmode_state_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_CMD")
-            xcvrd_config_hwmode_state_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_CMD")
-            xcvrd_config_hwmode_state_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_RSP")
-            xcvrd_config_hwmode_swmode_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_CMD")
-            xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_CMD")
-            xcvrd_config_hwmode_swmode_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_RSP")
-            xcvrd_show_hwmode_swmode_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_CMD")
-            xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_CMD")
-            xcvrd_show_hwmode_swmode_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_RSP")
-            xcvrd_config_prbs_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD")
-            xcvrd_config_prbs_cmd_arg_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD_ARG")
-            xcvrd_config_prbs_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD")
-            xcvrd_config_prbs_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_CONFIG_PRBS_RSP")
-            xcvrd_config_loop_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD")
-            xcvrd_config_loop_cmd_arg_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD_ARG")
-            xcvrd_config_loop_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD")
-            xcvrd_config_loop_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_CONFIG_LOOP_RSP")
-            xcvrd_show_event_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_EVENT_LOG_CMD")
-            xcvrd_show_event_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_EVENT_LOG_CMD")
-            xcvrd_show_event_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_EVENT_LOG_RSP")
-            xcvrd_show_event_res_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_EVENT_LOG_RES")
-            xcvrd_show_fec_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_GET_FEC_CMD")
-            xcvrd_show_fec_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_GET_FEC_CMD")
-            xcvrd_show_fec_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_GET_FEC_RSP")
-            xcvrd_show_fec_res_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_GET_FEC_RES")
-            xcvrd_show_ber_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], "XCVRD_GET_BER_CMD")
-            xcvrd_show_ber_cmd_arg_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_GET_BER_CMD_ARG")
-            xcvrd_show_ber_cmd_sts_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], "XCVRD_GET_BER_CMD")
-            xcvrd_show_ber_rsp_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_GET_BER_RSP")
-            xcvrd_show_ber_res_tbl[asic_id] = swsscommon.Table(
-                state_db[asic_id], "XCVRD_GET_BER_RES")
-            sel.addSelectable(xcvrd_log_tbl[asic_id])
-            sel.addSelectable(xcvrd_down_fw_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_down_fw_status_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_acti_fw_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_roll_fw_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_show_fw_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_show_hwmode_dir_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_config_hwmode_state_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_show_hwmode_swmode_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_config_hwmode_swmode_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_config_prbs_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_config_loop_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_show_event_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_show_fec_cmd_tbl[asic_id])
-            sel.addSelectable(xcvrd_show_ber_cmd_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_log_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_down_fw_cmd_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_down_fw_status_cmd_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_acti_fw_cmd_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_roll_fw_cmd_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_show_fw_cmd_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_show_hwmode_dir_cmd_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_config_hwmode_state_cmd_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_show_hwmode_swmode_cmd_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_config_hwmode_swmode_cmd_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_config_prbs_cmd_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_config_loop_cmd_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_show_event_cmd_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_show_fec_cmd_tbl[asic_id])
+            sel.addSelectable(self.cli_table_helper.xcvrd_show_ber_cmd_tbl[asic_id])
 
         # Listen indefinitely for changes to the XCVRD_CMD_TABLE in the Application DB's
         while True:
@@ -2944,7 +2727,7 @@ class YCableTableUpdateTask(object):
             asic_index = multi_asic.get_asic_index_from_namespace(namespace)
 
             while True:
-                (key, op_m, fvp_m) = xcvrd_log_tbl[asic_index].pop()
+                (key, op_m, fvp_m) = self.cli_table_helper.xcvrd_log_tbl[asic_index].pop()
 
                 if not key:
                     break
@@ -2956,140 +2739,139 @@ class YCableTableUpdateTask(object):
 
             while True:
                 # show muxcable hwmode state <port>
-                (port, op, fvp) = xcvrd_show_hwmode_dir_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.cli_table_helper.xcvrd_show_hwmode_dir_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+                    handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, self.cli_table_helper.port_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_rsp_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
                     break
-
             while True:
                 # Config muxcable hwmode state <active/standby> <port>
-                (port, op, fvp) = xcvrd_config_hwmode_state_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.cli_table_helper.xcvrd_config_hwmode_state_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_config_hwmode_state_cmd_arg_tbl_notification(fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
+                    handle_config_hwmode_state_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_config_hwmode_state_cmd_sts_tbl,  self.cli_table_helper.xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
                     break
 
 
             while True:
                 # Config muxcable hwmode setswitchmode <auto/manual> <port>
-                (port, op, fvp) = xcvrd_show_hwmode_swmode_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.cli_table_helper.xcvrd_show_hwmode_swmode_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_show_hwmode_swmode_cmd_arg_tbl_notification(fvp, xcvrd_show_hwmode_swmode_cmd_sts_tbl, xcvrd_show_hwmode_swmode_rsp_tbl, asic_index, port)
+                    handle_show_hwmode_swmode_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_show_hwmode_swmode_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_hwmode_swmode_rsp_tbl, asic_index, port)
                     break
 
             while True:
                 # Config muxcable hwmode setswitchmode <auto/manual> <port>
-                (port, op, fvp) = xcvrd_config_hwmode_swmode_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.cli_table_helper.xcvrd_config_hwmode_swmode_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                   handle_config_mux_switchmode_arg_tbl_notification(fvp, xcvrd_config_hwmode_swmode_cmd_sts_tbl, xcvrd_config_hwmode_swmode_rsp_tbl, asic_index, port)
+                   handle_config_mux_switchmode_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_config_hwmode_swmode_cmd_sts_tbl, self.cli_table_helper.xcvrd_config_hwmode_swmode_rsp_tbl, asic_index, port)
                    break
 
             while True:
-                (port, op, fvp) = xcvrd_down_fw_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.cli_table_helper.xcvrd_down_fw_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_config_firmware_down_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, self.task_download_firmware_thread)
+                    handle_config_firmware_down_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_down_fw_cmd_sts_tbl, self.cli_table_helper.xcvrd_down_fw_rsp_tbl, asic_index, port, self.task_download_firmware_thread)
                     break
 
             while True:
-                (port, op, fvp) = xcvrd_show_fw_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.cli_table_helper.xcvrd_show_fw_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_show_firmware_show_cmd_arg_tbl_notification(fvp, xcvrd_show_fw_cmd_sts_tbl, xcvrd_show_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+                    handle_show_firmware_show_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_show_fw_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_fw_rsp_tbl, self.cli_table_helper.xcvrd_show_fw_res_tbl, asic_index, port, self.cli_table_helper.mux_tbl)
                     break
 
             while True:
-                (port, op, fvp) = xcvrd_acti_fw_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.cli_table_helper.xcvrd_acti_fw_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_config_firmware_acti_cmd_arg_tbl_notification(fvp, xcvrd_acti_fw_cmd_sts_tbl, xcvrd_acti_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
+                    handle_config_firmware_acti_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_acti_fw_cmd_sts_tbl, self.cli_table_helper.xcvrd_acti_fw_rsp_tbl, self.cli_table_helper.xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
                     break
 
 
             while True:
-                (port, op, fvp) = xcvrd_roll_fw_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.cli_table_helper.xcvrd_roll_fw_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_config_firmware_roll_cmd_arg_tbl_notification(fvp, xcvrd_roll_fw_cmd_sts_tbl, xcvrd_roll_fw_rsp_tbl, asic_index, port)
+                    handle_config_firmware_roll_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_roll_fw_cmd_sts_tbl, self.cli_table_helper.xcvrd_roll_fw_rsp_tbl, asic_index, port)
                     break
 
             while True:
-                (port, op, fvp) = xcvrd_config_prbs_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.cli_table_helper.xcvrd_config_prbs_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+                    handle_config_prbs_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_config_prbs_cmd_arg_tbl, self.cli_table_helper.xcvrd_config_prbs_cmd_sts_tbl, self.cli_table_helper.xcvrd_config_prbs_rsp_tbl, asic_index, port)
                     break
 
             while True:
-                (port, op, fvp) = xcvrd_config_loop_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.cli_table_helper.xcvrd_config_loop_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_config_loop_cmd_arg_tbl_notification(fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
+                    handle_config_loop_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_config_loop_cmd_arg_tbl, self.cli_table_helper.xcvrd_config_loop_cmd_sts_tbl, self.cli_table_helper.xcvrd_config_loop_rsp_tbl, asic_index, port)
                     break
 
             while True:
-                (port, op, fvp) = xcvrd_show_event_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.cli_table_helper.xcvrd_show_event_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
 
-                    handle_show_event_cmd_arg_tbl_notification(fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
+                    handle_show_event_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_show_event_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_event_rsp_tbl, self.cli_table_helper.xcvrd_show_event_res_tbl, asic_index, port)
                     break
 
             while True:
-                (port, op, fvp) = xcvrd_show_fec_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.cli_table_helper.xcvrd_show_fec_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
 
-                    handle_get_fec_cmd_arg_tbl_notification(fvp,xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
+                    handle_get_fec_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_show_fec_rsp_tbl, self.cli_table_helper.xcvrd_show_fec_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_fec_res_tbl, asic_index, port)
                     break
 
             while True:
-                (port, op, fvp) = xcvrd_show_ber_cmd_tbl[asic_index].pop()
+                (port, op, fvp) = self.cli_table_helper.xcvrd_show_ber_cmd_tbl[asic_index].pop()
 
                 if not port:
                     break
 
                 if fvp:
-                    handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+                    handle_show_ber_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_show_ber_cmd_arg_tbl, self.cli_table_helper.xcvrd_show_ber_rsp_tbl, self.cli_table_helper.xcvrd_show_ber_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_ber_res_tbl, asic_index, port)
 
                     break
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -2748,7 +2748,7 @@ class YCableTableUpdateTask(object):
                     break
 
                 if fvp:
-                    handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, self.cli_table_helper.port_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_rsp_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+                    handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_show_hwmode_dir_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_rsp_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
                     break
             while True:
                 # Config muxcable hwmode state <active/standby> <port>

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
@@ -1,0 +1,391 @@
+"""
+    y_cable_table_helper.py
+    helper utlities configuring y_cable tables for ycabled daemon
+"""
+
+
+from sonic_py_common import daemon_base
+from sonic_py_common import multi_asic
+from swsscommon import swsscommon
+
+MUX_CABLE_STATIC_INFO_TABLE = "MUX_CABLE_STATIC_INFO"
+MUX_CABLE_INFO_TABLE = "MUX_CABLE_INFO"
+TRANSCEIVER_STATUS_TABLE = 'TRANSCEIVER_STATUS'
+
+class YcableInfoUpdateTableHelper(object):
+    def __init__(self):
+
+        self.state_db = {}
+        self.config_db = {}
+        self.port_tbl = {}
+        self.status_tbl = {}
+        self.y_cable_tbl = {} 
+        self.mux_tbl = {}
+
+        # Get the namespaces in the platform
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
+            self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
+            self.status_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
+            self.y_cable_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            self.mux_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], MUX_CABLE_INFO_TABLE)
+
+    def get_state_db(self):
+        return self.state_db
+
+    def get_config_db(self):
+        return self.config_db
+
+    def get_port_tbl(self):
+        return self.port_tbl
+
+    def get_status_tbl(self):
+        return self.status_tbl
+
+    def get_y_cable_tbl(self):
+        return self.y_cable_tbl
+
+    def get_mux_tbl(self):
+        return self.mux_tbl
+
+
+class YcableStateUpdateTableHelper(object):
+    def __init__(self):
+
+        self.state_db = {}
+        self.sub_status_tbl = {}
+
+        # Get the namespaces in the platform
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.sub_status_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
+
+
+
+    def get_sub_status_tbl(self):
+        return self.sub_status_tbl
+
+
+
+class DaemonYcableTableHelper(object):
+    def __init__(self):
+
+        self.state_db = {}
+        self.config_db = {}
+        self.port_tbl = {}
+        self.y_cable_tbl = {} 
+        self.metadata_tbl = {}
+        self.static_tbl, self.mux_tbl = {}, {}
+        self.port_table_keys = {}
+        self.xcvrd_log_tbl = {}
+        self.loopback_tbl= {}
+        self.loopback_keys = {}
+        self.hw_mux_cable_tbl = {}
+        self.hw_mux_cable_tbl_peer = {}
+        self.grpc_config_tbl = {}
+
+        # Get the namespaces in the platform
+        fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'notice')])
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
+            self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
+            self.y_cable_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            self.mux_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], MUX_CABLE_INFO_TABLE)
+            self.metadata_tbl[asic_id] = swsscommon.Table(
+                self.config_db[asic_id], "DEVICE_METADATA")
+            self.port_table_keys[asic_id] = self.port_tbl[asic_id].getKeys()
+            self.xcvrd_log_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "XCVRD_LOG")
+            self.xcvrd_log_tbl[asic_id].set("Y_CABLE", fvs_updated)
+            self.loopback_tbl[asic_id] = swsscommon.Table(
+                self.config_db[asic_id], "LOOPBACK_INTERFACE")
+            self.loopback_keys[asic_id] = self.loopback_tbl[asic_id].getKeys()
+            self.hw_mux_cable_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            self.hw_mux_cable_tbl_peer[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
+            self.static_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
+            self.grpc_config_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "GRPCCLIENT")
+
+
+    def get_state_db(self):
+        return self.state_db
+
+    def get_config_db(self):
+        return self.config_db
+
+    def get_port_tbl(self):
+        return self.port_tbl
+
+    def get_y_cable_tbl(self):
+        return self.y_cable_tbl
+
+    def get_mux_tbl(self):
+        return self.mux_tbl
+
+    def get_metadata_tbl(self):
+        return self.metadata_tbl
+
+    def get_xcvrd_log_tbl(self):
+        return self.xcvrd_log_tbl
+
+    def get_loopback_tbl(self):
+        return self.loopback_tbl
+
+    def get_hw_mux_cable_tbl(self):
+        return self.hw_mux_cable_tbl
+
+    def get_hw_mux_cable_tbl_peer(self):
+        return self.hw_mux_cable_tbl_peer
+
+    def get_static_tbl(self):
+        return self.static_tbl
+
+    def get_grpc_config_tbl(self):
+        return self.grpc_config_tbl
+
+
+class YcableTableUpdateTableHelper(object):
+    def __init__(self):
+
+        self.appl_db, self.state_db, self.config_db, self.status_tbl, self.status_tbl_peer = {}, {}, {}, {}, {}
+        self.hw_mux_cable_tbl, self.hw_mux_cable_tbl_peer = {}, {}
+        self.hw_mux_cable_tbl_keys = {}
+        self.port_tbl, self.port_table_keys = {}, {}
+        self.fwd_state_command_tbl, self.fwd_state_response_tbl, self.mux_cable_command_tbl = {}, {}, {}
+        self.mux_metrics_tbl = {}
+        self.y_cable_response_tbl = {}
+
+
+        if multi_asic.is_multi_asic():
+            # Load the namespace details first from the database_global.json file.
+            swsscommon.SonicDBConfig.initializeGlobalConfig()
+
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            # Open a handle to the Application database, in all namespaces
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
+            self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.status_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], swsscommon.APP_HW_MUX_CABLE_TABLE_NAME)
+            self.mux_cable_command_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], swsscommon.APP_MUX_CABLE_COMMAND_TABLE_NAME)
+            self.mux_metrics_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_MUX_METRICS_TABLE_NAME)
+            self.hw_mux_cable_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            # TODO add definition inside app DB
+            self.status_tbl_peer[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "HW_FORWARDING_STATE_PEER")
+            self.fwd_state_command_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "FORWARDING_STATE_COMMAND")
+            self.fwd_state_response_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "FORWARDING_STATE_RESPONSE")
+            self.hw_mux_cable_tbl_peer[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
+            self.y_cable_response_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "MUX_CABLE_RESPONSE_TABLE")
+            self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
+            self.port_table_keys[asic_id] = self.port_tbl[asic_id].getKeys()
+
+    def get_state_db(self):
+        return self.state_db
+
+    def get_config_db(self):
+        return self.config_db
+
+    def get_appl_db(self):
+        return self.appl_db
+
+    def get_status_tbl(self):
+        return self.status_tbl
+
+    def get_status_tbl_peer(self):
+        return self.status_tbl_peer
+
+    def get_mux_cable_command_tbl(self):
+        return self.mux_cable_command_tbl
+
+    def get_mux_metrics_tbl(self):
+        return self.mux_metrics_tbl
+
+    def get_hw_mux_cable_tbl(self):
+        return self.hw_mux_cable_tbl
+
+    def get_hw_mux_cable_tbl_peer(self):
+        return self.hw_mux_cable_tbl_peer
+
+    def get_fwd_state_command_tbl(self):
+        return self.fwd_state_command_tbl
+
+    def get_fwd_state_response_tbl(self):
+        return self.fwd_state_response_tbl
+
+    def get_y_cable_response_tbl(self):
+        return self.y_cable_response_tbl
+
+    def get_port_tbl(self):
+        return self.port_tbl
+
+class YcableCliUpdateTableHelper(object):
+    def __init__(self):
+
+        self.appl_db, self.state_db, self.config_db = {}, {}, {}
+        self.xcvrd_log_tbl = {}
+        self.port_tbl = {}
+        self.mux_tbl = {}
+        self.xcvrd_down_fw_cmd_tbl, self.xcvrd_down_fw_rsp_tbl, self.xcvrd_down_fw_cmd_sts_tbl = {}, {}, {}
+        self.xcvrd_down_fw_status_cmd_tbl, self.xcvrd_down_fw_status_rsp_tbl, self.xcvrd_down_fw_status_cmd_sts_tbl = {}, {}, {}
+        self.xcvrd_acti_fw_cmd_tbl, self.xcvrd_acti_fw_cmd_arg_tbl, self.xcvrd_acti_fw_rsp_tbl, self.xcvrd_acti_fw_cmd_sts_tbl = {}, {}, {}, {}
+        self.xcvrd_roll_fw_cmd_tbl, self.xcvrd_roll_fw_rsp_tbl, self.xcvrd_roll_fw_cmd_sts_tbl = {}, {}, {}
+        self.xcvrd_show_fw_cmd_tbl, self.xcvrd_show_fw_rsp_tbl, self.xcvrd_show_fw_cmd_sts_tbl, self.xcvrd_show_fw_res_tbl = {}, {}, {}, {}
+        self.xcvrd_show_hwmode_dir_cmd_tbl, self.xcvrd_show_hwmode_dir_rsp_tbl, self.xcvrd_show_hwmode_dir_res_tbl, self.xcvrd_show_hwmode_dir_cmd_sts_tbl = {}, {}, {}, {}
+        self.xcvrd_show_hwmode_swmode_cmd_tbl, self.xcvrd_show_hwmode_swmode_rsp_tbl, self.xcvrd_show_hwmode_swmode_cmd_sts_tbl = {}, {}, {}
+        self.xcvrd_config_hwmode_state_cmd_tbl, self.xcvrd_config_hwmode_state_rsp_tbl , self.xcvrd_config_hwmode_state_cmd_sts_tbl= {}, {}, {}
+        self.xcvrd_config_hwmode_swmode_cmd_tbl, self.xcvrd_config_hwmode_swmode_rsp_tbl , self.xcvrd_config_hwmode_swmode_cmd_sts_tbl= {}, {}, {}
+        self.xcvrd_config_prbs_cmd_tbl, self.xcvrd_config_prbs_cmd_arg_tbl, self.xcvrd_config_prbs_rsp_tbl , self.xcvrd_config_prbs_cmd_sts_tbl= {}, {}, {}, {}
+        self.xcvrd_config_loop_cmd_tbl, self.xcvrd_config_loop_cmd_arg_tbl, self.xcvrd_config_loop_rsp_tbl , self.xcvrd_config_loop_cmd_sts_tbl= {}, {}, {}, {}
+        self.xcvrd_show_event_cmd_tbl, self.xcvrd_show_event_rsp_tbl , self.xcvrd_show_event_cmd_sts_tbl, self.xcvrd_show_event_res_tbl= {}, {}, {}, {}
+        self.xcvrd_show_fec_cmd_tbl, self.xcvrd_show_fec_rsp_tbl , self.xcvrd_show_fec_cmd_sts_tbl, self.xcvrd_show_fec_res_tbl= {}, {}, {}, {}
+        self.xcvrd_show_ber_cmd_tbl, self.xcvrd_show_ber_cmd_arg_tbl, self.xcvrd_show_ber_rsp_tbl , self.xcvrd_show_ber_cmd_sts_tbl, self.xcvrd_show_ber_res_tbl= {}, {}, {}, {}, {}
+
+
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            # Open a handle to the Application database, in all namespaces
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
+            self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+
+            self.xcvrd_log_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.config_db[asic_id], "XCVRD_LOG")
+            self.xcvrd_show_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_SHOW_FW_CMD")
+            self.xcvrd_show_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_SHOW_FW_CMD")
+            self.xcvrd_show_fw_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_FW_RSP")
+            self.xcvrd_show_fw_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_FW_RES")
+            self.xcvrd_down_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_DOWN_FW_CMD")
+            self.xcvrd_down_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_DOWN_FW_CMD")
+            self.xcvrd_down_fw_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_DOWN_FW_RSP")
+            self.xcvrd_down_fw_status_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_DOWN_FW_STATUS_CMD")
+            self.xcvrd_down_fw_status_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_DOWN_FW_STATUS_RSP")
+            self.xcvrd_acti_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_ACTI_FW_CMD")
+            self.xcvrd_acti_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_ACTI_FW_CMD")
+            self.xcvrd_acti_fw_cmd_arg_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_ACTI_FW_CMD_ARG")
+            self.xcvrd_acti_fw_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_ACTI_FW_RSP")
+            self.xcvrd_roll_fw_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_ROLL_FW_CMD")
+            self.xcvrd_roll_fw_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_ROLL_FW_CMD")
+            self.xcvrd_roll_fw_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_ROLL_FW_RSP")
+            self.xcvrd_show_hwmode_dir_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_CMD")
+            self.xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_CMD")
+            self.xcvrd_show_hwmode_dir_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_RSP")
+            self.xcvrd_show_hwmode_dir_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_HWMODE_DIR_RES")
+            self.xcvrd_config_hwmode_state_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_CMD")
+            self.xcvrd_config_hwmode_state_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_CMD")
+            self.xcvrd_config_hwmode_state_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_CONFIG_HWMODE_DIR_RSP")
+            self.xcvrd_config_hwmode_swmode_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_CMD")
+            self.xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_CMD")
+            self.xcvrd_config_hwmode_swmode_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_CONFIG_HWMODE_SWMODE_RSP")
+            self.xcvrd_show_hwmode_swmode_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_CMD")
+            self.xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_CMD")
+            self.xcvrd_show_hwmode_swmode_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_SHOW_HWMODE_SWMODE_RSP")
+            self.xcvrd_config_prbs_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD")
+            self.xcvrd_config_prbs_cmd_arg_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD_ARG")
+            self.xcvrd_config_prbs_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_PRBS_CMD")
+            self.xcvrd_config_prbs_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_CONFIG_PRBS_RSP")
+            self.xcvrd_config_loop_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD")
+            self.xcvrd_config_loop_cmd_arg_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD_ARG")
+            self.xcvrd_config_loop_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_CONFIG_LOOP_CMD")
+            self.xcvrd_config_loop_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_CONFIG_LOOP_RSP")
+            self.xcvrd_show_event_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_EVENT_LOG_CMD")
+            self.xcvrd_show_event_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_EVENT_LOG_CMD")
+            self.xcvrd_show_event_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_EVENT_LOG_RSP")
+            self.xcvrd_show_event_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_EVENT_LOG_RES")
+            self.xcvrd_show_fec_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_GET_FEC_CMD")
+            self.xcvrd_show_fec_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_GET_FEC_CMD")
+            self.xcvrd_show_fec_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_GET_FEC_RSP")
+            self.xcvrd_show_fec_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_GET_FEC_RES")
+            self.xcvrd_show_ber_cmd_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                self.appl_db[asic_id], "XCVRD_GET_BER_CMD")
+            self.xcvrd_show_ber_cmd_arg_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_GET_BER_CMD_ARG")
+            self.xcvrd_show_ber_cmd_sts_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "XCVRD_GET_BER_CMD")
+            self.xcvrd_show_ber_rsp_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_GET_BER_RSP")
+            self.xcvrd_show_ber_res_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "XCVRD_GET_BER_RES")
+            self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
+            self.mux_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], MUX_CABLE_INFO_TABLE)
+
+    def get_state_db(self):
+        return self.state_db
+
+    def get_config_db(self):
+        return self.config_db
+
+    def get_appl_db(self):
+        return self.appl_db
+
+


### PR DESCRIPTION
This PR attempts for ycabled to have all 
```swsscommon.Table and daemon_base.db_connect```
as just a single call in the thread instance for all task_workers

For example all swsscommon calls to open Tables are moved as class object varables, which are reused when needed instead of opening the Table again in subroutines.
```
self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
```
This would help in avoiding unforeseen redis-errors
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Deploying changes on testbed and UT
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
