### PR TITLE
Added PCIe transaction check for all peripherals on the bus

### DIFF
--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -9,6 +9,7 @@ import os
 import signal
 import sys
 import threading
+import subprocess
 
 from sonic_py_common import daemon_base, device_info, logger
 from swsscommon import swsscommon
@@ -156,6 +157,17 @@ class DaemonPcied(daemon_base.DaemonBase):
         err = 0
         if self.resultInfo is None:
             return
+
+        for result in self.resultInfo:
+            bus = int(result["bus"], 16)
+            device = int(result["dev"], 16)
+            func = int(result["fn"], 16)
+
+            pcieDeviceArgs = ("%02x:%02x.%d" % (bus, device, func))
+            pcieDeviceQueryResult = subprocess.run(['lspci', '-s', pcieDeviceArgs], stdout=subprocess.PIPE).stdout.decode('utf-8')
+            
+            if pcieDeviceQueryResult is None:
+                self.log_error("PCIe Peripheral {} -- Not Found".format(pcieDeviceQueryResult))
 
         for result in self.resultInfo:
             if result["result"] == "Failed":

--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -169,10 +169,9 @@ class DaemonPcied(daemon_base.DaemonBase):
                 func = int(elem.get('fn'), 16)
                 pcieDeviceID = elem.get('id')
 
-                cmd = ("setpci -s %02x:%02x.%d 2.w" % (bus, device, func))
-                output, errs = subprocess.Popen(cmd, shell=True, executable='/bin/bash', stdout=subprocess.PIPE).communicate()
-                if errs:
-                    raise ValueError("subprocess command {} returned {}".format(cmd, errs))
+                pcie_device = ("{:02x}:{:02x}.{:01d}".format(bus, device, func))
+                cmd = ["setpci", "-s", pcie_device, "2.w"]
+                output = subprocess.check_output(cmd)
                 pcieDeviceQueryResult = output.decode('utf8').rstrip()
 
                 if pcieDeviceQueryResult is None or "No devices selected" in pcieDeviceQueryResult:

--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -10,6 +10,7 @@ import signal
 import sys
 import threading
 import subprocess
+import yaml
 
 from sonic_py_common import daemon_base, device_info, logger
 from swsscommon import swsscommon
@@ -177,7 +178,10 @@ class DaemonPcied(daemon_base.DaemonBase):
                 if pcieDeviceQueryResult is None or "No devices selected" in pcieDeviceQueryResult:
                     self.log_error("PCIe Peripheral {} -- Not Found".format(pcieDeviceQueryResult))
                 elif pcieDeviceQueryResult != pcieDeviceID:
-                    self.log_error("PCIe device %02x:%02x.%d ID DOES NOT match preconfigured YAML file" % (bus, device, func))
+                    if pcieDeviceQueryResult == 'ffff':
+                        self.log_error("PCIe device {:02x}:{:02x}.{:01d} missing.".format(bus, device, func))
+                    else:
+                        self.log_error("PCIe device {:02x}:{:02x}.{:01d} ID mismatch. Expected {}, received {}".format(bus, device, func, pcieDeviceID, pcieDeviceQueryResult))
         except Exception as ex:
             self.log_error("PCIe Exception occurred: {}".format(ex))
             pass

--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -160,6 +160,12 @@ class DaemonPcied(daemon_base.DaemonBase):
         if self.resultInfo is None:
             return
 
+        # This block reads the PCIE YAML file, iterates through each device and 
+        # for each device runs a transaction check to verify that the device ID
+        # matches the one on file. In the event of an invalid device ID such as
+        # '0xffff', it marks the device as missing as that is the only scenario
+        # in which such a value is returned.
+
         try:
             stream = open(PLATFORM_PCIE_YAML_FILE, 'r')
 
@@ -191,7 +197,7 @@ class DaemonPcied(daemon_base.DaemonBase):
                     else:
                         self.log_error("PCIe device {:02x}:{:02x}.{:01d} ID mismatch. Expected {}, received {}".format(bus, device, func, pcieDeviceID, pcieDeviceQueryResult))
         except Exception as ex:
-            self.log_error("PCIe Exception occurred: {}".format(ex))
+            self.log_error("PCIe Exception occurred for PCIe device {:02x}:{:02x}.{:01d}: {}".format(bus, device, func, ex))
             pass
 
         for result in self.resultInfo:

--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -166,6 +166,11 @@ class DaemonPcied(daemon_base.DaemonBase):
         # '0xffff', it marks the device as missing as that is the only scenario
         # in which such a value is returned.
 
+        # Default, invalid BDF values to begin
+        bus = None
+        device = None
+        func = None
+
         try:
             stream = open(PLATFORM_PCIE_YAML_FILE, 'r')
 
@@ -196,8 +201,13 @@ class DaemonPcied(daemon_base.DaemonBase):
                         self.log_error("PCIe device {:02x}:{:02x}.{:01d} missing.".format(bus, device, func))
                     else:
                         self.log_error("PCIe device {:02x}:{:02x}.{:01d} ID mismatch. Expected {}, received {}".format(bus, device, func, pcieDeviceID, pcieDeviceQueryResult))
+
         except Exception as ex:
-            self.log_error("PCIe Exception occurred for PCIe device {:02x}:{:02x}.{:01d}: {}".format(bus, device, func, ex))
+            # Verify that none of the BDF objects are None. If condition evals to False, do not mention BDF information in error log
+            if not [i for i in (bus, device, func) if i is None]:
+                self.log_error("PCIe Exception occurred for PCIe device {:02x}:{:02x}.{:01d}: {}".format(bus, device, func, ex))
+            else:
+                self.log_error("PCIe Exception occurred: {}".format(ex))
             pass
 
         for result in self.resultInfo:

--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -162,20 +162,29 @@ class DaemonPcied(daemon_base.DaemonBase):
 
         try:
             stream = open(PLATFORM_PCIE_YAML_FILE, 'r')
+
+            # Load contents of the PCIe YAML file into a dictionary object
             dictionary = yaml.safe_load(stream)
+            
+            # Iterate through each element in dict; extract the BDF information and device ID for that element
             for elem in dictionary:
                 bus = int(elem.get('bus'), 16)
                 device = int(elem.get('dev'), 16)
                 func = int(elem.get('fn'), 16)
                 pcieDeviceID = elem.get('id')
 
+                # Form the PCI device address from the BDF information above
                 pcie_device = ("{:02x}:{:02x}.{:01d}".format(bus, device, func))
+                
+                # Form and run the command to read the device ID from the PCI device
                 cmd = ["setpci", "-s", pcie_device, "2.w"]
                 output = subprocess.check_output(cmd)
                 pcieDeviceQueryResult = output.decode('utf8').rstrip()
 
+                # verify that the queried device ID matches what we have on file for the current PCI device
+                # If not, take appropriate action based on the queried value
                 if pcieDeviceQueryResult is None or "No devices selected" in pcieDeviceQueryResult:
-                    self.log_error("PCIe Peripheral {} -- Not Found".format(pcieDeviceQueryResult))
+                    self.log_error("Invalid PCIe Peripheral {:02x}:{:02x}.{:01d} - {}".format(bus, device, func, pcieDeviceQueryResult))
                 elif pcieDeviceQueryResult != pcieDeviceID:
                     if pcieDeviceQueryResult == 'ffff':
                         self.log_error("PCIe device {:02x}:{:02x}.{:01d} missing.".format(bus, device, func))

--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -33,6 +33,7 @@ PCIED_MAIN_THREAD_SLEEP_SECS = 60
 
 PCIEUTIL_CONF_FILE_ERROR = 1
 PCIEUTIL_LOAD_ERROR = 2
+PLATFORM_PCIE_YAML_FILE = "/usr/share/sonic/platform/pcie.yaml"
 
 platform_pcieutil = None
 
@@ -158,16 +159,28 @@ class DaemonPcied(daemon_base.DaemonBase):
         if self.resultInfo is None:
             return
 
-        for result in self.resultInfo:
-            bus = int(result["bus"], 16)
-            device = int(result["dev"], 16)
-            func = int(result["fn"], 16)
+        try:
+            stream = open(PLATFORM_PCIE_YAML_FILE, 'r')
+            dictionary = yaml.safe_load(stream)
+            for elem in dictionary:
+                bus = int(elem.get('bus'), 16)
+                device = int(elem.get('dev'), 16)
+                func = int(elem.get('fn'), 16)
+                pcieDeviceID = elem.get('id')
 
-            pcieDeviceArgs = ("%02x:%02x.%d" % (bus, device, func))
-            pcieDeviceQueryResult = subprocess.run(['lspci', '-s', pcieDeviceArgs], stdout=subprocess.PIPE).stdout.decode('utf-8')
-            
-            if pcieDeviceQueryResult is None:
-                self.log_error("PCIe Peripheral {} -- Not Found".format(pcieDeviceQueryResult))
+                cmd = ("setpci -s %02x:%02x.%d 2.w" % (bus, device, func))
+                output, errs = subprocess.Popen(cmd, shell=True, executable='/bin/bash', stdout=subprocess.PIPE).communicate()
+                if errs:
+                    raise ValueError("subprocess command {} returned {}".format(cmd, errs))
+                pcieDeviceQueryResult = output.decode('utf8').rstrip()
+
+                if pcieDeviceQueryResult is None or "No devices selected" in pcieDeviceQueryResult:
+                    self.log_error("PCIe Peripheral {} -- Not Found".format(pcieDeviceQueryResult))
+                elif pcieDeviceQueryResult != pcieDeviceID:
+                    self.log_error("PCIe device %02x:%02x.%d ID DOES NOT match preconfigured YAML file" % (bus, device, func))
+        except Exception as ex:
+            self.log_error("PCIe Exception occurred: {}".format(ex))
+            pass
 
         for result in self.resultInfo:
             if result["result"] == "Failed":

--- a/sonic-pcied/tests/test_DaemonPcied.py
+++ b/sonic-pcied/tests/test_DaemonPcied.py
@@ -59,18 +59,23 @@ pcie_device_list = \
 
 pcie_check_result_no = []
 
-pcie_check_result_pass = \
-"""
-[{'bus': '00', 'dev': '01', 'fn': '0', 'id': '1f10', 'name': 'PCI A', 'result': 'Passed'},
+pcie_check_result_pass = [{'bus': '00', 'dev': '01', 'fn': '0', 'id': '1f10', 'name': 'PCI A', 'result': 'Passed'},
  {'bus': '00', 'dev': '02', 'fn': '0', 'id': '1f11', 'name': 'PCI B', 'result': 'Passed'},
  {'bus': '00', 'dev': '03', 'fn': '0', 'id': '1f12', 'name': 'PCI C', 'result': 'Passed'}]
-"""
 
-pcie_check_result_fail = \
-"""
-[{'bus': '00', 'dev': '01', 'fn': '0', 'id': '1f10', 'name': 'PCI A', 'result': 'Passed'},
+
+pcie_check_result_fail = [{'bus': '00', 'dev': '01', 'fn': '0', 'id': '1f10', 'name': 'PCI A', 'result': 'Passed'},
  {'bus': '00', 'dev': '02', 'fn': '0', 'id': '1f11', 'name': 'PCI B', 'result': 'Passed'},
  {'bus': '00', 'dev': '03', 'fn': '0', 'id': '1f12', 'name': 'PCI C', 'result': 'Failed'}]
+
+
+TEST_PLATFORM_PCIE_YAML_FILE = \
+"""
+- bus: '00'
+  dev: '01'
+  fn: '0'
+  id: '9170'
+  name: 'PCI A'
 """
 
 class TestDaemonPcied(object):
@@ -142,6 +147,125 @@ class TestDaemonPcied(object):
 
         daemon_pcied.run()
         assert daemon_pcied.check_pcie_devices.call_count == 1
+
+    @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
+    def test_check_pcie_devices_yaml_file_open_error(self):
+        daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
+        pcied.platform_pcieutil.get_pcie_check = mock.MagicMock()
+
+        daemon_pcied.check_pcie_devices()
+
+        assert pcied.platform_pcieutil.get_pcie_check.called
+
+
+    @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
+    def test_check_pcie_devices_result_fail(self):
+        daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
+        pcied.platform_pcieutil.get_pcie_check = mock.MagicMock(return_value=pcie_check_result_fail)
+
+        daemon_pcied.check_pcie_devices()
+
+        assert pcied.platform_pcieutil.get_pcie_check.called
+
+    @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
+    def test_check_pcie_devices_result_pass(self):
+        daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
+        pcied.platform_pcieutil.get_pcie_check = mock.MagicMock(return_value=pcie_check_result_pass)
+
+        daemon_pcied.check_pcie_devices()
+
+        assert pcied.platform_pcieutil.get_pcie_check.called
+
+    @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
+    def test_check_pcie_devices_result_none(self):
+        daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
+        pcied.platform_pcieutil.get_pcie_check = mock.MagicMock(return_value=None)
+
+        daemon_pcied.check_pcie_devices()
+
+        assert pcied.platform_pcieutil.get_pcie_check.called
+
+    @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
+    def test_check_pcie_devices_load_yaml_happy(self):
+        daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
+
+        with mock.patch('builtins.open', new_callable=mock.mock_open, read_data=TEST_PLATFORM_PCIE_YAML_FILE) as mock_fd:
+
+            class MockOutput:
+                def decode(self, encodingType):
+                    return self
+                def rstrip(self):
+                    return "9170"
+
+            mock_output = MockOutput()
+            with mock.patch('subprocess.check_output', mock.MagicMock()) as mock_check_output:
+                mock_check_output.return_value = mock_output
+
+                daemon_pcied.check_pcie_devices()
+
+                assert mock_check_output.called
+    
+    @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
+    def test_check_pcie_devices_load_yaml_mismatch(self):
+        daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
+
+        with mock.patch('builtins.open', new_callable=mock.mock_open, read_data=TEST_PLATFORM_PCIE_YAML_FILE) as mock_fd:
+
+            class MockOutput:
+                def decode(self, encodingType):
+                    return self
+                def rstrip(self):
+                    return "0123"
+
+            mock_output = MockOutput()
+            with mock.patch('subprocess.check_output', mock.MagicMock()) as mock_check_output:
+                mock_check_output.return_value = mock_output
+
+                daemon_pcied.check_pcie_devices()
+
+                assert mock_check_output.called
+
+    @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
+    def test_check_pcie_devices_load_yaml_missing_device(self):
+        daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
+
+        with mock.patch('builtins.open', new_callable=mock.mock_open, read_data=TEST_PLATFORM_PCIE_YAML_FILE) as mock_fd:
+
+            class MockOutput:
+                def decode(self, encodingType):
+                    return self
+                def rstrip(self):
+                    return "ffff"
+
+            mock_output = MockOutput()
+            with mock.patch('subprocess.check_output', mock.MagicMock()) as mock_check_output:
+                mock_check_output.return_value = mock_output
+
+                daemon_pcied.check_pcie_devices()
+
+                assert mock_check_output.called
+
+    @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
+    def test_check_pcie_devices_load_yaml_invalid_device(self):
+        daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
+
+        with mock.patch('builtins.open', new_callable=mock.mock_open, read_data=TEST_PLATFORM_PCIE_YAML_FILE) as mock_fd:
+
+            class MockOutput:
+                def decode(self, encodingType):
+                    return self
+                def rstrip(self):
+                    return "No devices selected"
+
+            mock_output = MockOutput()
+            with mock.patch('subprocess.check_output', mock.MagicMock()) as mock_check_output:
+                mock_check_output.return_value = mock_output
+
+                daemon_pcied.check_pcie_devices()
+
+                assert mock_check_output.called
+
+
 
     @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
     def test_check_pcie_devices(self):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Added code to carry out PCI transactions with all the peripherals on the device. This is to determine if there are any unreachable devices on the PCIe bus. The gold list of PCI peripherals is a static file that varies depending on the platform. BDF information is parsed from this YAML file. Transactions are then carried out to determine the health of each peripheral.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

Fixes: Generate syslog alert for missing PCIe devices

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Manually disabled a PCI peripheral and verified that the code changes were able to pick it up:

```
admin@str-s6000-on-6:~$ lspci -tv
-[0000:00]-+-00.0  Intel Corporation Atom Processor S1200 Internal
           +-01.0-[01]----00.0  Broadcom Inc. and subsidiaries Broadcom BCM56850 Switch ASIC
           +-02.0-[02]----00.0  Marvell Technology Group Ltd. Device 9170
           +-03.0-[03-07]----00.0-[04-07]--+-01.0-[05]--
           |                               +-02.0-[06]--
           |                               \-03.0-[07]--+-00.0  Pericom Semiconductor PI7C9X442SL USB OHCI Controller
           |                                            +-00.1  Pericom Semiconductor PI7C9X442SL USB OHCI Controller
           |                                            \-00.2  Pericom Semiconductor PI7C9X442SL USB EHCI Controller
           +-04.0-[08]----00.0  Intel Corporation 82574L Gigabit Network Connection
           +-0e.0  Intel Corporation Atom Processor S1200 Internal
           +-13.0  Intel Corporation Atom Processor S1200 SMBus 2.0 Controller 0
           +-13.1  Intel Corporation Atom Processor S1200 SMBus 2.0 Controller 1
           +-14.0  Intel Corporation Atom Processor S1200 UART
           \-1f.0  Intel Corporation Atom Processor S1200 Integrated Legacy Bus
admin@str-s6000-on-6:~$ 
admin@str-s6000-on-6:~$ 
admin@str-s6000-on-6:~$ setpci -s 0000:00:01.0 BRIDGE_CONTROL
0013
admin@str-s6000-on-6:~$ sudo setpci -s 0000:00:01.0 BRIDGE_CONTROL=0053
admin@str-s6000-on-6:~$ 
admin@str-s6000-on-6:~$ 
admin@str-s6000-on-6:~$ lspci -tv
-[0000:00]-+-00.0  Intel Corporation Atom Processor S1200 Internal
           +-01.0-[01]----00.0  Broadcom Inc. and subsidiaries Broadcom BCM56850 Switch ASIC (ACTUALLY MISSING)
           +-02.0-[02]----00.0  Marvell Technology Group Ltd. Device 9170
           +-03.0-[03-07]----00.0-[04-07]--+-01.0-[05]--
           |                               +-02.0-[06]--
           |                               \-03.0-[07]--+-00.0  Pericom Semiconductor PI7C9X442SL USB OHCI Controller
           |                                            +-00.1  Pericom Semiconductor PI7C9X442SL USB OHCI Controller
           |                                            \-00.2  Pericom Semiconductor PI7C9X442SL USB EHCI Controller
           +-04.0-[08]----00.0  Intel Corporation 82574L Gigabit Network Connection
           +-0e.0  Intel Corporation Atom Processor S1200 Internal
           +-13.0  Intel Corporation Atom Processor S1200 SMBus 2.0 Controller 0
           +-13.1  Intel Corporation Atom Processor S1200 SMBus 2.0 Controller 1
           +-14.0  Intel Corporation Atom Processor S1200 UART
           \-1f.0  Intel Corporation Atom Processor S1200 Integrated Legacy Bus
admin@str-s6000-on-6:~$ lspci -v -s 0000:01:00.0
01:00.0 Ethernet controller: Broadcom Inc. and subsidiaries Broadcom BCM56850 Switch ASIC (rev ff) (prog-if ff)
        !!! Unknown header type 7f
        Kernel driver in use: linux-kernel-bde
        Kernel modules: linux_kernel_bde

admin@str-s6000-on-6:~$ setpci -s 0000:01:00.0 0.l
ffffffff
admin@str-s6000-on-6:~$ 




pcied logs:

Mar  8 03:34:10.205062 str-s6000-acs-12 INFO pmon#supervisord 2023-03-08 03:34:10,202 INFO spawned: 'pcied' with pid 921
Mar  8 03:34:11.363019 str-s6000-acs-12 NOTICE pmon#pcied[921]: Failed to load platform Pcie module. Error : No module named 'sonic_platform.pcie', Fallback to default module
Mar  8 03:34:20.238683 str-s6000-acs-12 INFO pmon#supervisord 2023-03-08 03:34:20,236 INFO success: pcied entered RUNNING state, process has stayed up for > than 10 seconds (startsecs)
Mar  8 03:35:11.650058 str-s6000-acs-12 ERR pmon#pcied[921]: PCIe device 01:00.0 missing.
Mar  8 03:36:12.067868 str-s6000-acs-12 ERR pmon#pcied[921]: PCIe device 01:00.0 missing.
Mar  8 03:37:12.568690 str-s6000-acs-12 ERR pmon#pcied[921]: PCIe device 01:00.0 missing.

```

#### Additional Information (Optional)
