### PR TITLE
[thermalctld] fix some redundant removal of state DB tables

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -561,12 +561,12 @@ class TemperatureUpdater(logger.Logger):
             table_keys = self.table.getKeys()
             for tk in table_keys:
                 self.table._del(tk)
+                if self.is_chassis_system and self.chassis_table is not None:
+                    self.chassis_table._del(tk)
         if self.phy_entity_table:
             phy_entity_keys = self.phy_entity_table.getKeys()
             for pek in phy_entity_keys:
                 self.phy_entity_table._del(pek)
-                if self.is_chassis_system and self.chassis_table is not None:
-                    self.chassis_table._del(pek)
 
     def _log_on_status_changed(self, normal_status, normal_log, abnormal_log):
         """

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -565,8 +565,8 @@ class TemperatureUpdater(logger.Logger):
             phy_entity_keys = self.phy_entity_table.getKeys()
             for pek in phy_entity_keys:
                 self.phy_entity_table._del(pek)
-            if self.is_chassis_system and self.chassis_table is not None:
-                self.chassis_table._del(pek)
+                if self.is_chassis_system and self.chassis_table is not None:
+                    self.chassis_table._del(pek)
 
     def _log_on_status_changed(self, normal_status, normal_log, abnormal_log):
         """

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -565,16 +565,8 @@ class TemperatureUpdater(logger.Logger):
             phy_entity_keys = self.phy_entity_table.getKeys()
             for pek in phy_entity_keys:
                 self.phy_entity_table._del(pek)
-
-    def deinit(self):
-        """
-        Deinitializer of TemperatureUpdater
-        :return:
-        """
-        for name in self.temperature_status_dict.keys():
-            self.table._del(name)
-            if self.is_chassis_system and self.chassis_table is not None:
-                self.chassis_table._del(name)
+        if self.is_chassis_system and self.chassis_table is not None:
+            self.chassis_table._del(name)
 
     def _log_on_status_changed(self, normal_status, normal_log, abnormal_log):
         """
@@ -793,8 +785,6 @@ class ThermalMonitor(ProcessTaskBase):
         # Start loop to update fan, temperature info in DB periodically
         while not self.task_stopping_event.wait(self.wait_time):
             self.main()
-
-        self.temperature_updater.deinit()
 
         self.logger.log_info("Stop thermal monitoring loop")
 

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -565,8 +565,8 @@ class TemperatureUpdater(logger.Logger):
             phy_entity_keys = self.phy_entity_table.getKeys()
             for pek in phy_entity_keys:
                 self.phy_entity_table._del(pek)
-        if self.is_chassis_system and self.chassis_table is not None:
-            self.chassis_table._del(name)
+            if self.is_chassis_system and self.chassis_table is not None:
+                self.chassis_table._del(pek)
 
     def _log_on_status_changed(self, normal_status, normal_log, abnormal_log):
         """

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -411,17 +411,17 @@ class TestTemperatureUpdater(object):
     Test cases to cover functionality in TemperatureUpdater class
     """
     
-    """def test_deinit(self):
+    def test_deinit(self):
         chassis = MockChassis()
         temp_updater = thermalctld.TemperatureUpdater(chassis, multiprocessing.Event())
         temp_updater.temperature_status_dict = {'key1': 'value1', 'key2': 'value2'}
         temp_updater.table._del = mock.MagicMock()
 
-        temp_updater.deinit()
+        temp_updater.__del__()
         assert temp_updater.table._del.call_count == 2
         expected_calls = [mock.call('key1'), mock.call('key2')]
         temp_updater.table._del.assert_has_calls(expected_calls, any_order=True)
-    """ 
+    
 
     def test_over_temper(self):
         chassis = MockChassis()

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -416,6 +416,7 @@ class TestTemperatureUpdater(object):
         temp_updater = thermalctld.TemperatureUpdater(chassis, multiprocessing.Event())
         temp_updater.temperature_status_dict = {'key1': 'value1', 'key2': 'value2'}
         temp_updater.table._del = mock.MagicMock()
+        temp_updater.table.getKeys = mock.MagicMock()
 
         temp_updater.__del__()
         assert temp_updater.table._del.call_count == 2

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -410,7 +410,8 @@ class TestTemperatureUpdater(object):
     """
     Test cases to cover functionality in TemperatureUpdater class
     """
-    def test_deinit(self):
+    
+    """def test_deinit(self):
         chassis = MockChassis()
         temp_updater = thermalctld.TemperatureUpdater(chassis, multiprocessing.Event())
         temp_updater.temperature_status_dict = {'key1': 'value1', 'key2': 'value2'}
@@ -420,7 +421,7 @@ class TestTemperatureUpdater(object):
         assert temp_updater.table._del.call_count == 2
         expected_calls = [mock.call('key1'), mock.call('key2')]
         temp_updater.table._del.assert_has_calls(expected_calls, any_order=True)
-        
+    """ 
 
     def test_over_temper(self):
         chassis = MockChassis()

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -410,7 +410,7 @@ class TestTemperatureUpdater(object):
     """
     Test cases to cover functionality in TemperatureUpdater class
     """
-    
+    """ 
     def test_deinit(self):
         chassis = MockChassis()
         temp_updater = thermalctld.TemperatureUpdater(chassis, multiprocessing.Event())
@@ -422,7 +422,7 @@ class TestTemperatureUpdater(object):
         assert temp_updater.table._del.call_count == 2
         expected_calls = [mock.call('key1'), mock.call('key2')]
         temp_updater.table._del.assert_has_calls(expected_calls, any_order=True)
-    
+    """
 
     def test_over_temper(self):
         chassis = MockChassis()

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -25,6 +25,7 @@ assert(os.path.samefile(swsscommon.__path__[0], os.path.join(mocked_libs_path, '
 from sonic_py_common import daemon_base
 
 from .mock_platform import MockChassis, MockFan, MockPsu, MockSfp, MockThermal
+from .mock_swsscommon import Table
 
 daemon_base.db_connect = mock.MagicMock()
 
@@ -410,19 +411,25 @@ class TestTemperatureUpdater(object):
     """
     Test cases to cover functionality in TemperatureUpdater class
     """
-    """ 
     def test_deinit(self):
         chassis = MockChassis()
         temp_updater = thermalctld.TemperatureUpdater(chassis, multiprocessing.Event())
         temp_updater.temperature_status_dict = {'key1': 'value1', 'key2': 'value2'}
+        temp_updater.table = Table("STATE_DB", "xtable")
         temp_updater.table._del = mock.MagicMock()
-        temp_updater.table.getKeys = mock.MagicMock()
+        temp_updater.table.getKeys = mock.MagicMock(return_value=['key1','key2'])
+        temp_updater.phy_entity_table = Table("STATE_DB", "ytable")
+        temp_updater.phy_entity_table._del = mock.MagicMock()
+        temp_updater.phy_entity_table.getKeys = mock.MagicMock(return_value=['key1','key2'])
+        temp_updater.chassis_table = Table("STATE_DB", "ctable")
+        temp_updater.chassis_table._del = mock.MagicMock()
+        temp_updater.is_chassis_system = True
 
         temp_updater.__del__()
+        assert temp_updater.table.getKeys.call_count == 1
         assert temp_updater.table._del.call_count == 2
         expected_calls = [mock.call('key1'), mock.call('key2')]
         temp_updater.table._del.assert_has_calls(expected_calls, any_order=True)
-    """
 
     def test_over_temper(self):
         chassis = MockChassis()


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
This PR aims to get rid of such messages in syslog when thermalctld, essentially delete keys is getting called twice, causing some redis issues.
This PR gets rid of deleting such keys twice.

Nov 16 00:33:00.566174 sonic INFO pmon#/supervisord: thermalctld Exception ignored in: <function TemperatureUpdater.__del__ at 0xb5dbe810>
Nov 16 00:33:00.566585 sonic INFO pmon#/supervisord: thermalctld Traceback (most recent call last):
Nov 16 00:33:00.566825 sonic INFO pmon#/supervisord: thermalctld   File "/usr/local/bin/thermalctld", line 558, in __del__
Nov 16 00:33:00.567014 sonic INFO pmon#/supervisord: thermalctld     table_keys = self.table.getKeys()
Nov 16 00:33:00.567181 sonic INFO pmon#/supervisord: thermalctld   File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 2320, in getKeys
Nov 16 00:33:00.567343 sonic INFO pmon#/supervisord: thermalctld     return _swsscommon.Table_getKeys(self)
Nov 16 00:33:00.567499 sonic INFO pmon#/supervisord: thermalctld RuntimeError: RedisReply catches system_error: command: *2#015
Nov 16 00:33:00.567658 sonic INFO pmon#/supervisord: thermalctld $4#015
Nov 16 00:33:00.567811 sonic INFO pmon#/supervisord: thermalctld KEYS#015
Nov 16 00:33:00.567964 sonic INFO pmon#/supervisord: thermalctld $18#015
Nov 16 00:33:00.568118 sonic INFO pmon#/supervisord: thermalctld TEMPERATURE_INFO|*#015
Nov 16 00:33:00.568273 sonicINFO pmon#/supervisord: thermalctld , reason: Expected to get redis type 2 got type 3, err: NON-STRING-REPLY: Input/output error: Input/output error

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
