### PR TITLE
Fixed chassis: test_container_checker failure for swss/syncd/teamd on multi-asic Supervisor - issue #13559

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -208,9 +208,10 @@ class ModuleUpdater(logger.Logger):
             self.chassis_table._del(CHASSIS_INFO_KEY_TEMPLATE.format(1))
 
         if self.asic_table is not None:
-            asics = list(self.asic_table.getKeys())
-            for asic in asics:
-                self.asic_table._del(asic)
+            if not self._is_supervisor():
+                asics = list(self.asic_table.getKeys())
+                for asic in asics:
+                    self.asic_table._del(asic)
 
     def modules_num_update(self):
         # Check if module list is populated

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -449,10 +449,8 @@ def test_asic_presence():
     midplane_table = module_updater.midplane_table
     fvs = midplane_table.get(name)
     assert fvs == None
-    fvs = fabric_asic_table.get("asic4")
-    assert fvs == None
-    fvs = fabric_asic_table.get("asic5")
-    assert fvs == None
+    verify_fabric_asic("asic4", "0000:04:00.0", name, "0")
+    verify_fabric_asic("asic5", "0000:05:00.0", name, "1")
 
 def test_signal_handler():
     exit_code = 0


### PR DESCRIPTION
#### Description
Code changes are implemented in deinit function such that it does not remove entries in CHASSI_FABRIC_ASIC_TABLE when supervisorctl stop chassisd is triggered.

#### Motivation and Context
fixes https://github.com/sonic-net/sonic-buildimage/issues/13559: The container_cheaker depends on CHASSIS_FABRIC_ASIC_TABLE to provide the available asic list to calculate the expected dockers but as pmon is down and the table is cleared from chassis db, asic information is not present. Due to this, container_checker does not include the swss, syncd, teamd services in the expected docker list and fails to report the error.

#### How Has This Been Tested?
1) Execute the below cmd.
```
admin@supervisor:~$docker exec pmon supervisorctl stop chassisd
chassisd: stopped
```
2) Look for the table entries using below cmd.
```
admin@supervisor:~$ sonic-db-dump -n CHASSIS_STATE_DB -y -k "CHASSIS*"
{
  "CHASSIS_FABRIC_ASIC_TABLE|asic6": {
    "expireat": 1677006173.948722,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "asic_id_in_module": "0",
      "asic_pci_address": "nokia-bdb:4:0",
      "name": "FABRIC-CARD3"
    }
  },
  "CHASSIS_FABRIC_ASIC_TABLE|asic7": {
    "expireat": 1677006173.9487307,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "asic_id_in_module": "1",
      "asic_pci_address": "nokia-bdb:4:1",
      "name": "FABRIC-CARD3"
    }
  }
}
```
#### Additional Information (Optional)
