### PR TITLE
[ycable] add changes for correcting telemetry values for 'active-active'

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -6271,8 +6271,10 @@ class TestYCableScript(object):
             test_db[asic_index], "HW_TABLE1")
         hw_mux_cable_tbl_peer[asic_index] = swsscommon.Table(
             test_db[asic_index], "HW_TABLE2")
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "MUX_INFO_TABLE")
 
-        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence)
+        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -6302,8 +6304,10 @@ class TestYCableScript(object):
             test_db[asic_index], "HW_TABLE1")
         hw_mux_cable_tbl_peer[asic_index] = swsscommon.Table(
             test_db[asic_index], "HW_TABLE2")
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "MUX_INFO_TABLE")
 
-        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence)
+        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence)
         assert(rc == None)
 
 
@@ -6337,8 +6341,10 @@ class TestYCableScript(object):
             test_db[asic_index], "HW_TABLE1")
         hw_mux_cable_tbl_peer[asic_index] = swsscommon.Table(
             test_db[asic_index], "HW_TABLE2")
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "MUX_INFO_TABLE")
 
-        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence)
+        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence)
         assert(rc == None)
 
     @patch('proto_out.linkmgr_grpc_driver_pb2_grpc.DualToRActiveStub', MagicMock(return_value=True))

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -734,6 +734,7 @@ def setup_grpc_channels(stop_event):
     loopback_keys = {}
     hw_mux_cable_tbl = {}
     hw_mux_cable_tbl_peer = {}
+    mux_tbl = {}
 
     namespaces = multi_asic.get_front_end_namespaces()
     for namespace in namespaces:

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -663,7 +663,7 @@ def process_loopback_interface_and_get_read_side(loopback_keys):
     return -1
 
 
-def check_identifier_presence_and_setup_channel(logical_port_name, port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence):
+def check_identifier_presence_and_setup_channel(logical_port_name, port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence):
 
     global grpc_port_stubs
     global grpc_port_channels
@@ -702,6 +702,7 @@ def check_identifier_presence_and_setup_channel(logical_port_name, port_tbl, hw_
                             return
 
                         channel, stub = setup_grpc_channel_for_port(logical_port_name, soc_ipv4)
+                        post_port_mux_info_to_db(logical_port_name,  mux_tbl, asic_index, hw_mux_cable_tbl, 'pseudo-cable')
                         if channel is not None:
                             grpc_port_channels[logical_port_name] = channel
                             helper_logger.log_notice(
@@ -748,6 +749,8 @@ def setup_grpc_channels(stop_event):
             state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
         hw_mux_cable_tbl_peer[asic_id] = swsscommon.Table(
             state_db[asic_id], "HW_MUX_CABLE_TABLE_PEER")
+        mux_tbl[asic_id] = swsscommon.Table(
+                state_db[asic_id], "MUX_CABLE_INFO")
 
     if read_side == -1:
         read_side = process_loopback_interface_and_get_read_side(loopback_keys)
@@ -772,7 +775,7 @@ def setup_grpc_channels(stop_event):
 
         if logical_port_name in port_table_keys[asic_index]:
             check_identifier_presence_and_setup_channel(
-                logical_port_name, port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence)
+                logical_port_name, port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence)
         else:
             # This port does not exist in Port table of config but is present inside
             # logical_ports after loading the port_mappings from port_config_file
@@ -1399,7 +1402,7 @@ def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presen
             if status and cable_type == "active-active":
                 grpc_port_stats[logical_port_name] = {}
                 check_identifier_presence_and_setup_channel(
-                    logical_port_name, port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence)
+                    logical_port_name, port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence)
         else:
             # This port does not exist in Port table of config but is present inside
             # logical_ports after loading the port_mappings from port_config_file
@@ -1469,7 +1472,7 @@ def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, st
                         state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name, y_cable_presence)
                 if status and cable_type == "active-active":
                     check_identifier_presence_and_setup_channel(
-                        logical_port_name, port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, y_cable_presence)
+                        logical_port_name, port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence)
             elif value == SFP_STATUS_REMOVED:
                 helper_logger.log_info("Got SFP deleted ycable event")
                 check_identifier_presence_and_delete_mux_table_entry(
@@ -2232,7 +2235,7 @@ def post_port_mux_info_to_db(logical_port_name, mux_tbl, asic_index, y_cable_tbl
 
     for physical_port in physical_port_list:
 
-        if not y_cable_wrapper_get_presence(physical_port):
+        if not y_cable_wrapper_get_presence(physical_port) or cable_type == 'pseudo-cable':
             mux_info_dict = get_muxcable_info_without_presence()
         elif cable_type == 'active-active':
             helper_logger.log_warning("Error: trying to post mux info without presence of port {}".format(logical_port_name))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

This change creates `unknown, N/A` values for `active-standby` cable types for `active-active` type cable.
Since streaming telemetry today looks for both `active-active` and `active-standby` for posting values to State DB, this change introduces a  one time posting of fields with 'pseudo-cable' type when channels are attempted to be created by ycabled.

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
UT and posting the changes on test device. 
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
