### PR TITLE
Update xcvrd to use new STATE_DB FAST_REBOOT entry

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1422,10 +1422,13 @@ class TestXcvrdScript(object):
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', None)))
     @patch('swsscommon.swsscommon.WarmStart', MagicMock())
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
-    def test_DaemonXcvrd_init_deinit(self):
+    def test_DaemonXcvrd_init_deinit_fastboot_enabled(self):
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
-        xcvrd.init()
-        xcvrd.deinit()
+        with patch("subprocess.check_output") as mock_run:
+            mock_run.return_value = "true"
+
+            xcvrd.init()
+            xcvrd.deinit()
 
 
 def wait_until(total_wait_time, interval, call_back, *args, **kwargs):

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -928,7 +928,7 @@ def is_fast_reboot_enabled():
 
     if "system" in keys:
         output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'get', "FAST_REBOOT|system"], universal_newlines=True)
-        if "1" in output:
+        if "enable" in output:
             fastboot_enabled = True
 
     return fastboot_enabled

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -927,8 +927,8 @@ def is_fast_reboot_enabled():
     keys = fastboot_tbl.getKeys()
 
     if "system" in keys:
-        output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'get', "FAST_RESTART_ENABLE_TABLE|system"], universal_newlines=True)
-        if "enable" in output:
+        output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'hget', "FAST_RESTART_ENABLE_TABLE|system", 'enable'], universal_newlines=True)
+        if "true" in output:
             fastboot_enabled = True
 
     return fastboot_enabled

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -923,11 +923,11 @@ def init_port_sfp_status_tbl(port_mapping, xcvr_table_helper, stop_event=threadi
 def is_fast_reboot_enabled():
     fastboot_enabled = False
     state_db_host =  daemon_base.db_connect("STATE_DB")
-    fastboot_tbl = swsscommon.Table(state_db_host, 'FAST_REBOOT')
+    fastboot_tbl = swsscommon.Table(state_db_host, 'FAST_RESTART_ENABLE_TABLE')
     keys = fastboot_tbl.getKeys()
 
     if "system" in keys:
-        output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'get', "FAST_REBOOT|system"], universal_newlines=True)
+        output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'get', "FAST_RESTART_ENABLE_TABLE|system"], universal_newlines=True)
         if "enable" in output:
             fastboot_enabled = True
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -921,17 +921,8 @@ def init_port_sfp_status_tbl(port_mapping, xcvr_table_helper, stop_event=threadi
                 update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_tbl(asic_index), sfp_status_helper.SFP_STATUS_INSERTED)
 
 def is_fast_reboot_enabled():
-    fastboot_enabled = False
-    state_db_host =  daemon_base.db_connect("STATE_DB")
-    fastboot_tbl = swsscommon.Table(state_db_host, 'FAST_RESTART_ENABLE_TABLE')
-    keys = fastboot_tbl.getKeys()
-
-    if "system" in keys:
-        output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'hget', "FAST_RESTART_ENABLE_TABLE|system", 'enable'], universal_newlines=True)
-        if "true" in output:
-            fastboot_enabled = True
-
-    return fastboot_enabled
+    fastboot_enabled = subprocess.check_output('sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable', shell=True, universal_newlines=True)
+    return "true" in fastboot_enabled
 
 #
 # Helper classes ===============================================================


### PR DESCRIPTION
Update xcvrd to check if fast-reboot is enabled according to the new value for FAST_REBOOT entry in STATE_DB.

This PR should come along with the following PRs:
https://github.com/sonic-net/sonic-utilities/pull/2621
https://github.com/sonic-net/sonic-buildimage/pull/13484
https://github.com/sonic-net/sonic-swss-common/pull/742
https://github.com/sonic-net/sonic-sairedis/pull/1196

This set of PRs solves the issue https://github.com/sonic-net/sonic-buildimage/issues/13251

#### Description
Update xcvrd to check the updated form of fast-reboot entry in state-db as it was changed.

#### Motivation and Context
Introducing fast-reboot finalizer on top of warmboot-finalizer, fast-reboot entry in STATE_DB is now changed from "1"/None to "enable"/"disable".

#### How Has This Been Tested?
Existing tests, and fast-reboot.

#### Additional Information (Optional)
