### PR TITLE
Chassisd do an explicit stop of the config_manager

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -444,6 +444,9 @@ class ChassisdDaemon(daemon_base.DaemonBase):
 
         self.log_info("Stop daemon main loop")
 
+        if config_manager is not None:
+            config_manager.task_stop()
+
         # Delete all the information from DB and then exit
         self.module_updater.deinit()
 

--- a/sonic-chassisd/tests/mock_swsscommon.py
+++ b/sonic-chassisd/tests/mock_swsscommon.py
@@ -7,7 +7,8 @@ class Table:
         self.mock_dict = {}
 
     def _del(self, key):
-        del self.mock_dict[key]
+        if key in self.mock_dict:
+            del self.mock_dict[key]
         pass
 
     def set(self, key, fvs):

--- a/sonic-chassisd/tests/mocked_libs/sonic_platform/__init__.py
+++ b/sonic-chassisd/tests/mocked_libs/sonic_platform/__init__.py
@@ -1,0 +1,6 @@
+"""
+    Mock implementation of sonic_platform package for unit testing
+"""
+
+from . import chassis
+from . import platform

--- a/sonic-chassisd/tests/mocked_libs/sonic_platform/chassis.py
+++ b/sonic-chassisd/tests/mocked_libs/sonic_platform/chassis.py
@@ -1,0 +1,27 @@
+"""
+    Mock implementation of sonic_platform package for unit testing
+"""
+
+# TODO: Clean this up once we no longer need to support Python 2
+import sys
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    import mock
+
+from sonic_platform_base.chassis_base import ChassisBase
+
+
+class Chassis(ChassisBase):
+    def __init__(self):
+        ChassisBase.__init__(self)
+        self.eeprom = mock.MagicMock()
+
+    def get_eeprom(self):
+        return self.eeprom
+
+    def get_my_slot(self):
+        return 1
+
+    def get_supervisor_slot(self):
+        return 1

--- a/sonic-chassisd/tests/mocked_libs/sonic_platform/chassis.py
+++ b/sonic-chassisd/tests/mocked_libs/sonic_platform/chassis.py
@@ -2,7 +2,6 @@
     Mock implementation of sonic_platform package for unit testing
 """
 
-# TODO: Clean this up once we no longer need to support Python 2
 import sys
 if sys.version_info.major == 3:
     from unittest import mock

--- a/sonic-chassisd/tests/mocked_libs/sonic_platform/platform.py
+++ b/sonic-chassisd/tests/mocked_libs/sonic_platform/platform.py
@@ -1,0 +1,12 @@
+"""
+    Mock implementation of sonic_platform package for unit testing
+"""
+
+from sonic_platform_base.platform_base import PlatformBase
+from sonic_platform.chassis import Chassis
+
+
+class Platform(PlatformBase):
+    def __init__(self):
+        PlatformBase.__init__(self)
+        self._chassis = Chassis()

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -14,6 +14,11 @@ NOT_AVAILABLE = 'N/A'
 daemon_base.db_connect = MagicMock()
 
 test_path = os.path.dirname(os.path.abspath(__file__))
+
+# Add mocked_libs path so that the file under test can load mocked modules from there
+mocked_libs_path = os.path.join(test_path, 'mocked_libs')
+sys.path.insert(0, mocked_libs_path)
+
 modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
@@ -503,3 +508,10 @@ def test_signal_handler():
     assert daemon_chassisd.log_info.call_count == 0
     assert daemon_chassisd.stop.set.call_count == 0
     assert exit_code == 0
+
+def test_daemon_run():
+    # Test the chassisd run
+    daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER)
+    daemon_chassisd.stop = MagicMock()
+    daemon_chassisd.stop.wait.return_value = True
+    daemon_chassisd.run()


### PR DESCRIPTION
#### Description
Do an explicit task stop of config_manager task in the chassisd 
 
#### Motivation and Context
Fixes issue https://github.com/sonic-net/sonic-buildimage/issues/11955

#### How Has This Been Tested?
Updated the test_chassisd.py as per https://github.com/sonic-net/sonic-mgmt/pull/7150 and made sure it is a consistent PASS

#### Additional Information (Optional)
