### PR TITLE
Fix bug where transceiver info is missing after port breakout change

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -790,6 +790,9 @@ class TestXcvrdScript(object):
         retry_eeprom_set = set()
         task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, retry_eeprom_set)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
+        task.xcvr_table_helper.get_status_tbl = mock_table_helper.get_status_tbl
+        task.xcvr_table_helper.get_intf_tbl = mock_table_helper.get_intf_tbl
+        task.xcvr_table_helper.get_dom_tbl = mock_table_helper.get_dom_tbl
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         wait_time = 5
         while wait_time > 0:

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2030,6 +2030,7 @@ class SfpStateUpdateTask(object):
             self.port_mapping.handle_port_change_event(port_change_event)
         elif port_change_event.event_type == port_mapping.PortChangeEvent.PORT_ADD:
             self.port_mapping.handle_port_change_event(port_change_event)
+            self.on_add_logical_port(port_change_event)
 
     def on_remove_logical_port(self, port_change_event):
         """Called when a logical port is removed from CONFIG_DB.


### PR DESCRIPTION
#### Description
Added a call to the `self.on_add_logical_port()` method when handling `PORT_ADD` event in `class SfpStateUpdateTask`.
This call was removed in commit 94fa239a, which caused transceiver info to be missing after port breakout change.

#### Motivation and Context
Fix bug where transceiver info is missing after port breakout change.

#### How Has This Been Tested?
Apply port breakout and ensure transceiver info exists for each sub-port.
