### PR TITLE
add async notification support in active-active topo; refactor code for ycable tasks for change events 

### DIFF
--- a/sonic-ycabled/proto/proto_out/linkmgr_grpc_driver.proto
+++ b/sonic-ycabled/proto/proto_out/linkmgr_grpc_driver.proto
@@ -82,9 +82,9 @@ enum GracefulRestartNotifyType {
 
 message GracefulAdminResponse {
 
-  GracefulRestartMsgType type = 1;
+  GracefulRestartMsgType msgtype = 1;
 
-  GracefulRestartNotifyType type = 2;
+  GracefulRestartNotifyType notifytype = 2;
 
   string guid = 3;
 

--- a/sonic-ycabled/proto/proto_out/linkmgr_grpc_driver.proto
+++ b/sonic-ycabled/proto/proto_out/linkmgr_grpc_driver.proto
@@ -51,45 +51,29 @@ service GracefulRestart {
 
 }
 
-
-
-message GracefulAdminRequest {
-
-  int32 portid = 1;
-
+enum ToRSide {
+  LOWER_TOR = 0;
+  UPPER_TOR =1;
 }
 
-enum GracefulRestartMsgType{
-
-
-   SERVICE_BEGIN = 0;
-
-   SERVICE_END = 1;// send this always from SoC Side even if not paired with Begin
+message GracefulAdminRequest { 
+  ToRSide tor = 1;
 }
 
-enum GracefulRestartNotifyType {
-
-   CONTROL_PLANE = 0;// need proper definitions
-
-   DATA_PLANE = 1;
-
-   BOTH = 2;
-
+enum GracefulRestartMsgType {
+  SERVICE_BEGIN = 0; 
+  SERVICE_END = 1;// send this always from SoC Side even if not paired with Begin
 }
 
-
-
-
-message GracefulAdminResponse {
-
-  GracefulRestartMsgType msgtype = 1;
-
-  GracefulRestartNotifyType notifytype = 2;
-
-  string guid = 3;
-
-  int32 period = 4;  // in seconds
-
+enum GracefulRestartNotifyType { 
+  CONTROL_PLANE = 0;// need proper definitions
+  DATA_PLANE = 1; 
+  BOTH = 2;
 }
 
-
+message GracefulAdminResponse { 
+  GracefulRestartMsgType msgtype = 1; 
+  GracefulRestartNotifyType notifytype = 2; 
+  string guid = 3; 
+  int32 period = 4; // in seconds
+}

--- a/sonic-ycabled/proto/proto_out/linkmgr_grpc_driver.proto
+++ b/sonic-ycabled/proto/proto_out/linkmgr_grpc_driver.proto
@@ -62,18 +62,18 @@ message GracefulAdminRequest {
 enum GracefulRestartMsgType{
 
 
-   SERVICE_BEGIN = 1;
+   SERVICE_BEGIN = 0;
 
-   SERVICE_END = 2;// send this always from SoC Side even if not paired with Begin
+   SERVICE_END = 1;// send this always from SoC Side even if not paired with Begin
 }
 
 enum GracefulRestartNotifyType {
 
-   CONTROL_PLANE = 1;// need proper definitions
+   CONTROL_PLANE = 0;// need proper definitions
 
-   DATA_PLANE = 2;
+   DATA_PLANE = 1;
 
-   BOTH = 3;
+   BOTH = 2;
 
 }
 

--- a/sonic-ycabled/proto/proto_out/linkmgr_grpc_driver.proto
+++ b/sonic-ycabled/proto/proto_out/linkmgr_grpc_driver.proto
@@ -45,3 +45,51 @@ message ServerVersionReply {
 }
 
 
+service GracefulRestart {
+
+  rpc NotifyGracefulRestartStart(GracefulAdminRequest) returns (stream GracefulAdminResponse) {}
+
+}
+
+
+
+message GracefulAdminRequest {
+
+  int32 portid = 1;
+
+}
+
+enum GracefulRestartMsgType{
+
+
+   SERVICE_BEGIN = 1;
+
+   SERVICE_END = 2;// send this always from SoC Side even if not paired with Begin
+}
+
+enum GracefulRestartNotifyType {
+
+   CONTROL_PLANE = 1;// need proper definitions
+
+   DATA_PLANE = 2;
+
+   BOTH = 3;
+
+}
+
+
+
+
+message GracefulAdminResponse {
+
+  GracefulRestartMsgType type = 1;
+
+  GracefulRestartNotifyType type = 2;
+
+  string guid = 3;
+
+  int32 period = 4;  // in seconds
+
+}
+
+

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -1711,8 +1711,9 @@ class TestYCableScript(object):
         grpc_config[asic_index] = swsscommon.Table(
             test_db[asic_index], "GRPC_CONFIG")
         grpc_config[asic_index].get.return_value = (status, fvs)
+        fwd_state_response_tbl = {}
 
-        rc = init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presence,  state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, port_table_keys, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, grpc_config, stop_event=threading.Event())
+        rc = init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presence,  state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, port_table_keys, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, grpc_config, fwd_state_response_tbl, stop_event=threading.Event())
 
         assert(rc == None)
 
@@ -1720,6 +1721,7 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.check_mux_cable_port_type', MagicMock(return_value=(True,"active-active")))
     @patch('ycable.ycable_utilities.y_cable_helper.check_identifier_presence_and_setup_channel', MagicMock(return_value=(None)))
+    @patch('ycable.ycable_utilities.y_cable_helper.process_loopback_interface_and_get_read_side',MagicMock(return_value=0))
     @patch('swsscommon.swsscommon.Table')
     def test_change_ports_status_for_y_cable_change_event(self, mock_swsscommon_table):
 
@@ -1751,6 +1753,7 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.check_mux_cable_port_type', MagicMock(return_value=(True,"active-active")))
     @patch('ycable.ycable_utilities.y_cable_helper.check_identifier_presence_and_setup_channel', MagicMock(return_value=(None)))
+    @patch('ycable.ycable_utilities.y_cable_helper.process_loopback_interface_and_get_read_side',MagicMock(return_value=0))
     @patch('swsscommon.swsscommon.Table')
     def test_change_ports_status_for_y_cable_change_event_sfp_removed(self, mock_swsscommon_table):
 
@@ -1780,6 +1783,7 @@ class TestYCableScript(object):
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.process_loopback_interface_and_get_read_side',MagicMock(return_value=0))
     @patch('swsscommon.swsscommon.Table')
     def test_change_ports_status_for_y_cable_change_event_sfp_unknown(self, mock_swsscommon_table):
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -6488,7 +6488,7 @@ class TestYCableScript(object):
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
-            (channel, stub) = setup_grpc_channel_for_port("Ethernet0", "192.168.0.1", asic_index, grpc_client, fwd_state_response_tbl)
+            (channel, stub) = setup_grpc_channel_for_port("Ethernet0", "192.168.0.1", asic_index, grpc_client, fwd_state_response_tbl, False)
 
         assert(stub == True)
         assert(channel != None)
@@ -7117,3 +7117,22 @@ class TestYCableScript(object):
         assert(rc['peer_mux_direction'] == 'unknown')
         assert(rc['mux_direction_probe_count'] == 'unknown')
         assert(rc['peer_mux_direction_probe_count'] == 'unknown')
+
+
+
+    @patch("grpc.aio.secure_channel")
+    @patch("proto_out.linkmgr_grpc_driver_pb2_grpc.GracefulRestartStub")
+    def test_ycable_graceful_client(self, channel, stub):
+
+
+        mock_channel = MagicMock()
+        channel.return_value = mock_channel
+
+        mock_stub = MagicMock()
+        mock_stub.NotifyGracefulRestartStart = MagicMock(return_value=[4, 5])
+        stub.return_value = mock_stub
+
+
+        read_side = 1
+        Y_cable_restart_client = GracefulRestartClient("Ethernet48", None, read_side)
+

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -2484,6 +2484,7 @@ class TestYCableScript(object):
     def test_get_muxcable_static_info(self, platform_sfputil):
         physical_port = 0
 
+        asic_index = 0
         logical_port_name = "Ethernet0"
         test_db = "TEST_DB"
         y_cable_tbl = {}
@@ -2568,10 +2569,12 @@ class TestYCableScript(object):
     def test_get_muxcable_static_info_read_side_peer(self, platform_sfputil):
         physical_port = 0
 
+        asic_index = 0
         logical_port_name = "Ethernet0"
 
         test_db = "TEST_DB"
         status = True
+        y_cable_tbl = {}
         fvs = [('state', "auto"), ('read_side', 2)]
 
         y_cable_tbl[asic_index] = swsscommon.Table(
@@ -2654,8 +2657,10 @@ class TestYCableScript(object):
     def test_get_muxcable_static_info_read_side_peer_exceptions(self, platform_sfputil):
         physical_port = 0
 
+        asic_index = 0
         logical_port_name = "Ethernet0"
         test_db = "TEST_DB"
+        y_cable_tbl = {}
 
         status = True
         fvs = [('state', "auto"), ('read_side', 2)]
@@ -5546,6 +5551,7 @@ class TestYCableScript(object):
         xcvrd_config_hwmode_swmode_rsp_tbl = mock_swsscommon_table
         xcvrd_show_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_show_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+        hw_mux_cable_tbl = mock_swsscommon_table
 
         asic_index = 0
         task_download_firmware_thread = {}
@@ -5972,6 +5978,7 @@ class TestYCableScript(object):
         xcvrd_show_hwmode_dir_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_show_hwmode_dir_rsp_tbl = mock_swsscommon_table
         xcvrd_show_hwmode_dir_res_tbl = mock_swsscommon_table
+        hw_mux_cable_tbl =mock_swsscommon_table
         port_tbl = mock_swsscommon_table
 
         asic_index = 0
@@ -5980,7 +5987,7 @@ class TestYCableScript(object):
         fvp = {"state": "active"}
 
         rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
-            fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+            fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, hw_mux_cable_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('swsscommon.swsscommon.Table')
@@ -6000,6 +6007,7 @@ class TestYCableScript(object):
         xcvrd_show_hwmode_dir_res_tbl = mock_swsscommon_table
         xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+        hw_mux_cable_tbl =mock_swsscommon_table
         port_tbl = mock_swsscommon_table
 
         asic_index = 0
@@ -6008,7 +6016,7 @@ class TestYCableScript(object):
         fvp = {"down_firmware": "null"}
 
         rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
-            fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+            fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, hw_mux_cable_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('swsscommon.swsscommon.Table')
@@ -6034,6 +6042,7 @@ class TestYCableScript(object):
         xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
         port_tbl = mock_swsscommon_table
+        hw_mux_cable_tbl =mock_swsscommon_table
         asic_index = 0
         task_download_firmware_thread = {}
         port = "Ethernet0"
@@ -6066,7 +6075,7 @@ class TestYCableScript(object):
 
             patched_util.get.return_value = PortInstanceHelper()
             rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
-                fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+                fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, hw_mux_cable_tbl, asic_index, port)
             assert(rc == None)
 
     @patch('swsscommon.swsscommon.Table')
@@ -6087,6 +6096,7 @@ class TestYCableScript(object):
         xcvrd_show_hwmode_dir_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_show_hwmode_dir_rsp_tbl = mock_swsscommon_table
         xcvrd_show_hwmode_dir_res_tbl = mock_swsscommon_table
+        hw_mux_cable_tbl =mock_swsscommon_table
         port_tbl = mock_swsscommon_table
 
         asic_index = 0
@@ -6095,7 +6105,7 @@ class TestYCableScript(object):
         fvp = {"state": "active"}
 
         rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
-            fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+            fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, hw_mux_cable_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('swsscommon.swsscommon.Table')
@@ -6128,6 +6138,10 @@ class TestYCableScript(object):
         port = "Ethernet0"
         platform_sfputil.get_asic_id_for_logical_port = 0
         fvp = {"state": "active"}
+        hw_mux_cable_tbl = {}
+        test_db = "TEST_DB"
+        hw_mux_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
             class PortInstanceHelper():
@@ -6155,7 +6169,7 @@ class TestYCableScript(object):
 
             patched_util.get.return_value = PortInstanceHelper()
             rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
-                fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+                fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, hw_mux_cable_tbl, asic_index, port)
             assert(rc == None)
 
     @patch('swsscommon.swsscommon.Table')
@@ -6183,9 +6197,13 @@ class TestYCableScript(object):
         fvp = {"state": "active"}
         swsscommon.Table.return_value.get.return_value = (
                 True, {"read_side": "2", "state": "active"})
+        hw_mux_cable_tbl = {}
+        test_db = "TEST_DB"
+        hw_mux_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
 
         rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
-            fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+            fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, hw_mux_cable_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('swsscommon.swsscommon.Table')
@@ -6213,11 +6231,16 @@ class TestYCableScript(object):
         fvp = {"state": "active"}
         swsscommon.Table.return_value.get.return_value = (
                 False, {"read_side": "2", "state": "active"})
+        hw_mux_cable_tbl = {}
+        test_db = "TEST_DB"
+        hw_mux_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
 
         rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
-            fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+            fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, hw_mux_cable_tbl, asic_index, port)
         assert(rc == -1)
 
+    @patch('ycable.ycable_utilities.y_cable_helper.setup_grpc_channel_for_port', MagicMock(return_value=(None,None)))
     def test_retry_setup_grpc_channel_for_port_incorrect(self):
 
         status = True
@@ -6225,20 +6248,14 @@ class TestYCableScript(object):
         Table = MagicMock()
         Table.get.return_value = (status, fvs)
         swsscommon.Table.return_value.get.return_value = (
-            False, {"read_side": "2"})
-        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0)
-        assert(rc == False)
-
-    @patch('ycable.ycable_utilities.y_cable_helper.setup_grpc_channel_for_port', MagicMock(return_value=(True,True)))
-    def test_retry_setup_grpc_channel_for_port_correct(self):
-
-        status = True
-        fvs = [('state', "auto"), ('read_side', 1)]
-        Table = MagicMock()
-        Table.get.return_value = (status, fvs)
-        swsscommon.Table.return_value.get.return_value = (
                 True, {"cable_type": "active-active", "soc_ipv4":"192.168.0.1/32", "state":"active"})
-        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0)
+        port_tbl = {}
+        test_db = "TEST_DB"
+        asic_index = 0
+        port_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        grpc_client , fwd_state_response_tbl = {}, {}
+        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0, port_tbl, grpc_client, fwd_state_response_tbl)
         assert(rc == True)
 
     @patch('ycable.ycable_utilities.y_cable_helper.setup_grpc_channel_for_port', MagicMock(return_value=(None,None)))
@@ -6250,7 +6267,67 @@ class TestYCableScript(object):
         Table.get.return_value = (status, fvs)
         swsscommon.Table.return_value.get.return_value = (
                 True, {"cable_type": "active-active", "soc_ipv4":"192.168.0.1/32", "state":"active"})
-        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0)
+        port_tbl = {}
+        test_db = "TEST_DB"
+        asic_index = 0
+        port_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        grpc_client , fwd_state_response_tbl = {}, {}
+        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0, port_tbl, grpc_client, fwd_state_response_tbl)
+        assert(rc == False)
+
+    def test_process_loopback_interface_and_get_read_side_rc(self):
+
+        loopback_keys = [["Loopback3|10.212.64.2/3", "Loopback3|2603:1010:100:d::1/128"]]
+        rc = process_loopback_interface_and_get_read_side(loopback_keys)
+        assert(rc == 0)
+        Table = MagicMock()
+        Table.get.return_value = (status, fvs)
+        swsscommon.Table.return_value.get.return_value = (
+                True, {"cable_type": "active-active", "soc_ipv4":"192.168.0.1/32", "state":"active"})
+        port_tbl = {}
+        test_db = "TEST_DB"
+        asic_index = 0
+        port_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        grpc_client , fwd_state_response_tbl = {}, {}
+        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0 , port_tbl, grpc_client, fwd_state_response_tbl )
+        assert(rc == False)
+
+    @patch('ycable.ycable_utilities.y_cable_helper.setup_grpc_channel_for_port', MagicMock(return_value=(True,True)))
+    def test_retry_setup_grpc_channel_for_port_correct(self):
+
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        Table = MagicMock()
+        Table.get.return_value = (status, fvs)
+        swsscommon.Table.return_value.get.return_value = (
+                True, {"cable_type": "active-active", "soc_ipv4":"192.168.0.1/32", "state":"active"})
+        port_tbl = {}
+        test_db = "TEST_DB"
+        asic_index = 0
+        port_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        grpc_client , fwd_state_response_tbl = {}, {}
+        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0, port_tbl, grpc_client, fwd_state_response_tbl)
+        assert(rc == True)
+
+    @patch('ycable.ycable_utilities.y_cable_helper.setup_grpc_channel_for_port', MagicMock(return_value=(None,None)))
+    def test_retry_setup_grpc_channel_for_port_correct_none_val(self):
+
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        Table = MagicMock()
+        Table.get.return_value = (status, fvs)
+        swsscommon.Table.return_value.get.return_value = (
+                True, {"cable_type": "active-active", "soc_ipv4":"192.168.0.1/32", "state":"active"})
+        port_tbl = {}
+        test_db = "TEST_DB"
+        asic_index = 0
+        port_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        grpc_client , fwd_state_response_tbl = {}, {}
+        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0, port_tbl, grpc_client, fwd_state_response_tbl)
         assert(rc == False)
 
     def test_process_loopback_interface_and_get_read_side_rc(self):

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -1718,6 +1718,8 @@ class TestYCableScript(object):
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.check_mux_cable_port_type', MagicMock(return_value=(True,"active-active")))
+    @patch('ycable.ycable_utilities.y_cable_helper.check_identifier_presence_and_setup_channel', MagicMock(return_value=(None)))
     @patch('swsscommon.swsscommon.Table')
     def test_change_ports_status_for_y_cable_change_event(self, mock_swsscommon_table):
 
@@ -1734,25 +1736,28 @@ class TestYCableScript(object):
         mock_table.get = MagicMock(
             side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
         mock_swsscommon_table.return_value = mock_table
-
+        port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl = {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+        port_table_keys[0] = ['Ethernet0']
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
 
-            change_ports_status_for_y_cable_change_event(
-                logical_port_dict,  y_cable_presence, stop_event=threading.Event())
+            rc = change_ports_status_for_y_cable_change_event(
+                logical_port_dict,  y_cable_presence, port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, stop_event=threading.Event())
 
-            mock_swsscommon_table.assert_called()
+            assert(rc == None)
 
-        @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
-        @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-        @patch('swsscommon.swsscommon.Table')
-        def test_change_ports_status_for_y_cable_change_event_sfp_removed(self, mock_swsscommon_table):
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.check_mux_cable_port_type', MagicMock(return_value=(True,"active-active")))
+    @patch('ycable.ycable_utilities.y_cable_helper.check_identifier_presence_and_setup_channel', MagicMock(return_value=(None)))
+    @patch('swsscommon.swsscommon.Table')
+    def test_change_ports_status_for_y_cable_change_event_sfp_removed(self, mock_swsscommon_table):
 
-            mock_logical_port_name = [""]
+        mock_logical_port_name = [""]
 
-            def mock_get_asic_id(mock_logical_port_name):
-                return 0
+        def mock_get_asic_id(mock_logical_port_name):
+            return 0
 
         y_cable_presence = [True]
         logical_port_dict = {'Ethernet0': '1'}
@@ -1762,14 +1767,16 @@ class TestYCableScript(object):
         mock_table.get = MagicMock(
             side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
         mock_swsscommon_table.return_value = mock_table
+        port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl = {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+        port_table_keys[0] = ['Ethernet0']
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
-            change_ports_status_for_y_cable_change_event(
-                logical_port_dict,  y_cable_presence, stop_event=threading.Event())
+            rc = change_ports_status_for_y_cable_change_event(
+                logical_port_dict,  y_cable_presence,  port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl,stop_event=threading.Event())
 
-            mock_swsscommon_table.assert_called()
+            assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
@@ -1789,14 +1796,15 @@ class TestYCableScript(object):
         mock_table.get = MagicMock(
             side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
         mock_swsscommon_table.return_value = mock_table
-
+        port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl = {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+        port_table_keys[0] = ['Ethernet0']
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
-            change_ports_status_for_y_cable_change_event(
-                logical_port_dict,  y_cable_presence, stop_event=threading.Event())
+            rc = change_ports_status_for_y_cable_change_event(
+                logical_port_dict,  y_cable_presence,port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, stop_event=threading.Event())
 
-            mock_swsscommon_table.assert_called()
+            assert(rc == None)
 
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
@@ -6243,12 +6251,12 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.setup_grpc_channel_for_port', MagicMock(return_value=(None,None)))
     def test_retry_setup_grpc_channel_for_port_incorrect(self):
 
-        status = True
+        status = False
         fvs = [('state', "auto"), ('read_side', 1)]
         Table = MagicMock()
         Table.get.return_value = (status, fvs)
         swsscommon.Table.return_value.get.return_value = (
-                True, {"cable_type": "active-active", "soc_ipv4":"192.168.0.1/32", "state":"active"})
+                False, {"cable_type": "active-active", "soc_ipv4":"192.168.0.1/32", "state":"active"})
         port_tbl = {}
         test_db = "TEST_DB"
         asic_index = 0
@@ -6256,7 +6264,7 @@ class TestYCableScript(object):
             test_db[asic_index], "PORT_INFO_TABLE")
         grpc_client , fwd_state_response_tbl = {}, {}
         rc = retry_setup_grpc_channel_for_port("Ethernet0", 0, port_tbl, grpc_client, fwd_state_response_tbl)
-        assert(rc == True)
+        assert(rc == False)
 
     @patch('ycable.ycable_utilities.y_cable_helper.setup_grpc_channel_for_port', MagicMock(return_value=(None,None)))
     def test_retry_setup_grpc_channel_for_port_correct_none_val(self):
@@ -6374,8 +6382,9 @@ class TestYCableScript(object):
             test_db[asic_index], "HW_TABLE1")
         hw_mux_cable_tbl_peer[asic_index] = swsscommon.Table(
             test_db[asic_index], "HW_TABLE2")
+        grpc_client , fwd_state_response_tbl = {}, {}
 
-        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence)
+        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence, grpc_client, fwd_state_response_tbl)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -6405,8 +6414,9 @@ class TestYCableScript(object):
             test_db[asic_index], "HW_TABLE1")
         hw_mux_cable_tbl_peer[asic_index] = swsscommon.Table(
             test_db[asic_index], "HW_TABLE2")
+        grpc_client , fwd_state_response_tbl = {}, {}
 
-        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence)
+        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence, grpc_client, fwd_state_response_tbl)
         assert(rc == None)
 
 
@@ -6440,17 +6450,32 @@ class TestYCableScript(object):
             test_db[asic_index], "HW_TABLE1")
         hw_mux_cable_tbl_peer[asic_index] = swsscommon.Table(
             test_db[asic_index], "HW_TABLE2")
+        grpc_client , fwd_state_response_tbl = {}, {}
 
-        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence)
+        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence, grpc_client, fwd_state_response_tbl)
         assert(rc == None)
 
     @patch('proto_out.linkmgr_grpc_driver_pb2_grpc.DualToRActiveStub', MagicMock(return_value=True))
     def test_setup_grpc_channel_for_port(self):
 
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1), ('cable_type','active-standby'), ('soc_ipv4','192.168.0.1')]
+        grpc_client , fwd_state_response_tbl = {}, {}
+        asic_index = 0
+        Table = MagicMock()
+        Table.get.return_value = (status, fvs)
+        #swsscommon.Table.return_value.get.return_value = (
+        #        True, { 'config', {'type': 'secure'}})
+        swsscommon.Table.return_value.get.return_value = (
+            True, {"config": "1"})
+        test_db = "TEST_DB"
+        asic_index = 0
+        grpc_client[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
-            (channel, stub) = setup_grpc_channel_for_port("Ethernet0", "192.168.0.1")
+            (channel, stub) = setup_grpc_channel_for_port("Ethernet0", "192.168.0.1", asic_index, grpc_client, fwd_state_response_tbl)
 
         assert(stub == True)
         assert(channel != None)
@@ -6471,7 +6496,8 @@ class TestYCableScript(object):
 
             patched_util.logical.return_value = ['Ethernet0', 'Ethernet4']
             patched_util.get_asic_id_for_logical_port.return_value = 0
-            rc = setup_grpc_channels(stop_event)
+            loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, port_tbl, loopback_tbl, port_table_keys, grpc_client, fwd_state_response_tbl = {}, {}, {}, {}, {}, {}, {}, {}
+            rc = setup_grpc_channels(stop_event, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, port_tbl, loopback_tbl, port_table_keys, grpc_client, fwd_state_response_tbl)
 
             assert(rc == None)
 
@@ -6866,12 +6892,16 @@ class TestYCableScript(object):
 
         parsed_data = {'GRPCCLIENT': {'config': {'type': 'secure', 'auth_level': 'server', 'log_level': 'info'}, 'certs': {'client_crt': 'one.crt', 'client_key': 'one.key', 'ca_crt': 'ss.crt', 'grpc_ssl_credential': 'jj.tsl'}}}
 
-        mock_file = MagicMock()
-        open.return_value = mock_file
+        asic_index = 0
+        grpc_client = {}
+        test_db = {}
+        test_db[asic_index] = 'xyz'
+        grpc_client[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
         #json_load.return_value = parsed_data
         with patch('json.load') as patched_util:
             patched_util.return_value = parsed_data
-            rc = apply_grpc_secrets_configuration(None)
+            rc = apply_grpc_secrets_configuration(None, grpc_client)
             assert(rc == None)
 
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -244,7 +244,8 @@ class TestYCableScript(object):
     def test_post_port_mux_static_info_to_db(self):
         logical_port_name = "Ethernet0"
         mux_tbl = Table("STATE_DB", "Y_CABLE_STATIC_INFO_TABLE")
-        rc = post_port_mux_static_info_to_db(logical_port_name, mux_tbl)
+        y_cable_tbl = Table("STATE_DB", "Y_CABLE_STATIC_INFO_TABLE")
+        rc = post_port_mux_static_info_to_db(logical_port_name, mux_tbl, y_cable_tbl)
         assert(rc != -1)
 
     def test_y_cable_helper_format_mapping_identifier1(self):
@@ -1686,6 +1687,7 @@ class TestYCableScript(object):
         port_tbl = {}
         port_table_keys = {}
         loopback_keys = {}
+        grpc_config = {}
         hw_mux_cable_tbl, hw_mux_cable_tbl_peer = {}, {}
         y_cable_presence = [True]
         delete_change_event = [True]
@@ -1706,8 +1708,11 @@ class TestYCableScript(object):
         port_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "PORT_INFO_TABLE")
         port_tbl[asic_index].get.return_value = (status, fvs)
+        grpc_config[asic_index] = swsscommon.Table(
+            test_db[asic_index], "GRPC_CONFIG")
+        grpc_config[asic_index].get.return_value = (status, fvs)
 
-        rc = init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presence,  state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, port_table_keys, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, stop_event=threading.Event())
+        rc = init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presence,  state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, port_table_keys, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, grpc_config, stop_event=threading.Event())
 
         assert(rc == None)
 
@@ -2480,7 +2485,14 @@ class TestYCableScript(object):
         physical_port = 0
 
         logical_port_name = "Ethernet0"
+        test_db = "TEST_DB"
+        y_cable_tbl = {}
+        status = True
+        fvs = [('state', "auto"), ('read_side', 2)]
 
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
         platform_sfputil.get_asic_id_for_logical_port = 0
         swsscommon.Table.return_value.get.return_value = (
             True, {"read_side": "1"})
@@ -2512,7 +2524,7 @@ class TestYCableScript(object):
 
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
-                rc = get_muxcable_static_info(physical_port, logical_port_name)
+                rc = get_muxcable_static_info(physical_port, logical_port_name, y_cable_tbl)
 
                 assert (rc['read_side'] == 'tor1')
                 assert (rc['nic_lane1_precursor1'] == 1)
@@ -2558,6 +2570,13 @@ class TestYCableScript(object):
 
         logical_port_name = "Ethernet0"
 
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 2)]
+
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
         #swsscommon.Table = MagicMock()
         # this patch is already done as global instance
         platform_sfputil.get_asic_id_for_logical_port = 0
@@ -2591,7 +2610,7 @@ class TestYCableScript(object):
 
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
-                rc = get_muxcable_static_info(physical_port, logical_port_name)
+                rc = get_muxcable_static_info(physical_port, logical_port_name, y_cable_tbl)
 
                 assert (rc['read_side'] == 'tor2')
                 assert (rc['nic_lane1_precursor1'] == 1)
@@ -2636,7 +2655,14 @@ class TestYCableScript(object):
         physical_port = 0
 
         logical_port_name = "Ethernet0"
+        test_db = "TEST_DB"
 
+        status = True
+        fvs = [('state', "auto"), ('read_side', 2)]
+
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
         #swsscommon.Table = MagicMock()
         # this patch is already done as global instance
         platform_sfputil.get_asic_id_for_logical_port = 0
@@ -2665,7 +2691,7 @@ class TestYCableScript(object):
 
             with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
                 patched_util.get_asic_id_for_logical_port.return_value = 0
-                rc = get_muxcable_static_info(physical_port, logical_port_name)
+                rc = get_muxcable_static_info(physical_port, logical_port_name, y_cable_tbl)
 
                 assert (rc['read_side'] == 'tor2')
                 assert (rc['nic_lane1_precursor1'] == "N/A")

--- a/sonic-ycabled/tests/test_ycable.py
+++ b/sonic-ycabled/tests/test_ycable.py
@@ -163,7 +163,7 @@ class TestYcableScript(object):
         mux_tbl = {}
         test_db = "TEST_DB"
         status = True
-        fvs = [('state', "auto"), ('read_side', 1)]
+        fvs = [('state', "auto"), ('read_side', 1), ('soc_ipv4', '192.168.0.1/32')]
         y_cable_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "Y_CABLE_TABLE")
         y_cable_tbl[asic_index].get.return_value = (status, fvs)
@@ -366,4 +366,37 @@ class TestYcableScriptException(object):
         assert("NotImplementedError" in str(trace) and "effect" in str(trace))
         assert("sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py" in str(trace))
         assert("swsscommon.Select" in str(trace))
+
+class TestYcableAsyncScript(object):
+
+    @patch("swsscommon.swsscommon.Select", MagicMock(side_effect=NotImplementedError))
+    @patch("swsscommon.swsscommon.Select.addSelectable", MagicMock(side_effect=NotImplementedError))
+    @patch("swsscommon.swsscommon.Select.select", MagicMock(side_effect=NotImplementedError))
+    @patch("swsscommon.swsscommon.Table.get", MagicMock(
+                    return_value=[(True, (('state', "auto"), ("soc_ipv4", "192.168.0.1/32"))), (True, (('index', 2), ))]))
+    @patch("ycable.ycable_utilities.y_cable_helper.setup_grpc_channel_for_port", MagicMock(side_effect=NotImplementedError))
+    @patch("ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil")
+    def test_ycable_helper_async_client_run_loop_with_exception(self, sfputil):
+
+
+        sfputil.logical = ["Ethernet0", "Ethernet4"]
+        sfputil.get_asic_id_for_logical_port = MagicMock(return_value=0)
+        Y_cable_async_task = YCableAsyncNotificationTask()
+        expected_exception_start = None
+        expected_exception_join = None
+        trace = None
+        try:
+            Y_cable_async_task.start()
+            Y_cable_async_task.task_worker()
+            Y_cable_async_task.join()
+        except Exception as e1:
+            expected_exception_start  = e1
+            trace = traceback.format_exc()
+
+
+         
+
+        assert("NotImplementedError" in str(trace) and "effect" in str(trace))
+        assert("sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py" in str(trace))
+        assert("setup_grpc_channel_for_port" in str(trace))
 

--- a/sonic-ycabled/tests/test_ycable.py
+++ b/sonic-ycabled/tests/test_ycable.py
@@ -209,7 +209,8 @@ class TestYcableScript(object):
     def test_post_port_mux_static_info_to_db(self):
         logical_port_name = "Ethernet0"
         mux_tbl = Table("STATE_DB", y_cable_helper.MUX_CABLE_STATIC_INFO_TABLE)
-        rc = post_port_mux_static_info_to_db(logical_port_name, mux_tbl)
+        y_cable_tbl = Table("STATE_DB", "Y_CABLE_STATIC_INFO_TABLE")
+        rc = post_port_mux_static_info_to_db(logical_port_name, mux_tbl, y_cable_tbl)
         assert(rc != -1)
 
     def test_y_cable_helper_format_mapping_identifier1(self):
@@ -308,7 +309,8 @@ class TestYcableScript(object):
         fvp_dict = {}
         y_cable_presence = False
         stopping_event = None
-        rc = handle_state_update_task(port, fvp_dict, y_cable_presence, stopping_event)
+        port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl = {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+        rc = handle_state_update_task(port, fvp_dict, y_cable_presence, port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, stopping_event)
         assert(rc == None)
 
 

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -81,13 +81,13 @@ def detect_port_in_error_status(logical_port_name, status_tbl):
     else:
         return False
 
-def handle_state_update_task(port, fvp_dict, y_cable_presence, stopping_event):
+def handle_state_update_task(port, fvp_dict, y_cable_presence, port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, stopping_event):
 
     port_dict = {}
     port_dict[port] = fvp_dict.get('status', None)
 
     y_cable_helper.change_ports_status_for_y_cable_change_event(
-        port_dict, y_cable_presence, stopping_event)
+        port_dict, y_cable_presence, port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, stopping_event)
 
 #
 # Helper classes ===============================================================
@@ -207,7 +207,8 @@ class YcableStateUpdateTask(threading.Thread):
                 if not fvp_dict:
                     continue
 
-                handle_state_update_task(port, fvp_dict, y_cable_presence, stopping_event)
+                # Check if all tables are created in table_helper
+                handle_state_update_task(port, fvp_dict, y_cable_presence, self.table_helper.get_port_tbl(), self.table_helper.port_tbl_keys(), self.table_helper.get_loopback_tbl(), self.table_helper.get_loopback_keys(), self.table_helper.get_hw_mux_cable_tbl(), self.table_helper.get_hw_mux_cable_tbl_peer(), self.table_helper.get_y_cable_tbl(), self.table_helper.get_static_tbl(), self.table_helper.mux_tbl(), self.table_helper.grpc_client(), self.table_helper.fwd_state_response_tbl(), stopping_event)
 
     def run(self):
         if self.task_stopping_event.is_set():

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -208,7 +208,7 @@ class YcableStateUpdateTask(threading.Thread):
                     continue
 
                 # Check if all tables are created in table_helper
-                handle_state_update_task(port, fvp_dict, y_cable_presence, self.table_helper.get_port_tbl(), self.table_helper.port_tbl_keys(), self.table_helper.get_loopback_tbl(), self.table_helper.get_loopback_keys(), self.table_helper.get_hw_mux_cable_tbl(), self.table_helper.get_hw_mux_cable_tbl_peer(), self.table_helper.get_y_cable_tbl(), self.table_helper.get_static_tbl(), self.table_helper.mux_tbl(), self.table_helper.grpc_client(), self.table_helper.fwd_state_response_tbl(), stopping_event)
+                handle_state_update_task(port, fvp_dict, y_cable_presence, self.table_helper.get_port_tbl(), self.table_helper.port_table_keys, self.table_helper.get_loopback_tbl(), self.table_helper.loopback_keys, self.table_helper.get_hw_mux_cable_tbl(), self.table_helper.get_hw_mux_cable_tbl_peer(), self.table_helper.get_y_cable_tbl(), self.table_helper.get_static_tbl(), self.table_helper.get_mux_tbl(), self.table_helper.get_grpc_config_tbl(), self.table_helper.get_fwd_state_response_tbl(), stopping_event)
 
     def run(self):
         if self.task_stopping_event.is_set():
@@ -339,7 +339,7 @@ class DaemonYcable(daemon_base.DaemonBase):
 
         # Init port y_cable status table
         y_cable_helper.init_ports_status_for_y_cable(
-            platform_sfputil, platform_chassis, self.y_cable_presence, self.table_helper.get_state_db(), self.table_helper.get_port_tbl(), self.table_helper.get_y_cable_tbl(), self.table_helper.get_static_tbl(), self.table_helper.get_mux_tbl(), self.table_helper.port_table_keys,  self.table_helper.loopback_keys , self.table_helper.get_hw_mux_cable_tbl(), self.table_helper.get_hw_mux_cable_tbl_peer(), self.stop_event, is_vs)
+            platform_sfputil, platform_chassis, self.y_cable_presence, self.table_helper.get_state_db(), self.table_helper.get_port_tbl(), self.table_helper.get_y_cable_tbl(), self.table_helper.get_static_tbl(), self.table_helper.get_mux_tbl(), self.table_helper.port_table_keys,  self.table_helper.loopback_keys , self.table_helper.get_hw_mux_cable_tbl(), self.table_helper.get_hw_mux_cable_tbl_peer(), self.table_helper.get_grpc_config_tbl(), self.table_helper.get_fwd_state_response_tbl(), self.stop_event, is_vs)
 
     # Deinitialize daemon
     def deinit(self):

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -388,6 +388,9 @@ class DaemonYcable(daemon_base.DaemonBase):
             y_cable_cli_worker_update = y_cable_helper.YCableCliUpdateTask()
             y_cable_cli_worker_update.start()
             self.threads.append(y_cable_cli_worker_update)
+            y_cable_async_noti_worker = y_cable_helper.YCableAsyncNotificationTask()
+            y_cable_async_noti_worker.start()
+            self.threads.append(y_cable_async_noti_worker)
 
         # Start main loop
         self.log_info("Start daemon main loop")

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -1355,7 +1355,7 @@ def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presen
                 "Could not retreive port inside config_db PORT table {} for Y-Cable initiation".format(logical_port_name))
 
 
-def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, stop_event=threading.Event()):
+def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, stop_event=threading.Event()):
 
     global read_side
     delete_change_event = [False]
@@ -3147,7 +3147,6 @@ def handle_config_hwmode_state_cmd_arg_tbl_notification(fvp, xcvrd_config_hwmode
 
 def handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl,  xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, hw_mux_cable_tbl, asic_index, port):
     state_db = {}
-    hw_mux_cable_tbl = {}
 
     fvp_dict = dict(fvp)
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -629,7 +629,7 @@ def process_loopback_interface_and_get_read_side(loopback_keys):
     return -1
 
 
-def check_identifier_presence_and_setup_channel(logical_port_name, port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence, grpc_client, fwd_state_response_tbl):
+def check_identifier_presence_and_setup_channel(logical_port_name, port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence, grpc_client, fwd_state_response_tbl):
     global grpc_port_stubs
     global grpc_port_channels
 
@@ -1409,7 +1409,7 @@ def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, po
                         state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name, y_cable_presence)
                 if status and cable_type == "active-active":
                     check_identifier_presence_and_setup_channel(
-                        logical_port_name, port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl,mux_tbl,  y_cable_presence, grpc_client, fwd_state_response_tbl)
+                        logical_port_name, port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl,  y_cable_presence, grpc_client, fwd_state_response_tbl)
             elif value == SFP_STATUS_REMOVED:
                 helper_logger.log_info("Got SFP deleted ycable event")
                 check_identifier_presence_and_delete_mux_table_entry(

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
@@ -58,20 +58,90 @@ class YcableStateUpdateTableHelper(object):
     def __init__(self):
 
         self.state_db = {}
+        self.appl_db = {}
         self.sub_status_tbl = {}
+        self.config_db = {}
+        self.port_tbl = {}
+        self.y_cable_tbl = {}
+        self.static_tbl = {}
+        self.mux_tbl = {}
+        self.port_table_keys = {}
+        self.loopback_tbl= {}
+        self.loopback_keys = {}
+        self.hw_mux_cable_tbl = {}
+        self.hw_mux_cable_tbl_peer = {}
+        self.grpc_config_tbl = {}
+        self.fwd_state_response_tbl = {}
 
         # Get the namespaces in the platform
         namespaces = multi_asic.get_front_end_namespaces()
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
             self.sub_status_tbl[asic_id] = swsscommon.SubscriberStateTable(
                 self.state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
-
-
+            self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
+            self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
+            self.port_table_keys[asic_id] = self.port_tbl[asic_id].getKeys()
+            self.loopback_tbl[asic_id] = swsscommon.Table(
+                self.config_db[asic_id], "LOOPBACK_INTERFACE")
+            self.loopback_keys[asic_id] = self.loopback_tbl[asic_id].getKeys()
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.hw_mux_cable_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            self.hw_mux_cable_tbl_peer[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
+            self.y_cable_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            self.static_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
+            self.mux_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], MUX_CABLE_INFO_TABLE)
+            self.grpc_config_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "GRPCCLIENT")
+            self.fwd_state_response_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "FORWARDING_STATE_RESPONSE")
+            self.static_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
 
     def get_sub_status_tbl(self):
         return self.sub_status_tbl
+
+    def get_state_db(self):
+        return self.state_db
+
+    def get_config_db(self):
+        return self.config_db
+
+    def get_appl_db(self):
+        return self.appl_db
+
+    def get_port_tbl(self):
+        return self.port_tbl
+
+    def get_mux_tbl(self):
+        return self.mux_tbl
+
+    def get_loopback_tbl(self):
+        return self.loopback_tbl
+
+    def get_hw_mux_cable_tbl(self):
+        return self.hw_mux_cable_tbl
+
+    def get_hw_mux_cable_tbl_peer(self):
+        return self.hw_mux_cable_tbl_peer
+
+    def get_grpc_config_tbl(self):
+        return self.grpc_config_tbl
+
+    def get_y_cable_tbl(self):
+        return self.y_cable_tbl
+
+    def get_static_tbl(self):
+        return self.static_tbl
+
+    def get_fwd_state_response_tbl(self):
+        return self.fwd_state_response_tbl
 
 
 
@@ -79,6 +149,7 @@ class DaemonYcableTableHelper(object):
     def __init__(self):
 
         self.state_db = {}
+        self.appl_db = {}
         self.config_db = {}
         self.port_tbl = {}
         self.y_cable_tbl = {} 
@@ -91,12 +162,14 @@ class DaemonYcableTableHelper(object):
         self.hw_mux_cable_tbl = {}
         self.hw_mux_cable_tbl_peer = {}
         self.grpc_config_tbl = {}
+        self.fwd_state_response_tbl = {}
 
         # Get the namespaces in the platform
         fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'notice')])
         namespaces = multi_asic.get_front_end_namespaces()
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
             self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
             self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
             self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
@@ -119,6 +192,8 @@ class DaemonYcableTableHelper(object):
             self.static_tbl[asic_id] = swsscommon.Table(
                 self.state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
             self.grpc_config_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "GRPCCLIENT")
+            self.fwd_state_response_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "FORWARDING_STATE_RESPONSE")
 
 
     def get_state_db(self):
@@ -157,6 +232,8 @@ class DaemonYcableTableHelper(object):
     def get_grpc_config_tbl(self):
         return self.grpc_config_tbl
 
+    def get_fwd_state_response_tbl(self):
+        return self.fwd_state_response_tbl
 
 class YcableTableUpdateTableHelper(object):
     def __init__(self):
@@ -399,16 +476,22 @@ class YcableAsyncNotificationTableHelper(object):
 
         self.state_db = {}
         self.config_db = {}
+        self.appl_db = {}
         self.port_tbl = {}
         self.status_tbl = {}
         self.y_cable_tbl = {} 
         self.mux_tbl = {}
+        self.grpc_config_tbl = {}
+        self.fwd_state_response_tbl = {}
+        self.loopback_tbl= {}
+        self.loopback_keys = {}
 
         # Get the namespaces in the platform
         namespaces = multi_asic.get_front_end_namespaces()
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
             self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
             self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
             self.status_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
@@ -416,6 +499,12 @@ class YcableAsyncNotificationTableHelper(object):
                 self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
             self.mux_tbl[asic_id] = swsscommon.Table(
                 self.state_db[asic_id], MUX_CABLE_INFO_TABLE)
+            self.grpc_config_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "GRPCCLIENT")
+            self.fwd_state_response_tbl[asic_id] = swsscommon.Table(
+                self.appl_db[asic_id], "FORWARDING_STATE_RESPONSE")
+            self.loopback_tbl[asic_id] = swsscommon.Table(
+                self.config_db[asic_id], "LOOPBACK_INTERFACE")
+            self.loopback_keys[asic_id] = self.loopback_tbl[asic_id].getKeys()
 
     def get_state_db(self):
         return self.state_db
@@ -435,3 +524,8 @@ class YcableAsyncNotificationTableHelper(object):
     def get_mux_tbl(self):
         return self.mux_tbl
 
+    def get_grpc_config_tbl(self):
+        return self.grpc_config_tbl
+
+    def get_fwd_state_response_tbl(self):
+        return self.fwd_state_response_tbl

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
@@ -168,6 +168,7 @@ class YcableTableUpdateTableHelper(object):
         self.fwd_state_command_tbl, self.fwd_state_response_tbl, self.mux_cable_command_tbl = {}, {}, {}
         self.mux_metrics_tbl = {}
         self.grpc_config_tbl = {}
+        self.y_cable_response_tbl = {}
 
 
         if multi_asic.is_multi_asic():

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_table_helper.py
@@ -167,7 +167,7 @@ class YcableTableUpdateTableHelper(object):
         self.port_tbl, self.port_table_keys = {}, {}
         self.fwd_state_command_tbl, self.fwd_state_response_tbl, self.mux_cable_command_tbl = {}, {}, {}
         self.mux_metrics_tbl = {}
-        self.y_cable_response_tbl = {}
+        self.grpc_config_tbl = {}
 
 
         if multi_asic.is_multi_asic():
@@ -202,6 +202,7 @@ class YcableTableUpdateTableHelper(object):
                 self.appl_db[asic_id], "MUX_CABLE_RESPONSE_TABLE")
             self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
             self.port_table_keys[asic_id] = self.port_tbl[asic_id].getKeys()
+            self.grpc_config_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "GRPCCLIENT")
 
     def get_state_db(self):
         return self.state_db
@@ -241,6 +242,9 @@ class YcableTableUpdateTableHelper(object):
 
     def get_port_tbl(self):
         return self.port_tbl
+
+    def get_grpc_config_tbl(self):
+        return self.grpc_config_tbl
 
 class YcableCliUpdateTableHelper(object):
     def __init__(self):
@@ -388,4 +392,45 @@ class YcableCliUpdateTableHelper(object):
     def get_appl_db(self):
         return self.appl_db
 
+
+class YcableAsyncNotificationTableHelper(object):
+    def __init__(self):
+
+        self.state_db = {}
+        self.config_db = {}
+        self.port_tbl = {}
+        self.status_tbl = {}
+        self.y_cable_tbl = {} 
+        self.mux_tbl = {}
+
+        # Get the namespaces in the platform
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
+            self.port_tbl[asic_id] = swsscommon.Table(self.config_db[asic_id], "MUX_CABLE")
+            self.status_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
+            self.y_cable_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            self.mux_tbl[asic_id] = swsscommon.Table(
+                self.state_db[asic_id], MUX_CABLE_INFO_TABLE)
+
+    def get_state_db(self):
+        return self.state_db
+
+    def get_config_db(self):
+        return self.config_db
+
+    def get_port_tbl(self):
+        return self.port_tbl
+
+    def get_status_tbl(self):
+        return self.status_tbl
+
+    def get_y_cable_tbl(self):
+        return self.y_cable_tbl
+
+    def get_mux_tbl(self):
+        return self.mux_tbl
 


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
This PR adds an enhancement to ycabled when if and whenever a notification arrives from SoC or server that it is going to be serviced. The notification can come at anytime and hence it must be listened to or awaited by the client at all times. For this we use asyncio lib and avail the async functionality in python. 

the added code defines a GracefulRestartClient class that can be used to send requests to a gRPC server for graceful restart. The class has three async methods: send_request, receive_response, and notify_graceful_restart_start.

send_request method retrieves tor from request_queue, creates a request with the ToR, and sends it to the server using the stub's NotifyGracefulRestartStart method. It then reads the response from the server and prints the details of the response.

receive_response method retrieves response from response_queue, prints/puts the the response in DB, sleeps for the period mentioned in the response, and then puts the tor of the response back in the request_queue

We follow the existing ycabled pattern and instantiate the task_worker which contains all these tasks in a seperate thread


<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
UT and using this server to validate

```
import asyncio
import grpc
import os
from concurrent import futures
from proto_out import linkmgr_grpc_driver_pb2 as linkmgr_pb2
from proto_out import linkmgr_grpc_driver_pb2_grpc as linkmgr_pb2_grpc os.environ["GRPC_TRACE"] = "http" class GracefulRestartServicer(linkmgr_pb2_grpc.GracefulRestartServicer):     async def NotifyGracefulRestartStart(self, request, context):
        # Dummy values
        msgtype = linkmgr_pb2.SERVICE_BEGIN
        notifytype = linkmgr_pb2.CONTROL_PLANE
        guid = "abc123"
        period = 60         # Yield a stream of responses
        for i in range(5):
            response = linkmgr_pb2.GracefulAdminResponse(
                msgtype=msgtype,
                notifytype=notifytype,
                guid=guid,
                period=period
            )
            yield response
            await asyncio.sleep(1)  # delay between responses async def serve():
    server = grpc.aio.server()
    linkmgr_pb2_grpc.add_GracefulRestartServicer_to_server(
        GracefulRestartServicer(), server)
    server.add_insecure_port('[::]:50052')
    await server.start()
    await server.wait_for_termination() if __name__ == '__main__':
    asyncio.run(serve())
```
    
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
