### PR TITLE
[Xcvrd]: Fix optics insertion/removal not detected

### DIFF
--- a/sonic-xcvrd/setup.py
+++ b/sonic-xcvrd/setup.py
@@ -37,7 +37,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.7',
         'Topic :: System :: Hardware',
     ],

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1896,7 +1896,7 @@ class SfpStateUpdateTask(object):
                             self.sfp_error_dict[key] = (value, error_dict)
                         else:
                             self.sfp_error_dict.pop(key, None)
-                        logical_port_list = self.port_mapping.get_physical_to_logical(key)
+                        logical_port_list = self.port_mapping.get_physical_to_logical(int(key))
                         if logical_port_list is None:
                             helper_logger.log_warning("Got unknown FP port index {}, ignored".format(key))
                             continue
@@ -1909,15 +1909,15 @@ class SfpStateUpdateTask(object):
                                 continue
 
                             if value == sfp_status_helper.SFP_STATUS_INSERTED:
-                                helper_logger.log_info("Got SFP inserted event")
+                                helper_logger.log_info("{}: Got SFP inserted event".format(logical_port))
                                 # A plugin event will clear the error state.
                                 update_port_transceiver_status_table_sw(
                                     logical_port, self.xcvr_table_helper.get_status_tbl(asic_index), sfp_status_helper.SFP_STATUS_INSERTED)
-                                helper_logger.log_info("receive plug in and update port sfp status table.")
+                                helper_logger.log_info("{}: received plug in and update port sfp status table.".format(logical_port))
                                 rc = post_port_sfp_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict)
                                 # If we didn't get the sfp info, assuming the eeprom is not ready, give a try again.
                                 if rc == SFP_EEPROM_NOT_READY:
-                                    helper_logger.log_warning("SFP EEPROM is not ready. One more try...")
+                                    helper_logger.log_warning("{}: SFP EEPROM is not ready. One more try...".format(logical_port))
                                     time.sleep(TIME_FOR_SFP_READY_SECS)
                                     rc = post_port_sfp_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict)
                                     if rc == SFP_EEPROM_NOT_READY:
@@ -1932,10 +1932,10 @@ class SfpStateUpdateTask(object):
                                     notify_media_setting(logical_port, transceiver_dict, self.xcvr_table_helper.get_app_port_tbl(asic_index), self.port_mapping)
                                     transceiver_dict.clear()
                             elif value == sfp_status_helper.SFP_STATUS_REMOVED:
-                                helper_logger.log_info("Got SFP removed event")
+                                helper_logger.log_info("{}: Got SFP removed event".format(logical_port))
                                 update_port_transceiver_status_table_sw(
                                     logical_port, self.xcvr_table_helper.get_status_tbl(asic_index), sfp_status_helper.SFP_STATUS_REMOVED)
-                                helper_logger.log_info("receive plug out and pdate port sfp status table.")
+                                helper_logger.log_info("{}: received plug out and update port sfp status table.".format(logical_port))
                                 del_port_sfp_dom_info_from_db(logical_port, self.port_mapping,
                                                               self.xcvr_table_helper.get_intf_tbl(asic_index),
                                                               self.xcvr_table_helper.get_dom_tbl(asic_index),
@@ -1945,7 +1945,7 @@ class SfpStateUpdateTask(object):
                             else:
                                 try:
                                     error_bits = int(value)
-                                    helper_logger.log_info("Got SFP error event {}".format(value))
+                                    helper_logger.log_info("{}: Got SFP error event {}".format(logical_port, value))
 
                                     error_descriptions = sfp_status_helper.fetch_generic_error_description(error_bits)
 
@@ -1959,7 +1959,7 @@ class SfpStateUpdateTask(object):
                                     # Add error info to database
                                     # Any existing error will be replaced by the new one.
                                     update_port_transceiver_status_table_sw(logical_port, self.xcvr_table_helper.get_status_tbl(asic_index), value, '|'.join(error_descriptions))
-                                    helper_logger.log_info("Receive error update port sfp status table.")
+                                    helper_logger.log_info("{}: Receive error update port sfp status table.".format(logical_port))
                                     # In this case EEPROM is not accessible. The DOM info will be removed since it can be out-of-date.
                                     # The interface info remains in the DB since it is static.
                                     if sfp_status_helper.is_error_block_eeprom_reading(error_bits):
@@ -1971,7 +1971,7 @@ class SfpStateUpdateTask(object):
                                                                       self.xcvr_table_helper.get_pm_tbl(asic_index))
                                         delete_port_from_status_table_hw(logical_port, self.port_mapping, self.xcvr_table_helper.get_status_tbl(asic_index))
                                 except (TypeError, ValueError) as e:
-                                    helper_logger.log_error("Got unrecognized event {}, ignored".format(value))
+                                    helper_logger.log_error("{}: Got unrecognized event {}, ignored".format(logical_port, value))
 
                 else:
                     next_state = STATE_EXIT

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1909,11 +1909,11 @@ class SfpStateUpdateTask(object):
                                 continue
 
                             if value == sfp_status_helper.SFP_STATUS_INSERTED:
-                                helper_logger.log_info("{}: Got SFP inserted event".format(logical_port))
+                                helper_logger.log_notice("{}: Got SFP inserted event".format(logical_port))
                                 # A plugin event will clear the error state.
                                 update_port_transceiver_status_table_sw(
                                     logical_port, self.xcvr_table_helper.get_status_tbl(asic_index), sfp_status_helper.SFP_STATUS_INSERTED)
-                                helper_logger.log_info("{}: received plug in and update port sfp status table.".format(logical_port))
+                                helper_logger.log_notice("{}: received plug in and update port sfp status table.".format(logical_port))
                                 rc = post_port_sfp_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict)
                                 # If we didn't get the sfp info, assuming the eeprom is not ready, give a try again.
                                 if rc == SFP_EEPROM_NOT_READY:
@@ -1932,10 +1932,10 @@ class SfpStateUpdateTask(object):
                                     notify_media_setting(logical_port, transceiver_dict, self.xcvr_table_helper.get_app_port_tbl(asic_index), self.port_mapping)
                                     transceiver_dict.clear()
                             elif value == sfp_status_helper.SFP_STATUS_REMOVED:
-                                helper_logger.log_info("{}: Got SFP removed event".format(logical_port))
+                                helper_logger.log_notice("{}: Got SFP removed event".format(logical_port))
                                 update_port_transceiver_status_table_sw(
                                     logical_port, self.xcvr_table_helper.get_status_tbl(asic_index), sfp_status_helper.SFP_STATUS_REMOVED)
-                                helper_logger.log_info("{}: received plug out and update port sfp status table.".format(logical_port))
+                                helper_logger.log_notice("{}: received plug out and update port sfp status table.".format(logical_port))
                                 del_port_sfp_dom_info_from_db(logical_port, self.port_mapping,
                                                               self.xcvr_table_helper.get_intf_tbl(asic_index),
                                                               self.xcvr_table_helper.get_dom_tbl(asic_index),
@@ -1945,7 +1945,7 @@ class SfpStateUpdateTask(object):
                             else:
                                 try:
                                     error_bits = int(value)
-                                    helper_logger.log_info("{}: Got SFP error event {}".format(logical_port, value))
+                                    helper_logger.log_error("{}: Got SFP error event {}".format(logical_port, value))
 
                                     error_descriptions = sfp_status_helper.fetch_generic_error_description(error_bits)
 
@@ -1959,7 +1959,7 @@ class SfpStateUpdateTask(object):
                                     # Add error info to database
                                     # Any existing error will be replaced by the new one.
                                     update_port_transceiver_status_table_sw(logical_port, self.xcvr_table_helper.get_status_tbl(asic_index), value, '|'.join(error_descriptions))
-                                    helper_logger.log_info("{}: Receive error update port sfp status table.".format(logical_port))
+                                    helper_logger.log_notice("{}: Receive error update port sfp status table.".format(logical_port))
                                     # In this case EEPROM is not accessible. The DOM info will be removed since it can be out-of-date.
                                     # The interface info remains in the DB since it is static.
                                     if sfp_status_helper.is_error_block_eeprom_reading(error_bits):

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/port_mapping.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/port_mapping.py
@@ -78,7 +78,8 @@ class PortMapping:
         port_index = self.logical_to_physical.get(port_name)
         return None if port_index is None else [port_index]
 
-    def get_physical_to_logical(self, physical_port):
+    def get_physical_to_logical(self, physical_port: int):
+        assert isinstance(physical_port, int), "{} is NOT integer".format(physical_port)
         return self.physical_to_logical.get(physical_port)
 
     def logical_port_name_to_physical_port_list(self, port_name):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Fixed optics insertion/removal not detected by Xcvrd.

The key to port_mapping.get_physical_to_logical() expects integer. Otherwise, on OIR events, Xcvrd throws the below error and misses processing of OIR events

```
/var/log/syslog.169.gz:Nov 29 19:21:47.275665 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[42]: Got unknown FP port index 29, ignored
/var/log/syslog.169.gz:Nov 29 19:21:52.309169 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[42]: Got unknown FP port index 30, ignored
/var/log/syslog.180.gz:Nov 29 16:30:14.687024 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 11, ignored
/var/log/syslog.180.gz:Nov 29 16:30:24.780574 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 16, ignored
/var/log/syslog.180.gz:Nov 29 16:30:31.850078 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 13, ignored
/var/log/syslog.180.gz:Nov 29 16:30:37.907455 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 10, ignored
/var/log/syslog.180.gz:Nov 29 16:30:55.108639 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 12, ignored
/var/log/syslog.180.gz:Nov 29 16:31:10.284906 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 15, ignored
/var/log/syslog.180.gz:Nov 29 16:31:21.406967 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 14, ignored
/var/log/syslog.180.gz:Nov 29 16:31:27.451387 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 9, ignored
/var/log/syslog.180.gz:Nov 29 16:34:53.750040 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 22, ignored
/var/log/syslog.180.gz:Nov 29 16:35:14.988818 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 23, ignored
/var/log/syslog.180.gz:Nov 29 16:35:26.113949 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 21, ignored
/var/log/syslog.180.gz:Nov 29 16:35:40.273945 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 17, ignored
/var/log/syslog.180.gz:Nov 29 16:36:26.836894 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 19, ignored
/var/log/syslog.180.gz:Nov 29 16:36:44.042048 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 20, ignored
/var/log/syslog.180.gz:Nov 29 16:36:57.170354 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 18, ignored
/var/log/syslog.180.gz:Nov 29 16:37:04.239963 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 24, ignored
/var/log/syslog.181.gz:Nov 29 16:26:31.566368 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 1, ignored
/var/log/syslog.181.gz:Nov 29 16:26:56.867366 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 6, ignored
/var/log/syslog.181.gz:Nov 29 16:27:02.911397 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 3, ignored
/var/log/syslog.181.gz:Nov 29 16:27:07.953958 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 8, ignored
/var/log/syslog.181.gz:Nov 29 16:27:18.060718 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 5, ignored
/var/log/syslog.181.gz:Nov 29 16:27:28.164588 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 2, ignored
/var/log/syslog.181.gz:Nov 29 16:27:37.260823 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 4, ignored
/var/log/syslog.181.gz:Nov 29 16:27:44.331360 3POs-7050CX-T1-H06-39 WARNING pmon#xcvrd[43]: Got unknown FP port index 7, ignored

```
#### Motivation and Context
"show interface transceiver presence" did not reflect the actual presence/absence of the transceiver.

#### How Has This Been Tested?
Physically removed and inserted optics on Arista 7050CX and ensured the optics is shown in:-
1. show interfaces status
2. sfputil show presence
3. show interface transceiver presence

#### Additional Information (Optional)
