### PR TITLE
[ycabled] fix minor appl_db retrieving logic for update

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5799,11 +5799,15 @@ class TestYCableScript(object):
             rc = apply_grpc_secrets_configuration(None)
             assert(rc == None)
 
+
+
     def test_handle_ycable_active_standby_probe_notification(self):
 
         test_db = "TEST_DB"
+        status = True
         port_m = "Ethernet0"
-        fvp_dict = [('command', "probe"), ('read_side', 1), ('cable_type','active-standby'), ('soc_ipv4','192.168.0.1')]
+        fvp_m = [('command', "probe"), ('read_side', 1), ('cable_type','active-standby'), ('soc_ipv4','192.168.0.1')]
+        fvp_dict = {"command": "probe"}
         hw_mux_cable_tbl = {}
         y_cable_response_tbl = {}
         asic_index = 0
@@ -5811,7 +5815,8 @@ class TestYCableScript(object):
             test_db[asic_index], "PORT_INFO_TABLE")
         y_cable_response_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "PORT_INFO_TABLE")
-        hw_mux_cable_tbl[asic_index].get.return_value = (status, fvp_dict)
-        
+        hw_mux_cable_tbl[asic_index].get.return_value = (status, fvp_m)
+
         rc = handle_ycable_active_standby_probe_notification("active-standby", fvp_dict, test_db, hw_mux_cable_tbl, port_m, asic_index, y_cable_response_tbl)
         assert(rc == True)
+

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5805,7 +5805,8 @@ class TestYCableScript(object):
         port_m = "Ethernet0"
         fvp_dict = [('command', "probe"), ('read_side', 1), ('cable_type','active-standby'), ('soc_ipv4','192.168.0.1')]
         hw_mux_cable_tbl = {}
-        y_cable__response_tbl = {}
+        y_cable_response_tbl = {}
+        asic_index = 0
         hw_mux_cable_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "PORT_INFO_TABLE")
         y_cable_response_tbl[asic_index] = swsscommon.Table(

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5798,3 +5798,19 @@ class TestYCableScript(object):
             patched_util.return_value = parsed_data
             rc = apply_grpc_secrets_configuration(None)
             assert(rc == None)
+
+    def test_handle_ycable_active_standby_probe_notification(self):
+
+        test_db = "TEST_DB"
+        port_m = "Ethernet0"
+        fvp_dict = [('command', "probe"), ('read_side', 1), ('cable_type','active-standby'), ('soc_ipv4','192.168.0.1')]
+        hw_mux_cable_tbl = {}
+        y_cable__response_tbl = {}
+        hw_mux_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        y_cable_response_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        hw_mux_cable_tbl[asic_index].get.return_value = (status, fvp_dict)
+        
+        rc = handle_ycable_active_standby_probe_notification("active-standby", fvp_dict, test_db, hw_mux_cable_tbl, port_m, asic_index, y_cable_response_tbl)
+        assert(rc == True)

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3411,6 +3411,29 @@ def handle_hw_mux_cable_table_grpc_notification(fvp, hw_mux_cable_tbl, asic_inde
             helper_logger.log_info("Got a change event on port {} of table {} that does not contain state".format(
                 port, swsscommon.APP_HW_MUX_CABLE_TABLE_NAME))
 
+
+def handle_ycable_active_standby_probe_notification(cable_type, fvp_dict, appl_db, hw_mux_cable_tbl, port_m, asic_index,  y_cable_response_tbl):
+
+    if cable_type == 'active-standby' and "command" in fvp_dict:
+
+        # check if xcvrd got a probe command
+        probe_identifier = fvp_dict["command"]
+
+        if probe_identifier == "probe":
+
+            (status, fv) = hw_mux_cable_tbl[asic_index].get(port_m)
+
+            if status is False:
+                helper_logger.log_warning("Could not retreive fieldvalue pairs for {}, inside state_db table {}".format(
+                    port_m, hw_mux_cable_tbl[asic_index].getTableName()))
+                return False
+
+                mux_port_dict = dict(fv)
+                read_side = mux_port_dict.get("read_side")
+                update_appdb_port_mux_cable_response_table(port_m, asic_index, appl_db, int(read_side), y_cable_response_tbl)
+
+                return True
+
 def handle_ycable_enable_disable_tel_notification(fvp_m, key):
 
     global disable_telemetry
@@ -3576,21 +3599,8 @@ class YCableTableUpdateTask(threading.Thread):
                     (status, cable_type) = check_mux_cable_port_type(port_m, self.table_helper.get_port_tbl(), asic_index)
 
                     if status:
+                        handle_ycable_active_standby_probe_notification(cable_type, fvp_dict, self.table_helper.get_appl_db(), self.table_helper.get_hw_mux_cable_tbl(), port_m, asic_index, self.table_helper.get_y_cable_response_tbl())
 
-                        if cable_type == 'active-standby' and "command" in fvp_dict:
-
-                            # check if xcvrd got a probe command
-                            probe_identifier = fvp_dict["command"]
-
-                            if probe_identifier == "probe":
-                                (status, fv) = self.table_helper.get_hw_mux_cable_tbl()[asic_index].get(port_m)
-                                if status is False:
-                                    helper_logger.log_warning("Could not retreive fieldvalue pairs for {}, inside state_db table {}".format(
-                                        port_m, self.table_helper.get_hw_mux_cable_tbl()[asic_index].getTableName()))
-                                    continue
-                                mux_port_dict = dict(fv)
-                                read_side = mux_port_dict.get("read_side")
-                                update_appdb_port_mux_cable_response_table(port_m, asic_index, self.table_helper.get_appl_db(), int(read_side), self.table_helper.get_y_cable_response_tbl())
 
             while True:
                 (port_m, op_m, fvp_m) = self.table_helper.get_fwd_state_command_tbl()[asic_index].pop()

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3428,11 +3428,11 @@ def handle_ycable_active_standby_probe_notification(cable_type, fvp_dict, appl_d
                     port_m, hw_mux_cable_tbl[asic_index].getTableName()))
                 return False
 
-                mux_port_dict = dict(fv)
-                read_side = mux_port_dict.get("read_side")
-                update_appdb_port_mux_cable_response_table(port_m, asic_index, appl_db, int(read_side), y_cable_response_tbl)
+            mux_port_dict = dict(fv)
+            read_side = mux_port_dict.get("read_side")
+            update_appdb_port_mux_cable_response_table(port_m, asic_index, appl_db, int(read_side), y_cable_response_tbl)
 
-                return True
+            return True
 
 def handle_ycable_enable_disable_tel_notification(fvp_m, key):
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3590,7 +3590,7 @@ class YCableTableUpdateTask(threading.Thread):
                                     continue
                                 mux_port_dict = dict(fv)
                                 read_side = mux_port_dict.get("read_side")
-                                update_appdb_port_mux_cable_response_table(port_m, asic_index, self.appl_db, int(read_side), self.table_helper.get_y_cable_response_tbl())
+                                update_appdb_port_mux_cable_response_table(port_m, asic_index, self.table_helper.get_appl_db(), int(read_side), self.table_helper.get_y_cable_response_tbl())
 
             while True:
                 (port_m, op_m, fvp_m) = self.table_helper.get_fwd_state_command_tbl()[asic_index].pop()


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
This PR fixes the app DB access fix logic by updating the values causing some failures for ycabled's response for mux probe from linkmgrd.
This PR essentially fixes that logic, calling the correct method to access the app DB
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
UT and deploying changes to kvm
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
