### PR TITLE
[chassisd] update chassisd to write fabric and lc asics on seperate table in chassis state db

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -51,6 +51,7 @@ CHASSIS_MODULE_INFO_NUM_ASICS_FIELD = 'num_asics'
 CHASSIS_MODULE_INFO_ASICS = 'asics'
 
 CHASSIS_ASIC_INFO_TABLE = 'CHASSIS_ASIC_TABLE'
+CHASSIS_FABRIC_ASIC_INFO_TABLE = 'CHASSIS_FABRIC_ASIC_TABLE'
 CHASSIS_ASIC = 'asic'
 CHASSIS_ASIC_PCI_ADDRESS_FIELD = 'asic_pci_address'
 CHASSIS_ASIC_ID_IN_MODULE_FIELD = 'asic_id_in_module'
@@ -158,7 +159,7 @@ class ModuleConfigUpdater(logger.Logger):
 
 class ModuleUpdater(logger.Logger):
 
-    def __init__(self, log_identifier, chassis):
+    def __init__(self, log_identifier, chassis, my_slot, supervisor_slot):
         """
         Constructor for ModuleUpdater
         :param chassis: Object representing a platform chassis
@@ -166,6 +167,8 @@ class ModuleUpdater(logger.Logger):
         super(ModuleUpdater, self).__init__(log_identifier)
 
         self.chassis = chassis
+        self.my_slot = my_slot
+        self.supervisor_slot = supervisor_slot
         self.num_modules = chassis.get_num_modules()
         # Connect to STATE_DB and create chassis info tables
         state_db = daemon_base.db_connect("STATE_DB")
@@ -177,9 +180,14 @@ class ModuleUpdater(logger.Logger):
                                CHASSIS_MODULE_INFO_SLOT_FIELD,
                                CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
-        chassis_state_db = daemon_base.db_connect("CHASSIS_STATE_DB")
-        self.asic_table = swsscommon.Table(chassis_state_db, CHASSIS_ASIC_INFO_TABLE)
-
+        self.chassis_state_db = daemon_base.db_connect("CHASSIS_STATE_DB")
+        if self._is_supervisor():
+            self.asic_table = swsscommon.Table(self.chassis_state_db, 
+                                            CHASSIS_FABRIC_ASIC_INFO_TABLE)
+        else:
+            self.asic_table = swsscommon.Table(self.chassis_state_db, 
+                                            CHASSIS_ASIC_INFO_TABLE)
+#
         self.midplane_initialized = try_get(chassis.init_midplane_switch, default=False)
         if not self.midplane_initialized:
             self.log_error("Chassisd midplane intialization failed")
@@ -240,25 +248,28 @@ class ModuleUpdater(logger.Logger):
                 self.module_table.set(key, fvs)
 
                 if module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD] != str(ModuleBase.MODULE_STATUS_ONLINE):
-                   notOnlineModules.append(key)
-                   continue
+                    notOnlineModules.append(key)
+                    continue
 
                 for asic_id, asic in enumerate(module_info_dict[CHASSIS_MODULE_INFO_ASICS]):
-                   asic_global_id, asic_pci_addr = asic
-                   asic_key = "%s%s" % (CHASSIS_ASIC, asic_global_id)
-                   asic_fvs = swsscommon.FieldValuePairs([(CHASSIS_ASIC_PCI_ADDRESS_FIELD, asic_pci_addr),
-                                                          (CHASSIS_MODULE_INFO_NAME_FIELD, key),
-                                                          (CHASSIS_ASIC_ID_IN_MODULE_FIELD, str(asic_id))])
-                   self.asic_table.set(asic_key, asic_fvs)
+                    asic_global_id, asic_pci_addr = asic
+                    asic_key = "%s%s" % (CHASSIS_ASIC, asic_global_id)
+                    if not self._is_supervisor():
+                        asic_key = "%s|%s" % (key, asic_key)
+
+                    asic_fvs = swsscommon.FieldValuePairs([(CHASSIS_ASIC_PCI_ADDRESS_FIELD, asic_pci_addr),
+                                                            (CHASSIS_MODULE_INFO_NAME_FIELD, key),
+                                                            (CHASSIS_ASIC_ID_IN_MODULE_FIELD, str(asic_id))])
+                    self.asic_table.set(asic_key, asic_fvs)
 
         # Asics that are on the "not online" modules need to be cleaned up
         asics = list(self.asic_table.getKeys())
         for asic in asics:
-           fvs = self.asic_table.get(asic)
-           if isinstance(fvs, list):
-              fvs = dict(fvs[-1])
-           if fvs[CHASSIS_MODULE_INFO_NAME_FIELD] in notOnlineModules:
-              self.asic_table._del(asic)
+            fvs = self.asic_table.get(asic)
+            if isinstance(fvs, list):
+                fvs = dict(fvs[-1])
+            if fvs[CHASSIS_MODULE_INFO_NAME_FIELD] in notOnlineModules:
+                self.asic_table._del(asic)
 
     def _get_module_info(self, module_index):
         """
@@ -403,15 +414,17 @@ class ChassisdDaemon(daemon_base.DaemonBase):
             self.log_error("Failed to load chassis due to {}".format(repr(e)))
             sys.exit(CHASSIS_LOAD_ERROR)
 
+        # Check for valid slot numbers
+        my_slot = try_get(platform_chassis.get_my_slot,
+                                              default=INVALID_SLOT)
+        supervisor_slot = try_get(platform_chassis.get_supervisor_slot,
+                                                      default=INVALID_SLOT)
+        
         # Check if module list is populated
-        self.module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, platform_chassis)
+        self.module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, platform_chassis, my_slot, supervisor_slot)
         self.module_updater.modules_num_update()
 
-        # Check for valid slot numbers
-        self.module_updater.my_slot = try_get(platform_chassis.get_my_slot,
-                                              default=INVALID_SLOT)
-        self.module_updater.supervisor_slot = try_get(platform_chassis.get_supervisor_slot,
-                                                      default=INVALID_SLOT)
+
         if ((self.module_updater.my_slot == INVALID_SLOT) or
                 (self.module_updater.supervisor_slot == INVALID_SLOT)):
             self.log_error("Chassisd not supported for this platform")

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -59,7 +59,8 @@ def test_moduleupdater_check_valid_fields():
 
     chassis.module_list.append(module)
 
-    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis)
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
+                                   module.supervisor_slot)
     module_updater.module_db_update()
     fvs = module_updater.module_table.get(name)
     assert desc == fvs[CHASSIS_MODULE_INFO_DESC_FIELD]
@@ -82,7 +83,8 @@ def test_moduleupdater_check_invalid_name():
 
     chassis.module_list.append(module)
 
-    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis)
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
+                                   module.supervisor_slot)
     module_updater.module_db_update()
     fvs = module_updater.module_table.get(name)
     assert fvs == None
@@ -102,7 +104,8 @@ def test_moduleupdater_check_status_update():
     module.set_oper_status(status)
     chassis.module_list.append(module)
 
-    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis)
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
+                                   module.supervisor_slot)
     module_updater.module_db_update()
     fvs = module_updater.module_table.get(name)
     print('Initial DB-entry {}'.format(fvs))
@@ -136,7 +139,8 @@ def test_moduleupdater_check_deinit():
     module.set_oper_status(status)
     chassis.module_list.append(module)
 
-    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis)
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
+                                   module.supervisor_slot)
     module_updater.modules_num_update()
     module_updater.module_db_update()
     fvs = module_updater.module_table.get(name)
@@ -226,7 +230,8 @@ def test_configupdater_check_num_modules():
     module = MockModule(index, name, desc, module_type, slot)
 
     # No modules
-    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis)
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
+                                   module.supervisor_slot)
     module_updater.modules_num_update()
     fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
     assert fvs == None
@@ -274,7 +279,8 @@ def test_midplane_presence_modules():
     chassis.module_list.append(fabric)
 
     #Run on supervisor
-    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis)
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
+                                   module.supervisor_slot)
     module_updater.supervisor_slot = supervisor.get_slot()
     module_updater.my_slot = supervisor.get_slot()
     module_updater.modules_num_update()
@@ -338,7 +344,8 @@ def test_midplane_presence_supervisor():
     chassis.module_list.append(fabric)
 
     #Run on supervisor
-    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis)
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
+                                   module.supervisor_slot)
     module_updater.supervisor_slot = supervisor.get_slot()
     module_updater.my_slot = module.get_slot()
     module_updater.modules_num_update()
@@ -403,9 +410,9 @@ def test_asic_presence():
     chassis.module_list.append(fabric)
 
     #Run on supervisor
-    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis)
-    module_updater.supervisor_slot = supervisor.get_slot()
-    module_updater.my_slot = supervisor.get_slot()
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis,
+                                   module.supervisor_slot,
+                                   module.supervisor_slot)
     module_updater.modules_num_update()
     module_updater.module_db_update()
     module_updater.check_midplane_reachability()


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
The following changes are done in chassisd
-  Change the `ModuleUpdater` init changed to include slot and supervisor as argument.
-  Add logic to in `ModuleUpdater` to update the asic_info in `CHASSIS_FABRIC_ASIC_INFO` for the supervisor and `CHASSIS_ASIC_TABLE` for the linecard asics respectively.
- Add the linecard name is the key of the `CHASSIS_ASIC_TABLE` 
- update the UT

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Fixes https://github.com/sonic-net/sonic-buildimage/issues/12575 and https://github.com/sonic-net/sonic-buildimage/issues/12575
#### How Has This Been Tested?
Update the pmon on the supervisor and linecard and verify the `CHASSIS_STATE_DB` is update properly
```
admin@str2-sonic-sup-1:~$ redis-cli -h redis_chassis.server -p 6380 -n 13 keys *ASIC*
 1) "CHASSIS_ASIC_TABLE|LINE-CARD4|asic0"
 2) "CHASSIS_FABRIC_ASIC_TABLE|asic1"
 3) "CHASSIS_FABRIC_ASIC_TABLE|asic8"
 4) "CHASSIS_FABRIC_ASIC_TABLE|asic10"
 5) "CHASSIS_ASIC_TABLE|LINE-CARD0|asic0"
 6) "CHASSIS_FABRIC_ASIC_TABLE|asic6"
 7) "CHASSIS_FABRIC_ASIC_TABLE|asic9"
 8) "CHASSIS_FABRIC_ASIC_TABLE|asic5"
 9) "CHASSIS_FABRIC_ASIC_TABLE|asic3"
10) "CHASSIS_ASIC_TABLE|LINE-CARD3|asic0"
11) "CHASSIS_FABRIC_ASIC_TABLE|asic2"
12) "CHASSIS_ASIC_TABLE|LINE-CARD2|asic0"
13) "CHASSIS_ASIC_TABLE|LINE-CARD2|asic1"
14) "CHASSIS_FABRIC_ASIC_TABLE|asic11"
15) "CHASSIS_FABRIC_ASIC_TABLE|asic0"
16) "CHASSIS_FABRIC_ASIC_TABLE|asic4"
17) "CHASSIS_FABRIC_ASIC_TABLE|asic7"
admin@str2-sonic-sup-1:~$
```

#### Additional Information (Optional)
