### PR TITLE
add data for telemtery enhancement for 'active-active' cable type

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5529,8 +5529,9 @@ class TestYCableScript(object):
 
 
         response = Response_Helper()
+        port = "Ethernet4"
         
-        rc = parse_grpc_response_forwarding_state(False, None, 0)
+        rc = parse_grpc_response_forwarding_state(False, None, 0, port)
         assert(rc == ("unknown", "unknown"))
 
 
@@ -5543,8 +5544,9 @@ class TestYCableScript(object):
 
 
         response = Response_Helper()
+        port = "Ethernet4"
         
-        rc = parse_grpc_response_forwarding_state(True, response, 0)
+        rc = parse_grpc_response_forwarding_state(True, response, 0, port)
         assert(rc == ("active", "standby"))
 
 
@@ -5557,8 +5559,9 @@ class TestYCableScript(object):
 
 
         response = Response_Helper()
+        port = "Ethernet4"
         
-        rc = parse_grpc_response_forwarding_state(True, response, 0)
+        rc = parse_grpc_response_forwarding_state(True, response, 0, port)
         assert(rc == ("active", "active"))
 
 
@@ -5571,8 +5574,9 @@ class TestYCableScript(object):
 
 
         response = Response_Helper()
+        port = "Ethernet4"
         
-        rc = parse_grpc_response_forwarding_state(True, response, 1)
+        rc = parse_grpc_response_forwarding_state(True, response, 1, port)
         assert(rc == ("standby", "active"))
 
 
@@ -5585,8 +5589,9 @@ class TestYCableScript(object):
 
 
         response = Response_Helper()
+        port = "Ethernet4"
         
-        rc = parse_grpc_response_forwarding_state(True, response, 1)
+        rc = parse_grpc_response_forwarding_state(True, response, 1, port)
         assert(rc == ("active", "active"))
 
 
@@ -5599,8 +5604,9 @@ class TestYCableScript(object):
 
 
         response = Response_Helper()
+        port = "Ethernet4"
         
-        rc = parse_grpc_response_forwarding_state(True, response, 1)
+        rc = parse_grpc_response_forwarding_state(True, response, 1, port)
         assert(rc == ("active", "active"))
 
 
@@ -5613,8 +5619,9 @@ class TestYCableScript(object):
 
 
         response = Response_Helper()
+        port = "Ethernet4"
         
-        rc = parse_grpc_response_forwarding_state(True, response, 1)
+        rc = parse_grpc_response_forwarding_state(True, response, 1, port)
         assert(rc == ("standby", "active"))
 
 
@@ -5627,8 +5634,9 @@ class TestYCableScript(object):
 
 
         response = Response_Helper()
+        port = "Ethernet4"
         
-        rc = parse_grpc_response_forwarding_state(True, response, 0)
+        rc = parse_grpc_response_forwarding_state(True, response, 0, port)
         assert(rc == ("standby", "active"))
 
 
@@ -5641,8 +5649,9 @@ class TestYCableScript(object):
 
 
         response = Response_Helper()
+        port = "Ethernet4"
         
-        rc = parse_grpc_response_forwarding_state(True, response, 1)
+        rc = parse_grpc_response_forwarding_state(True, response, 1, port)
         assert(rc == ("standby", "standby"))
 
 
@@ -5655,8 +5664,9 @@ class TestYCableScript(object):
 
 
         response = Response_Helper()
+        port = "Ethernet4"
         
-        rc = parse_grpc_response_forwarding_state(True, response, 0)
+        rc = parse_grpc_response_forwarding_state(True, response, 0, port)
         assert(rc == ("standby", "standby"))
 
 
@@ -5669,8 +5679,9 @@ class TestYCableScript(object):
 
 
         response = Response_Helper()
+        port = "Ethernet4"
         
-        rc = parse_grpc_response_forwarding_state(True, response, 0)
+        rc = parse_grpc_response_forwarding_state(True, response, 0, port)
         assert(rc == ("active", "active"))
 
 
@@ -5798,25 +5809,3 @@ class TestYCableScript(object):
             patched_util.return_value = parsed_data
             rc = apply_grpc_secrets_configuration(None)
             assert(rc == None)
-
-
-
-    def test_handle_ycable_active_standby_probe_notification(self):
-
-        test_db = "TEST_DB"
-        status = True
-        port_m = "Ethernet0"
-        fvp_m = [('command', "probe"), ('read_side', 1), ('cable_type','active-standby'), ('soc_ipv4','192.168.0.1')]
-        fvp_dict = {"command": "probe"}
-        hw_mux_cable_tbl = {}
-        y_cable_response_tbl = {}
-        asic_index = 0
-        hw_mux_cable_tbl[asic_index] = swsscommon.Table(
-            test_db[asic_index], "PORT_INFO_TABLE")
-        y_cable_response_tbl[asic_index] = swsscommon.Table(
-            test_db[asic_index], "PORT_INFO_TABLE")
-        hw_mux_cable_tbl[asic_index].get.return_value = (status, fvp_m)
-
-        rc = handle_ycable_active_standby_probe_notification("active-standby", fvp_dict, test_db, hw_mux_cable_tbl, port_m, asic_index, y_cable_response_tbl)
-        assert(rc == True)
-

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -6008,6 +6008,6 @@ class TestYCableScript(object):
         rc = get_muxcable_info_for_active_active(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
         assert(rc['self_mux_direction'] == 'unknown')
-        assert(rc['peer_mux_direction'] == 'uknown')
+        assert(rc['peer_mux_direction'] == 'unknown')
         assert(rc['mux_direction_probe_count'] == 'unknown')
         assert(rc['peer_mux_direction_probe_count'] == 'unknown')

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5988,3 +5988,26 @@ class TestYCableScript(object):
         
         rc = parse_grpc_response_link_and_oper_state(True, response, 0, "link_state", "Ethernet4")
         assert(rc == ("up", "up"))
+        
+    def test_get_muxcable_info_for_active_active(self):
+        physical_port = 20
+
+        logical_port_name = "Ethernet20"
+        swsscommon.Table.return_value.get.return_value = (
+            True, {"read_side": "1"})
+        asic_index = 0
+        y_cable_tbl = {}
+        mux_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+
+        rc = get_muxcable_info_for_active_active(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
+
+        assert(rc['self_mux_direction'] == 'unknown')
+        assert(rc['peer_mux_direction'] == 'uknown')
+        assert(rc['mux_direction_probe_count'] == 'unknown')
+        assert(rc['peer_mux_direction_probe_count'] == 'unknown')

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5910,3 +5910,81 @@ class TestYCableScript(object):
         
         rc = parse_grpc_response_link_and_oper_state(True, response, 0, "oper_state", "Ethernet4")
         assert(rc == ("up", "up"))
+        
+    def test_parse_grpc_response_link_and_oper_state_down_down_read_side_zero_unknown(self):
+
+        class Response_Helper():
+            def __init__(self):
+                self.portid = [0,1]
+                self.state = [False,False]
+
+
+        response = Response_Helper()
+        
+        rc = parse_grpc_response_link_and_oper_state(False, response, 0, "oper_state", "Ethernet4")
+        assert(rc == ("unknown", "unknown"))
+
+    def test_parse_grpc_response_link_and_oper_state_up_down_read_side_zero(self):
+
+        class Response_Helper():
+            def __init__(self):
+                self.portid = [0]
+                self.state = [False]
+
+
+        response = Response_Helper()
+        
+        rc = parse_grpc_response_link_and_oper_state(True, response, 0, "oper_state", "Ethernet4")
+        assert(rc == ("unknown", "unknown"))
+
+    def test_parse_grpc_response_link_and_oper_state_up_up_read_side_zero(self):
+
+        class Response_Helper():
+            def __init__(self):
+                self.portid = [0,1]
+                self.state = [True]
+
+
+        response = Response_Helper()
+        
+        rc = parse_grpc_response_link_and_oper_state(True, response, 0, "link_state", "Ethernet4")
+        assert(rc == ("unknown", "unknown"))
+        
+    def test_parse_grpc_response_link_and_oper_state_down_down_read_side_zero_link_state(self):
+
+        class Response_Helper():
+            def __init__(self):
+                self.portid = [0,1]
+                self.state = [False,False]
+
+
+        response = Response_Helper()
+        
+        rc = parse_grpc_response_link_and_oper_state(True, response, 0, "link_state", "Ethernet4")
+        assert(rc == ("down", "down"))
+
+    def test_parse_grpc_response_link_and_oper_state_up_down_read_side_zero_link_state(self):
+
+        class Response_Helper():
+            def __init__(self):
+                self.portid = [0,1]
+                self.state = [True,False]
+
+
+        response = Response_Helper()
+        
+        rc = parse_grpc_response_link_and_oper_state(True, response, 0, "link_state", "Ethernet4")
+        assert(rc == ("up", "down"))
+
+    def test_parse_grpc_response_link_and_oper_state_up_up_read_side_zero_link_state(self):
+
+        class Response_Helper():
+            def __init__(self):
+                self.portid = [0,1]
+                self.state = [True, True]
+
+
+        response = Response_Helper()
+        
+        rc = parse_grpc_response_link_and_oper_state(True, response, 0, "link_state", "Ethernet4")
+        assert(rc == ("up", "up"))

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5694,8 +5694,9 @@ class TestYCableScript(object):
 
 
         response = Response_Helper()
+        port = "Ethernet4"
         
-        rc = parse_grpc_response_forwarding_state(True, response, 1)
+        rc = parse_grpc_response_forwarding_state(True, response, 1, port)
         assert(rc == ("standby", "standby"))
 
 
@@ -5809,3 +5810,103 @@ class TestYCableScript(object):
             patched_util.return_value = parsed_data
             rc = apply_grpc_secrets_configuration(None)
             assert(rc == None)
+
+
+
+    def test_handle_ycable_active_standby_probe_notification(self):
+
+        test_db = "TEST_DB"
+        status = True
+        port_m = "Ethernet0"
+        fvp_m = [('command', "probe"), ('read_side', 1), ('cable_type','active-standby'), ('soc_ipv4','192.168.0.1')]
+        fvp_dict = {"command": "probe"}
+        hw_mux_cable_tbl = {}
+        y_cable_response_tbl = {}
+        asic_index = 0
+        hw_mux_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        y_cable_response_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        hw_mux_cable_tbl[asic_index].get.return_value = (status, fvp_m)
+
+        rc = handle_ycable_active_standby_probe_notification("active-standby", fvp_dict, test_db, hw_mux_cable_tbl, port_m, asic_index, y_cable_response_tbl)
+        assert(rc == True)
+
+
+    def test_parse_grpc_response_link_and_oper_state_down_down(self):
+
+        class Response_Helper():
+            def __init__(self):
+                self.portid = [0,1]
+                self.state = [False,False]
+
+
+        response = Response_Helper()
+        
+        rc = parse_grpc_response_link_and_oper_state(True, response, 1, "oper_state", "Ethernet4")
+        assert(rc == ("down", "down"))
+
+    def test_parse_grpc_response_link_and_oper_state_up_down(self):
+
+        class Response_Helper():
+            def __init__(self):
+                self.portid = [0,1]
+                self.state = [True,False]
+
+
+        response = Response_Helper()
+        
+        rc = parse_grpc_response_link_and_oper_state(True, response, 1, "oper_state", "Ethernet4")
+        assert(rc == ("down", "up"))
+
+    def test_parse_grpc_response_link_and_oper_state_up_up(self):
+
+        class Response_Helper():
+            def __init__(self):
+                self.portid = [0,1]
+                self.state = [True, True]
+
+
+        response = Response_Helper()
+        
+        rc = parse_grpc_response_link_and_oper_state(True, response, 1, "oper_state", "Ethernet4")
+        assert(rc == ("up", "up"))
+        
+    def test_parse_grpc_response_link_and_oper_state_down_down_read_side_zero(self):
+
+        class Response_Helper():
+            def __init__(self):
+                self.portid = [0,1]
+                self.state = [False,False]
+
+
+        response = Response_Helper()
+        
+        rc = parse_grpc_response_link_and_oper_state(True, response, 0, "oper_state", "Ethernet4")
+        assert(rc == ("down", "down"))
+
+    def test_parse_grpc_response_link_and_oper_state_up_down_read_side_zero(self):
+
+        class Response_Helper():
+            def __init__(self):
+                self.portid = [0,1]
+                self.state = [True,False]
+
+
+        response = Response_Helper()
+        
+        rc = parse_grpc_response_link_and_oper_state(True, response, 0, "oper_state", "Ethernet4")
+        assert(rc == ("up", "down"))
+
+    def test_parse_grpc_response_link_and_oper_state_up_up_read_side_zero(self):
+
+        class Response_Helper():
+            def __init__(self):
+                self.portid = [0,1]
+                self.state = [True, True]
+
+
+        response = Response_Helper()
+        
+        rc = parse_grpc_response_link_and_oper_state(True, response, 0, "oper_state", "Ethernet4")
+        assert(rc == ("up", "up"))

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -910,7 +910,11 @@ def toggle_mux_tor_direction_and_update_read_side(state, logical_port_name, phys
         helper_logger.log_error("Error: Could not get port instance for read side for while processing a toggle Y cable port {} {}".format(physical_port, threading.currentThread().getName()))
         return (-1, -1)
 
-    read_side = port_instance.get_read_side()
+    try:
+        read_side = port_instance.get_read_side()
+    except Exception as e:
+        read_side = None
+        helper_logger.log_warning("Failed to execute the get_read_side API for port {} due to {} from update_read_side".format(logical_port_name,repr(e)))
 
     if read_side is None or read_side is port_instance.EEPROM_ERROR or read_side < 0:
         helper_logger.log_error(
@@ -2031,7 +2035,13 @@ def get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_c
                 mux_info_dict["link_status_peer"] = "down"
 
     with y_cable_port_locks[physical_port]:
-        if port_instance.is_link_active(port_instance.TARGET_NIC):
+        try:
+            link_state_tor_nic = port_instance.is_link_active(port_instance.TARGET_NIC)
+        except Exception as e:
+            link_state_tor_nic = False
+            helper_logger.log_warning("Failed to execute the is_link_active NIC side API for port {} due to {}".format(physical_port,repr(e)))
+
+        if link_state_tor_nic:
             mux_info_dict["link_status_nic"] = "up"
         else:
             mux_info_dict["link_status_nic"] = "down"
@@ -3210,7 +3220,7 @@ def handle_config_hwmode_state_cmd_arg_tbl_notification(fvp, xcvrd_config_hwmode
                         status = -1
                         helper_logger.log_warning("Failed to execute the toggle mux ToR A API for port {} due to {}".format(physical_port,repr(e)))
         else:
-            set_result_and_delete_port('result', status, xcvrd_show_hwmode_state_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_state_rsp_tbl[asic_index], port)
+            set_result_and_delete_port('result', status, xcvrd_config_hwmode_state_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_state_rsp_tbl[asic_index], port)
             helper_logger.log_error(
                 "Error: Could not get valid config read side for cli command config mux hwmode state active/standby Y cable port {}".format(port))
             return -1

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -46,6 +46,10 @@ y_cable_is_platform_vs = None
 grpc_port_channels = {}
 # Global port channel stubs for gRPC RPC's
 grpc_port_stubs = {}
+# Global port channel connectivity for gRPC RPC's
+grpc_port_connectivity = {}
+# Global port statistics for gRPC RPC's
+grpc_port_stats = {}
 
 GRPC_PORT = 50075
 
@@ -490,19 +494,24 @@ def create_channel(type, level, kvp, soc_ip, port):
             # for connectivity state to FAILURE/IDLE report a failure
             fvs_updated = swsscommon.FieldValuePairs([('response', 'failure')])
             fwd_state_response_tbl[asic_index].set(port, fvs_updated)
+            grpc_port_connectivity[port] = "TRANSIENT_FAILURE"
 
         if channel_connectivity == grpc.ChannelConnectivity.CONNECTING:
             helper_logger.log_notice("gRPC port {} state changed to CONNECTING".format(port))
+            grpc_port_connectivity[port] = "CONNECTING"
         if channel_connectivity == grpc.ChannelConnectivity.READY:
             helper_logger.log_notice("gRPC port {} state changed to READY".format(port))
+            grpc_port_connectivity[port] = "READY"
         if channel_connectivity == grpc.ChannelConnectivity.IDLE:
             helper_logger.log_notice("gRPC port {} state changed to IDLE".format(port))
             # for connectivity state to FAILURE/IDLE report a failure
             fvs_updated = swsscommon.FieldValuePairs([('response', 'failure')])
             fwd_state_response_tbl[asic_index].set(port, fvs_updated) 
+            grpc_port_connectivity[port] = "IDLE"
 
         if channel_connectivity == grpc.ChannelConnectivity.SHUTDOWN:
             helper_logger.log_notice("gRPC port {} state changed to SHUTDOWN".format(port))
+            grpc_port_connectivity[port] = "SHUTDOWN"
 
 
     if type == "secure": 
@@ -607,7 +616,7 @@ def put_init_values_for_grpc_states(port, read_side, hw_mux_cable_tbl, hw_mux_ca
         return
 
     ret, response = try_grpc(stub.QueryAdminForwardingPortState, QUERY_ADMIN_FORWARDING_TIMEOUT, request)
-    (self_state, peer_state) = parse_grpc_response_forwarding_state(ret, response, read_side)
+    (self_state, peer_state) = parse_grpc_response_forwarding_state(ret, response, read_side, port)
     if response is not None:
         # Debug only, remove this section once Server side is Finalized
         fwd_response_port_ids = response.portid
@@ -1384,6 +1393,7 @@ def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presen
                 check_identifier_presence_and_update_mux_table_entry(
                     state_db, port_tbl, hw_mux_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name, y_cable_presence)
             if status and cable_type == "active-active":
+                grpc_port_stats[logical_port_name] = {}
                 check_identifier_presence_and_setup_channel(
                     logical_port_name, port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence)
         else:
@@ -1660,7 +1670,7 @@ def get_muxcable_static_info_without_presence():
 
     return mux_info_static_dict
 
-def parse_grpc_response_link_and_oper_state(ret, response, read_side, query_type):
+def parse_grpc_response_link_and_oper_state(ret, response, read_side, query_type, port):
     self_state = peer_state = 'unknown'
 
     if ret is True and response is not None:
@@ -1695,6 +1705,25 @@ def parse_grpc_response_link_and_oper_state(ret, response, read_side, query_type
         self_state = 'unknown'
         peer_state = 'unknown'
 
+    stat = grpc_port_stats.get(port,None)
+    if stat is not None:
+
+        if query_type == "link_state":
+            grpc_port_stats[port]["link_state_probe_count"] = str(int(stat.get("link_state_probe_count", 0)) + 1 )
+            grpc_port_stats[port]["peer_link_state_probe_count"] = str(int(stat.get("peer_link_state_probe_count", 0)) + 1 )
+        elif query_type == "oper_state":
+            grpc_port_stats[port]["operation_state_probe_count"] = str(int(stat.get("operation_state_probe_count", 0)) + 1 )
+            grpc_port_stats[port]["peer_operation_state_probe_count"] = str(int(stat.get("peer_operation_state_probe_count", 0)) + 1 )
+    else:
+        grpc_port_stats[port] = {}
+        if query_type == "link_state":
+            grpc_port_stats[port]["link_state_probe_count"] = 0
+            grpc_port_stats[port]["peer_link_state_probe_count"] = 0
+        elif query_type == "oper_state":
+            grpc_port_stats[port]["operation_state_probe_count"] = 0
+            grpc_port_stats[port]["peer_operation_state_probe_count"] = 0
+
+
     return (self_state, peer_state)
 
 
@@ -1703,6 +1732,7 @@ def get_muxcable_info_for_active_active(physical_port, port, mux_tbl, asic_index
     mux_info_dict = {}
 
     time_post = datetime.datetime.utcnow().strftime("%Y-%b-%d %H:%M:%S.%f")
+    mux_info_dict["time_post"] = str(time_post)
 
     (status, fvs) = y_cable_tbl[asic_index].get(port)
     if status is False:
@@ -1712,6 +1742,24 @@ def get_muxcable_info_for_active_active(physical_port, port, mux_tbl, asic_index
     mux_port_dict = dict(fvs)
     read_side = int(mux_port_dict.get("read_side"))
 
+    stat = grpc_port_stats.get(port, None)
+    if stat is not None:
+        mux_info_dict['mux_direction_probe_count'] = grpc_port_stats[port].get("mux_direction_probe_count", "unknown")
+        mux_info_dict['peer_mux_direction_probe_count'] = grpc_port_stats[port].get("peer_mux_direction_probe_count", "unknown")
+        mux_info_dict['link_state_probe_count'] = grpc_port_stats[port].get("link_state_probe_count", "unknown")
+        mux_info_dict['peer_link_state_probe_count'] = grpc_port_stats[port].get("peer_link_state_probe_count", "unknown")
+        mux_info_dict['operation_state_probe_count'] = grpc_port_stats[port].get("operation_state_probe_count", "unknown")
+        mux_info_dict['peer_operation_state_probe_count'] = grpc_port_stats[port].get("peer_operation_state_probe_count", "unknown")
+    else:
+        mux_info_dict['mux_direction_probe_count'] = "unknown"
+        mux_info_dict['peer_mux_direction_probe_count'] = "unknown"
+        mux_info_dict['link_state_probe_count'] = "unknown"
+        mux_info_dict['peer_link_state_probe_count'] = "unknown"
+        mux_info_dict['operation_state_probe_count'] = "unknown"
+        mux_info_dict['peer_operation_state_probe_count'] = "unknown"
+
+
+
     stub = grpc_port_stubs.get(port, None)
     if stub is None:
         #Can't make any RPC gRPC for this port, fill everything as unknown except cached values
@@ -1720,6 +1768,9 @@ def get_muxcable_info_for_active_active(physical_port, port, mux_tbl, asic_index
         mux_info_dict['self_oper_state'] = "unknown"
         mux_info_dict['peer_oper_state'] = "unknown"
         mux_info_dict['server_version'] = "N/A"
+        mux_info_dict['self_mux_direction'] = "unknown"
+        mux_info_dict['peer_mux_direction'] = "unknown"
+        mux_info_dict['grpc_connection_status'] = "unknown"
         return mux_info_dict
 
 
@@ -1727,7 +1778,7 @@ def get_muxcable_info_for_active_active(physical_port, port, mux_tbl, asic_index
 
     ret, response = try_grpc(stub.QueryLinkState, QUERY_ADMIN_FORWARDING_TIMEOUT , request)
 
-    (self_link_state, peer_link_state) = parse_grpc_response_link_and_oper_state(ret, response, read_side, "link_state")
+    (self_link_state, peer_link_state) = parse_grpc_response_link_and_oper_state(ret, response, read_side, "link_state", port)
 
     mux_info_dict['self_link_state'] = self_link_state
     mux_info_dict['peer_link_state'] = peer_link_state
@@ -1736,19 +1787,34 @@ def get_muxcable_info_for_active_active(physical_port, port, mux_tbl, asic_index
 
     ret, response = try_grpc(stub.QueryOperationPortState, QUERY_ADMIN_FORWARDING_TIMEOUT , request)
 
-    (self_oper_state, peer_oper_state) = parse_grpc_response_link_and_oper_state(ret, response, read_side, "oper_state")
+    (self_oper_state, peer_oper_state) = parse_grpc_response_link_and_oper_state(ret, response, read_side, "oper_state", port)
 
     mux_info_dict['self_oper_state'] = self_oper_state
     mux_info_dict['peer_oper_state'] = peer_oper_state
 
+    request = linkmgr_grpc_driver_pb2.AdminRequest(portid=DEFAULT_PORT_IDS, state=[0, 0])
+
+    ret, response = try_grpc(stub.QueryAdminForwardingPortState, QUERY_ADMIN_FORWARDING_TIMEOUT , request)
+
+    (self_state, peer_state) = parse_grpc_response_forwarding_state(ret, response, read_side, port)
+
+    mux_info_dict['self_mux_direction'] = self_state
+    mux_info_dict['peer_mux_direction'] = peer_state
+
     request = linkmgr_grpc_driver_pb2.ServerVersionRequest(version="1.0")
 
     ret, response = try_grpc(stub.QueryServerVersion, QUERY_ADMIN_FORWARDING_TIMEOUT , request)
+
     if ret is True:
         version = response.version
     else:
         version = "N/A"
+
     mux_info_dict['server_version'] = version
+
+    grpc_connection_status = grpc_port_connectivity.get(port, "unknown")
+
+    mux_info_dict['grpc_connection_status'] = grpc_connection_status
 
     return mux_info_dict
 
@@ -1785,10 +1851,6 @@ def get_muxcable_info_without_presence():
     mux_info_dict['version_nic_next'] = 'N/A'
 
     return mux_info_dict
-
-
-
-
 
 def get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl):
 
@@ -2162,9 +2224,31 @@ def post_port_mux_info_to_db(logical_port_name, mux_tbl, asic_index, y_cable_tbl
 
         if not y_cable_wrapper_get_presence(physical_port):
             mux_info_dict = get_muxcable_info_without_presence()
-        elif cable_type == 'active-active'
+        elif cable_type == 'active-active':
             helper_logger.log_warning("Error: trying to post mux info without presence of port {}".format(logical_port_name))
             mux_info_dict = get_muxcable_info_for_active_active(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
+            if mux_info_dict is not None and mux_info_dict !=  -1:
+                fvs = swsscommon.FieldValuePairs(
+                    [('self_link_state',  mux_info_dict["self_link_state"]),
+                     ('peer_link_state',  str(mux_info_dict["peer_link_state"])),
+                     ('self_oper_state', str(mux_info_dict["self_oper_state"])),
+                     ('peer_oper_state', str(mux_info_dict["peer_oper_state"])),
+                     ('server_version', str(mux_info_dict["server_version"])),
+                     ('time_post',  str(mux_info_dict["time_post"])),
+                     ('self_mux_direction',  str(mux_info_dict["self_mux_direction"])),
+                     ('peer_mux_direction',  str(mux_info_dict["peer_mux_direction"])),
+                     ('peer_mux_direction_probe_count',  str(mux_info_dict["peer_mux_direction_probe_count"])),
+                     ('mux_direction_probe_count',  str(mux_info_dict["mux_direction_probe_count"])),
+                     ('link_state_probe_count',  str(mux_info_dict["link_state_probe_count"])),
+                     ('peer_link_state_probe_count',  str(mux_info_dict["peer_link_state_probe_count"])),
+                     ('operation_state_probe_count',  str(mux_info_dict["operation_state_probe_count"])),
+                     ('peer_operation_state_probe_count',  str(mux_info_dict["peer_operation_state_probe_count"])),
+                     ('grpc_connection_status',  str(mux_info_dict["grpc_connection_status"]))
+                     ])
+                mux_tbl[asic_index].set(logical_port_name, fvs)
+                return
+            else:
+                return -1
         else:
             mux_info_dict = get_muxcable_info(physical_port, logical_port_name, mux_tbl, asic_index, y_cable_tbl)
 
@@ -3256,7 +3340,7 @@ def handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, port_tbl, xcvrd_show_
 
             ret, response = try_grpc(stub.QueryAdminForwardingPortState, QUERY_ADMIN_FORWARDING_TIMEOUT , request)
 
-            (self_state, peer_state) = parse_grpc_response_forwarding_state(ret, response, read_side)
+            (self_state, peer_state) = parse_grpc_response_forwarding_state(ret, response, read_side, port)
             state = self_state
             set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
             if response is not None:
@@ -3299,7 +3383,7 @@ def parse_grpc_response_hw_mux_cable_change_state(ret, response, portid, port):
     return state
 
 
-def parse_grpc_response_forwarding_state(ret, response, read_side):
+def parse_grpc_response_forwarding_state(ret, response, read_side, port):
     self_state = peer_state = 'unknown'
 
     if ret is True and response is not None:
@@ -3333,6 +3417,17 @@ def parse_grpc_response_forwarding_state(ret, response, read_side):
     else:
         self_state = 'unknown'
         peer_state = 'unknown'
+
+    stat = grpc_port_stats.get(port,None)
+    if stat is not None:
+        grpc_port_stats[port]["mux_direction_probe_count"] = str(int(stat.get("mux_direction_probe_count", 0)) + 1 )
+        grpc_port_stats[port]["peer_mux_direction_probe_count"] = str(int(stat.get("peer_mux_direction_probe_count", 0)) + 1 )
+    else:
+        grpc_port_stats[port] = {}
+        grpc_port_stats[port]["mux_direction_probe_count"] = 0
+        grpc_port_stats[port]["peer_mux_direction_probe_count"] = 0
+
+    
 
     return (self_state, peer_state)
 
@@ -3378,7 +3473,7 @@ def handle_fwd_state_command_grpc_notification(fvp_m, hw_mux_cable_tbl, fwd_stat
 
             ret, response = try_grpc(stub.QueryAdminForwardingPortState, QUERY_ADMIN_FORWARDING_TIMEOUT, request)
 
-            (self_state, peer_state) = parse_grpc_response_forwarding_state(ret, response, read_side)
+            (self_state, peer_state) = parse_grpc_response_forwarding_state(ret, response, read_side, port)
             if response is not None:
                 # Debug only, remove this section once Server side is Finalized
                 fwd_response_port_ids = response.portid


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
This PR adds logic to add the following gRPC relevant telemetry schema fields in the state DB  table
`MUX_CABLE_INFO`
```
1) "self_link_state"
2) "up"
3) "peer_link_state"
4) "up"
5) "self_oper_state"
6) "up"
7) "peer_oper_state"
8) "up"
9) "server_version"
10) "1.0"
11) "grpc_connection_status"
12) "READY"
13) "self_mux_direction"
14) "active"
15) "peer_mux_direction"
16) "active"
17) "peer_mux_direction_probe_count"
18) "23"
19) "mux_direction_probe_count"
20) "23"
21) "link_state_probe_count"
22) "1"
23) "peer_link_state_probe_count"
24) "1"
25) "operation_state_probe_count"
26) "1"
27) "peer_operation_state_probe_count"
28)"1"
```
This data will allow telemetry to check gRPC stats and version of the server and be able to raise alert if needed appropriatley. 
<!-- Provide a general summary of your changes in the Title above -->

#### Description
gPRC data for telemetry
appropriate logic is added for handling the gRPC stats and RPC's are called and counted as appropriate
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
UT and putting the changes on the testbed
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
