### PR TITLE
Pass grid parameter while calling set_laser_freq

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1293,7 +1293,7 @@ class CmisManagerTask:
            self.log_error("{} configured tx power {} > maximum power {} supported".format(lport, tx_power, max_p))
         return api.set_tx_power(tx_power)
 
-    def configure_laser_frequency(self, api, lport, freq):
+    def configure_laser_frequency(self, api, lport, freq, grid=75):
         _, _,  _, lowf, highf = api.get_supported_freq_config()
         if freq < lowf:
             self.log_error("{} configured freq:{} GHz is lower than the supported freq:{} GHz".format(lport, freq, lowf))
@@ -1304,7 +1304,7 @@ class CmisManagerTask:
             self.log_error("{} configured freq:{} GHz is NOT in 75GHz grid".format(lport, freq))
         if api.get_tuning_in_progress():
             self.log_error("{} Tuning in progress, channel selection may fail!".format(lport))
-        return api.set_laser_freq(freq)
+        return api.set_laser_freq(freq, grid)
 
     def wait_for_port_config_done(self, namespace):
         # Connect to APPL_DB and subscribe to PORT table notifications


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
It seems that with the below PR, a new parameter "grid" was added to set_laser_freq function. However, xcvrd is not passing this parameter and hence, we are seeing an error while calling set_laser_freq function for 400ZR transceiver. This task will ensure that we resolve the current error seen.

PR which triggers the error
https://github.com/sonic-net/sonic-platform-common/pull/294

Error
```
Nov 28 21:19:28.258483 sonic INFO pmon#supervisord: xcvrd Process Process-1:
Nov 28 21:19:28.262677 sonic INFO pmon#supervisord: xcvrd Traceback (most recent call last):
Nov 28 21:19:28.262677 sonic INFO pmon#supervisord: xcvrd   File "/usr/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
Nov 28 21:19:28.262677 sonic INFO pmon#supervisord: xcvrd     self.run()
Nov 28 21:19:28.263290 sonic INFO pmon#supervisord: xcvrd   File "/usr/lib/python3.9/multiprocessing/process.py", line 108, in run
Nov 28 21:19:28.263290 sonic INFO pmon#supervisord: xcvrd     self._target(*self._args, **self._kwargs)
Nov 28 21:19:28.263368 sonic INFO pmon#supervisord: xcvrd   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1514, in task_worker
Nov 28 21:19:28.263395 sonic INFO pmon#supervisord: xcvrd     if 1 != self.configure_laser_frequency(api, lport, freq):
Nov 28 21:19:28.263434 sonic INFO pmon#supervisord: xcvrd   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1307, in configure_laser_frequency
Nov 28 21:19:28.263458 sonic INFO pmon#supervisord: xcvrd     return api.set_laser_freq(freq)
Nov 28 21:19:28.263481 sonic INFO pmon#supervisord: xcvrd TypeError: set_laser_freq() missing 1 required positional argument: 'grid'
```
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This change will help in resolving an error seen while bringing up 400ZR transceiver

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Link was verified on 400ZR transceiver and LLDP was verified as well.
```
root@sonic:/home/admin# show version

SONiC Software Version: SONiC.master.181162-f3809c217
Distribution: Debian 11.5
Kernel: 5.10.0-18-2-amd64
Build commit: f3809c217
Build date: Mon Nov 28 16:08:37 UTC 2022
Built by: AzDevOps@vmss-soni0001R9

Platform: x86_64-arista_7060dx4_32
HwSKU: Arista-7060DX4-C32
ASIC: broadcom
ASIC Count: 1
Serial Number: JPE19161053
Model Number: DCS-7060DX4-32
Hardware Revision: 04.00
Uptime: 22:53:07 up 24 min, 13 users,  load average: 1.42, 1.15, 0.93
Date: Mon 28 Nov 2022 22:53:07

root@sonic:/home/admin# show int status | grep Ethernet144                                                                                                
Ethernet144  145,146,147,148,149,150,151,152     400G   9100    N/A  Ethernet19/1   trunk      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
root@sonic:/home/admin# show int status | grep Ethernet160
Ethernet160  161,162,163,164,165,166,167,168     400G   9100    N/A  Ethernet21/1   trunk      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
root@sonic:/home/admin# show lldp t
Capability codes: (R) Router, (B) Bridge, (O) Other
LocalPort    RemoteDevice                  RemotePortID    Capability    RemotePortDescr
-----------  ----------------------------  --------------  ------------  ------------------------
Ethernet0    sonic                         Ethernet3/1     BR            Ethernet16
Ethernet16   sonic                         Ethernet1/1     BR            Ethernet0
Ethernet144  sonic                         Ethernet21/1    BR            Ethernet160
Ethernet160  sonic                         Ethernet19/1    BR            Ethernet144
eth0         STR43-0101-0100-01M0.phx.gbl  Ethernet1/31    BR            INFRA:MGMT:$Description$
--------------------------------------------------
Total entries displayed:  5
root@sonic:/home/admin# 
```

#### Additional Information (Optional)

Signed-off-by: Mihir Patel <patelmi@microsoft.com>
