### PR TITLE
Retrieve subport from CONFIG_DB to enable breakout support

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -663,7 +663,7 @@ class TestXcvrdScript(object):
         (1, 50000, 2, 0x2),
         (1, 200000, 2, 0x0)
     ])
-    def test_CmisManagerTask_get_cmis_host_lane_mask(self, host_lane_count, speed, channel, expected):
+    def test_CmisManagerTask_get_cmis_host_lanes_mask(self, host_lane_count, speed, channel, expected):
         appl_advert_dict = {
             1: {
                 'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)',
@@ -697,7 +697,8 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
 
-        assert task.get_cmis_host_lane_mask(mock_xcvr_api, host_lane_count, channel, speed) == expected
+        appl = task.get_cmis_application_desired(mock_xcvr_api, host_lane_count, speed)
+        assert task.get_cmis_host_lanes_mask(mock_xcvr_api, appl, host_lane_count, channel, speed) == expected
 
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_update_event', MagicMock(return_value=(None, None)))

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -713,7 +713,7 @@ class TestXcvrdScript(object):
 
         assert task.is_cmis_application_update_required(mock_xcvr_api, app_new, host_lanes_mask) == expected
 
-    @pytest.mark.parametrize("host_lane_count, speed, channel, expected", [
+    @pytest.mark.parametrize("host_lane_count, speed, subport, expected", [
         (8, 400000, 0, 0xFF),
         (4, 100000, 1, 0xF),
         (4, 100000, 2, 0xF0),
@@ -722,7 +722,7 @@ class TestXcvrdScript(object):
         (1, 50000, 2, 0x2),
         (1, 200000, 2, 0x0)
     ])
-    def test_CmisManagerTask_get_cmis_host_lanes_mask(self, host_lane_count, speed, channel, expected):
+    def test_CmisManagerTask_get_cmis_host_lanes_mask(self, host_lane_count, speed, subport, expected):
         appl_advert_dict = {
             1: {
                 'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)',
@@ -757,7 +757,7 @@ class TestXcvrdScript(object):
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
 
         appl = task.get_cmis_application_desired(mock_xcvr_api, host_lane_count, speed)
-        assert task.get_cmis_host_lanes_mask(mock_xcvr_api, appl, host_lane_count, channel) == expected
+        assert task.get_cmis_host_lanes_mask(mock_xcvr_api, appl, host_lane_count, subport) == expected
 
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_update_event', MagicMock(return_value=(None, None)))

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -655,13 +655,15 @@ class TestXcvrdScript(object):
         assert not cmis_manager.is_alive()
 
     @pytest.mark.parametrize("host_lane_count, speed, channel, expected", [
+        (8, 400000, 0, 0xFF),
         (4, 100000, 1, 0xF),
         (4, 100000, 2, 0xF0),
-        (8, 100000, 0, 0xFF),
-        (8, 400000, 0, 0xFF),
-        (4, 100000, 9, 0x0)
+        (4, 100000, 0, 0xF),
+        (4, 100000, 9, 0x0),
+        (1, 50000, 2, 0x2),
+        (1, 200000, 2, 0x0)
     ])
-    def test_CmisManagerTask_get_cmis_host_lanes(self, host_lane_count, speed, channel, expected):
+    def test_CmisManagerTask_get_cmis_host_lane_mask(self, host_lane_count, speed, channel, expected):
         appl_advert_dict = {
             1: {
                 'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)',
@@ -676,6 +678,13 @@ class TestXcvrdScript(object):
                 'media_lane_count': 4,
                 'host_lane_count': 4,
                 'host_lane_assignment_options': 17
+            },
+            3: {
+                'host_electrical_interface_id': '50GAUI-1 C2M',
+                'module_media_interface_id': '50GBASE-SR',
+                'media_lane_count': 1,
+                'host_lane_count': 1,
+                'host_lane_assignment_options': 255
             }
         }
         mock_xcvr_api = MagicMock()
@@ -688,7 +697,7 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
 
-        assert task.get_cmis_host_lanes(mock_xcvr_api, host_lane_count, channel, speed) == expected
+        assert task.get_cmis_host_lane_mask(mock_xcvr_api, host_lane_count, channel, speed) == expected
 
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_update_event', MagicMock(return_value=(None, None)))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1097,13 +1097,15 @@ class CmisManagerTask(threading.Thread):
     def get_cmis_dp_deinit_duration_secs(self, api):
         return api.get_datapath_deinit_duration()/1000
 
-    def get_cmis_host_lane_mask(self, api, host_lane_count, channel, speed):
+    def get_cmis_host_lanes_mask(self, api, appl, host_lane_count, channel, speed):
         """
         Retrieves mask of active host lanes based on host lane count, channel and speed
 
         Args:
             api:
                 XcvrApi object
+            appl:
+                Integer, the transceiver-specific application code
             host_lane_count:
                 Integer, number of lanes on the host side
             channel:
@@ -1115,28 +1117,26 @@ class CmisManagerTask(threading.Thread):
             Integer, a mask of the active lanes on the host side
             e.g. 0x5 for lane 0 and lane 2.
         """
-        host_lane_mask = 0
+        host_lanes_mask = 0
 
-        if host_lane_count <= 0 or channel < 0 or speed <= 0:
-            self.log_error("Invalid input to get host lane mask - host_lane_count {} channel {} speed {}!".format(
-                            host_lane_count, channel, speed))
-            return host_lane_mask
+        if host_lane_count <= 0 or channel < 0 or speed <= 0 or appl < 1:
+            self.log_error("Invalid input to get host lane mask - host_lane_count {} "
+                            "channel {} speed {} appl {}!".format(
+                            host_lane_count, channel, speed, appl))
+            return host_lanes_mask
 
-        if channel != 0:
-            appl = self.get_cmis_application_desired(api, host_lane_count, speed)
-            if appl < 1:
-                self.log_error("Failed to get host lanes as no suitable app {} found host_lane_count {} speed {}".format(
-                                appl, host_lane_count, speed))
-                return host_lane_mask
-
-            host_lane_assignment_option = api.get_host_lane_assignment_option(appl)
-            host_lane_start_bit = (host_lane_count * (channel - 1))
-            if host_lane_assignment_option & (1 << host_lane_start_bit):
-                host_lane_mask = ((1 << host_lane_count) - 1) << host_lane_start_bit
+        host_lane_assignment_option = api.get_host_lane_assignment_option(appl)
+        host_lane_start_bit = (host_lane_count * (0 if channel == 0 else channel - 1))
+        if host_lane_assignment_option & (1 << host_lane_start_bit):
+            host_lanes_mask = ((1 << host_lane_count) - 1) << host_lane_start_bit
         else:
-            host_lane_mask = (1 << host_lane_count) - 1
+            self.log_error("Unable to find lowest host lane - host_lane_assignment_option {}"
+                            " host_lane_start_bit {} host_lane_count {} channel {} speed {}"
+                            " appl {}!".format(
+                            host_lane_assignment_option, host_lane_start_bit, host_lane_count,
+                            channel, speed, appl))
 
-        return host_lane_mask
+        return host_lanes_mask
 
     def is_cmis_application_update_required(self, api, host_lane_count, channel, speed):
         """
@@ -1464,10 +1464,17 @@ class CmisManagerTask(threading.Thread):
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
                         continue
 
-                    host_lanes = self.get_cmis_host_lane_mask(api, host_lane_count, channel, speed)
-                    if host_lanes == 0:
-                        self.log_error("{}: Invalid lane mask received host_lane_count {} channel {} speed {}!".format(
-                                        lport, host_lane_count, channel, speed))
+                    appl = self.get_cmis_application_desired(api, host_lane_count, host_speed)
+                    if appl < 1:
+                        self.log_error("{}: no suitable app for the port".format(lport))
+                        self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
+                        continue
+
+                    host_lanes_mask = self.get_cmis_host_lanes_mask(api, appl, host_lane_count, channel, speed)
+                    if host_lanes_mask == 0:
+                        self.log_error("{}: Invalid lane mask received - host_lane_count {} channel {} "
+                                        "speed {} appl {}!".format(
+                                        lport, host_lane_count, channel, speed, appl))
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
                         continue
 
@@ -1489,8 +1496,8 @@ class CmisManagerTask(threading.Thread):
                 now = datetime.datetime.now()
                 expired = self.port_dict[lport].get('cmis_expired')
                 retries = self.port_dict[lport].get('cmis_retries', 0)
-                self.log_notice("{}: {}G, lanemask=0x{:x}, state={}, retries={}".format(
-                                lport, int(speed/1000), host_lanes, state, retries))
+                self.log_notice("{}: {}G, lanemask=0x{:x}, state={}, appl {} retries={}".format(
+                                lport, int(speed/1000), host_lanes_mask, state, appl, retries))
                 if retries > self.CMIS_MAX_RETRIES:
                     self.log_error("{}: FAILED".format(lport))
                     self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
@@ -1503,7 +1510,7 @@ class CmisManagerTask(threading.Thread):
                                 self.port_dict[lport]['admin_status'] != 'up':
                            self.log_notice("{} Forcing Tx laser OFF".format(lport))
                            # Force DataPath re-init
-                           api.tx_disable_channel(host_lanes, True)
+                           api.tx_disable_channel(host_lanes_mask, True)
                            self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
                            continue
                     # Configure the target output power if ZR module
@@ -1516,13 +1523,7 @@ class CmisManagerTask(threading.Thread):
                               else:
                                  self.log_notice("{} Successfully configured Tx power = {}".format(lport, tx_power))
 
-                        appl = self.get_cmis_application_desired(api, host_lane_count, host_speed)
-                        if appl < 1:
-                            self.log_error("{}: no suitable app for the port".format(lport))
-                            self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
-                            continue
-
-                        need_update = self.is_cmis_application_update_required(api, host_lane_count, host_lanes, host_speed)
+                        need_update = self.is_cmis_application_update_required(api, host_lane_count, host_lanes_mask, host_speed)
 
                         # For ZR module, Datapath needes to be re-initlialized on new channel selection
                         if api.is_coherent_module():
@@ -1541,11 +1542,11 @@ class CmisManagerTask(threading.Thread):
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_DP_DEINIT
                     elif state == self.CMIS_STATE_DP_DEINIT:
                         # D.2.2 Software Deinitialization
-                        api.set_datapath_deinit(host_lanes)
+                        api.set_datapath_deinit(host_lanes_mask)
 
                         # D.1.3 Software Configuration and Initialization
-                        if not api.tx_disable_channel(host_lanes, True):
-                            self.log_notice("{}: unable to turn off tx power".format(lport))
+                        if not api.tx_disable_channel(host_lanes_mask, True):
+                            self.log_notice("{}: unable to turn off tx power with host_lanes_mask {}".format(lport, host_lanes_mask))
                             self.port_dict[lport]['cmis_retries'] = retries + 1
                             continue
 
@@ -1563,7 +1564,7 @@ class CmisManagerTask(threading.Thread):
                                 self.force_cmis_reinit(lport, retries + 1)
                             continue
 
-                        if not self.check_datapath_state(api, host_lanes, ['DataPathDeactivated']):
+                        if not self.check_datapath_state(api, host_lanes_mask, ['DataPathDeactivated']):
                             if (expired is not None) and (expired <= now):
                                 self.log_notice("{}: timeout for 'DataPathDeactivated state'".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
@@ -1579,29 +1580,23 @@ class CmisManagerTask(threading.Thread):
                                    self.log_notice("{} configured laser frequency {} GHz".format(lport, freq))
 
                         # D.1.3 Software Configuration and Initialization
-                        appl = self.get_cmis_application_desired(api, host_lane_count, host_speed)
-                        if appl < 1:
-                            self.log_error("{}: no suitable app for the port".format(lport))
-                            self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
-                            continue
-
-                        if not api.set_application(host_lanes, appl):
+                        if not api.set_application(host_lanes_mask, appl):
                             self.log_notice("{}: unable to set application".format(lport))
                             self.force_cmis_reinit(lport, retries + 1)
                             continue
 
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_DP_INIT
                     elif state == self.CMIS_STATE_DP_INIT:
-                        if not self.check_config_error(api, host_lanes, ['ConfigSuccess']):
+                        if not self.check_config_error(api, host_lanes_mask, ['ConfigSuccess']):
                             if (expired is not None) and (expired <= now):
                                 self.log_notice("{}: timeout for 'ConfigSuccess'".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
                             continue
-
-                        if getattr(api, 'get_cmis_rev', None):
+                        
+                        if hasattr(api, 'get_cmis_rev'):
                             # Check datapath init pending on module that supports CMIS 5.x
                             majorRev = int(api.get_cmis_rev().split('.')[0])
-                            if majorRev >= 5 and not self.check_datapath_init_pending(api, host_lanes):
+                            if majorRev >= 5 and not self.check_datapath_init_pending(api, host_lanes_mask):
                                 self.log_notice("{}: datapath init not pending".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
                                 continue
@@ -1616,24 +1611,24 @@ class CmisManagerTask(threading.Thread):
                             continue
 
                         # D.1.3 Software Configuration and Initialization
-                        api.set_datapath_init(host_lanes)
+                        api.set_datapath_init(host_lanes_mask)
                         dpInitDuration = self.get_cmis_dp_init_duration_secs(api)
                         self.log_notice("{}: DpInit duration {} secs".format(lport, dpInitDuration))
                         self.port_dict[lport]['cmis_expired'] = now + datetime.timedelta(seconds=dpInitDuration)
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_DP_TXON
                     elif state == self.CMIS_STATE_DP_TXON:
-                        if not self.check_datapath_state(api, host_lanes, ['DataPathInitialized']):
+                        if not self.check_datapath_state(api, host_lanes_mask, ['DataPathInitialized']):
                             if (expired is not None) and (expired <= now):
                                 self.log_notice("{}: timeout for 'DataPathInitialized'".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
                             continue
 
                         # Turn ON the laser
-                        api.tx_disable_channel(host_lanes, False)
+                        api.tx_disable_channel(host_lanes_mask, False)
                         self.log_notice("{}: Turning ON tx power".format(lport))
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_DP_ACTIVATE
                     elif state == self.CMIS_STATE_DP_ACTIVATE:
-                        if not self.check_datapath_state(api, host_lanes, ['DataPathActivated']):
+                        if not self.check_datapath_state(api, host_lanes_mask, ['DataPathActivated']):
                             if (expired is not None) and (expired <= now):
                                 self.log_notice("{}: timeout for 'DataPathActivated'".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
@@ -1642,8 +1637,8 @@ class CmisManagerTask(threading.Thread):
                         self.log_notice("{}: READY".format(lport))
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
 
-                except (NotImplementedError, AttributeError):
-                    self.log_error("{}: internal errors".format(lport))
+                except (NotImplementedError, AttributeError) as e:
+                    self.log_error("{}: internal errors due to {}".format(lport, e))
                     self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
 
         self.log_notice("Stopped")

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -944,7 +944,7 @@ class CmisManagerTask(threading.Thread):
     CMIS_MAX_RETRIES     = 3
     CMIS_DEF_EXPIRED     = 60 # seconds, default expiration time
     CMIS_MODULE_TYPES    = ['QSFP-DD', 'QSFP_DD', 'OSFP', 'QSFP+C']
-    CMIS_NUM_CHANNELS    = 8
+    CMIS_MAX_HOST_LANES    = 8
 
     CMIS_STATE_UNKNOWN   = 'UNKNOWN'
     CMIS_STATE_INSERTED  = 'INSERTED'
@@ -1097,9 +1097,9 @@ class CmisManagerTask(threading.Thread):
     def get_cmis_dp_deinit_duration_secs(self, api):
         return api.get_datapath_deinit_duration()/1000
 
-    def get_cmis_host_lanes_mask(self, api, appl, host_lane_count, channel, speed):
+    def get_cmis_host_lanes_mask(self, api, appl, host_lane_count, channel):
         """
-        Retrieves mask of active host lanes based on host lane count, channel and speed
+        Retrieves mask of active host lanes based on appl, host lane count and channel
 
         Args:
             api:
@@ -1109,20 +1109,18 @@ class CmisManagerTask(threading.Thread):
             host_lane_count:
                 Integer, number of lanes on the host side
             channel:
-                Integer, channel id of the group which the host lanes belong to (1 based)
-            speed:
-                Integer, the port speed of the host interface
+                Integer, channel id of the group which the host lanes belong to (1 based),
+                0 means port is a non-breakout port
 
         Returns:
             Integer, a mask of the active lanes on the host side
-            e.g. 0x5 for lane 0 and lane 2.
+            e.g. 0x3 for lane 0 and lane 1.
         """
         host_lanes_mask = 0
 
-        if host_lane_count <= 0 or channel < 0 or speed <= 0 or appl < 1:
-            self.log_error("Invalid input to get host lane mask - host_lane_count {} "
-                            "channel {} speed {} appl {}!".format(
-                            host_lane_count, channel, speed, appl))
+        if appl < 1 or host_lane_count <= 0 or channel < 0:
+            self.log_error("Invalid input to get host lane mask - appl {} host_lane_count {} "
+                            "channel {}!".format(appl, host_lane_count, channel))
             return host_lanes_mask
 
         host_lane_assignment_option = api.get_host_lane_assignment_option(appl)
@@ -1130,42 +1128,38 @@ class CmisManagerTask(threading.Thread):
         if host_lane_assignment_option & (1 << host_lane_start_bit):
             host_lanes_mask = ((1 << host_lane_count) - 1) << host_lane_start_bit
         else:
-            self.log_error("Unable to find lowest host lane - host_lane_assignment_option {}"
-                            " host_lane_start_bit {} host_lane_count {} channel {} speed {}"
-                            " appl {}!".format(
+            self.log_error("Unable to find starting host lane - host_lane_assignment_option {}"
+                            " host_lane_start_bit {} host_lane_count {} channel {} appl {}!".format(
                             host_lane_assignment_option, host_lane_start_bit, host_lane_count,
-                            channel, speed, appl))
+                            channel, appl))
 
         return host_lanes_mask
 
-    def is_cmis_application_update_required(self, api, host_lane_count, channel, speed):
+    def is_cmis_application_update_required(self, api, app_new, host_lanes_mask):
         """
         Check if the CMIS application update is required
 
         Args:
             api:
                 XcvrApi object
-            host_lane_count:
-                Number of lanes on the host side
-            channel:
+            app_new:
+                Integer, the transceiver-specific application code for the new application
+            host_lanes_mask:
                 Integer, a bitmask of the lanes on the host side
                 e.g. 0x5 for lane 0 and lane 2.
-            speed:
-                Integer, the port speed of the host interface
 
         Returns:
             Boolean, true if application update is required otherwise false
         """
-        if speed == 0 or channel == 0 or api.is_flat_memory():
+        if api.is_flat_memory() or app_new <= 0 or host_lanes_mask <= 0:
+            self.log_error("Invalid input while checking CMIS update required - is_flat_memory {}"
+                            "app_new {} host_lanes_mask {}!".format(
+                            api.is_flat_memory(), app_new, host_lanes_mask))
             return False
 
-        app_new = self.get_cmis_application_desired(api, host_lane_count, speed)
-        if app_new != 1:
-            self.log_notice("Non-default application is not supported")
-
         app_old = 0
-        for lane in range(self.CMIS_NUM_CHANNELS):
-            if ((1 << lane) & channel) == 0:
+        for lane in range(self.CMIS_MAX_HOST_LANES):
+            if ((1 << lane) & host_lanes_mask) == 0:
                 continue
             if app_old == 0:
                 app_old = api.get_application(lane)
@@ -1178,8 +1172,8 @@ class CmisManagerTask(threading.Thread):
             skip = True
             dp_state = api.get_datapath_state()
             conf_state = api.get_config_datapath_hostlane_status()
-            for lane in range(self.CMIS_NUM_CHANNELS):
-                if ((1 << lane) & channel) == 0:
+            for lane in range(self.CMIS_MAX_HOST_LANES):
+                if ((1 << lane) & host_lanes_mask) == 0:
                     continue
                 name = "DP{}State".format(lane + 1)
                 if dp_state[name] != 'DataPathActivated':
@@ -1215,14 +1209,14 @@ class CmisManagerTask(threading.Thread):
         """
         return api.get_module_state() in states
 
-    def check_config_error(self, api, channel, states):
+    def check_config_error(self, api, host_lanes_mask, states):
         """
         Check if the CMIS configuration states are in the specified state
 
         Args:
             api:
                 XcvrApi object
-            channel:
+            host_lanes_mask:
                 Integer, a bitmask of the lanes on the host side
                 e.g. 0x5 for lane 0 and lane 2.
             states:
@@ -1233,8 +1227,8 @@ class CmisManagerTask(threading.Thread):
         """
         done = True
         cerr = api.get_config_datapath_hostlane_status()
-        for lane in range(self.CMIS_NUM_CHANNELS):
-            if ((1 << lane) & channel) == 0:
+        for lane in range(self.CMIS_MAX_HOST_LANES):
+            if ((1 << lane) & host_lanes_mask) == 0:
                 continue
             key = "ConfigStatusLane{}".format(lane + 1)
             if cerr[key] not in states:
@@ -1243,14 +1237,14 @@ class CmisManagerTask(threading.Thread):
 
         return done
 
-    def check_datapath_init_pending(self, api, channel):
+    def check_datapath_init_pending(self, api, host_lanes_mask):
         """
         Check if the CMIS datapath init is pending
 
         Args:
             api:
                 XcvrApi object
-            channel:
+            host_lanes_mask:
                 Integer, a bitmask of the lanes on the host side
                 e.g. 0x5 for lane 0 and lane 2.
 
@@ -1259,8 +1253,8 @@ class CmisManagerTask(threading.Thread):
         """
         pending = True
         dpinit_pending_dict = api.get_dpinit_pending()
-        for lane in range(self.CMIS_NUM_CHANNELS):
-            if ((1 << lane) & channel) == 0:
+        for lane in range(self.CMIS_MAX_HOST_LANES):
+            if ((1 << lane) & host_lanes_mask) == 0:
                 continue
             key = "DPInitPending{}".format(lane + 1)
             if not dpinit_pending_dict[key]:
@@ -1269,14 +1263,14 @@ class CmisManagerTask(threading.Thread):
 
         return pending
 
-    def check_datapath_state(self, api, channel, states):
+    def check_datapath_state(self, api, host_lanes_mask, states):
         """
         Check if the CMIS datapath states are in the specified state
 
         Args:
             api:
                 XcvrApi object
-            channel:
+            host_lanes_mask:
                 Integer, a bitmask of the lanes on the host side
                 e.g. 0x5 for lane 0 and lane 2.
             states:
@@ -1287,8 +1281,8 @@ class CmisManagerTask(threading.Thread):
         """
         done = True
         dpstate = api.get_datapath_state()
-        for lane in range(self.CMIS_NUM_CHANNELS):
-            if ((1 << lane) & channel) == 0:
+        for lane in range(self.CMIS_MAX_HOST_LANES):
+            if ((1 << lane) & host_lanes_mask) == 0:
                 continue
             key = "DP{}State".format(lane + 1)
             if dpstate[key] not in states:
@@ -1417,6 +1411,9 @@ class CmisManagerTask(threading.Thread):
                              self.CMIS_STATE_FAILED,
                              self.CMIS_STATE_READY,
                              self.CMIS_STATE_REMOVED]:
+                    if state != self.CMIS_STATE_READY:
+                        self.port_dict[lport]['appl'] = 0
+                        self.port_dict[lport]['host_lanes_mask'] = 0
                     continue
 
                 # Handle the case when Xcvrd was NOT running when 'host_tx_ready' or 'admin_status'
@@ -1431,7 +1428,7 @@ class CmisManagerTask(threading.Thread):
                 speed = int(info.get('speed', "0"))
                 lanes = info.get('lanes', "").strip()
                 channel = info.get('channel', 0)
-                if pport < 0 or speed == 0 or len(lanes) < 1:
+                if pport < 0 or speed == 0 or len(lanes) < 1 or channel < 0:
                     continue
 
                 # Desired port speed on the host side
@@ -1464,20 +1461,6 @@ class CmisManagerTask(threading.Thread):
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
                         continue
 
-                    appl = self.get_cmis_application_desired(api, host_lane_count, host_speed)
-                    if appl < 1:
-                        self.log_error("{}: no suitable app for the port".format(lport))
-                        self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
-                        continue
-
-                    host_lanes_mask = self.get_cmis_host_lanes_mask(api, appl, host_lane_count, channel, speed)
-                    if host_lanes_mask == 0:
-                        self.log_error("{}: Invalid lane mask received - host_lane_count {} channel {} "
-                                        "speed {} appl {}!".format(
-                                        lport, host_lane_count, channel, speed, appl))
-                        self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
-                        continue
-
                     if api.is_coherent_module():
                        if 'tx_power' not in self.port_dict[lport]:
                            self.port_dict[lport]['tx_power'] = self.get_configured_tx_power_from_db(lport)
@@ -1496,8 +1479,17 @@ class CmisManagerTask(threading.Thread):
                 now = datetime.datetime.now()
                 expired = self.port_dict[lport].get('cmis_expired')
                 retries = self.port_dict[lport].get('cmis_retries', 0)
-                self.log_notice("{}: {}G, lanemask=0x{:x}, state={}, appl {} retries={}".format(
-                                lport, int(speed/1000), host_lanes_mask, state, appl, retries))
+                host_lanes_mask = self.port_dict[lport].get('host_lanes_mask', 0)
+                appl = self.port_dict[lport].get('appl', 0)
+                if state != self.CMIS_STATE_INSERTED and (host_lanes_mask <= 0 or appl < 1):
+                    self.log_error("{}: Unexpected value for host_lanes_mask {} or appl {} in "
+                                    "{} state".format(lport, host_lanes_mask, appl, state))
+                    self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
+                    continue
+
+                self.log_notice("{}: {}G, lanemask=0x{:x}, state={}, appl {} host_lane_count {} "
+                                "retries={}".format(lport, int(speed/1000), host_lanes_mask,
+                                state, appl, host_lane_count, retries))
                 if retries > self.CMIS_MAX_RETRIES:
                     self.log_error("{}: FAILED".format(lport))
                     self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
@@ -1506,6 +1498,26 @@ class CmisManagerTask(threading.Thread):
                 try:
                     # CMIS state transitions
                     if state == self.CMIS_STATE_INSERTED:
+                        self.port_dict[lport]['appl'] = self.get_cmis_application_desired(api,
+                                                                host_lane_count, host_speed)
+                        if self.port_dict[lport]['appl'] < 1:
+                            self.log_error("{}: no suitable app for the port appl {} host_lane_count {} "
+                                            "host_speed {}".format(lport, appl, host_lane_count, host_speed))
+                            self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
+                            continue
+                        appl = self.port_dict[lport]['appl']
+                        self.log_notice("{}: Setting appl={}".format(lport, appl))
+
+                        self.port_dict[lport]['host_lanes_mask'] = self.get_cmis_host_lanes_mask(api,
+                                                                        appl, host_lane_count, channel)
+                        if self.port_dict[lport]['host_lanes_mask'] <= 0:
+                            self.log_error("{}: Invalid lane mask received - host_lane_count {} channel {} "
+                                            "appl {}!".format(lport, host_lane_count, channel, appl))
+                            self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
+                            continue
+                        host_lanes_mask = self.port_dict[lport]['host_lanes_mask']
+                        self.log_notice("{}: Setting lanemask=0x{:x}".format(lport, host_lanes_mask))
+
                         if self.port_dict[lport]['host_tx_ready'] != 'true' or \
                                 self.port_dict[lport]['admin_status'] != 'up':
                            self.log_notice("{} Forcing Tx laser OFF".format(lport))
@@ -1523,7 +1535,7 @@ class CmisManagerTask(threading.Thread):
                               else:
                                  self.log_notice("{} Successfully configured Tx power = {}".format(lport, tx_power))
 
-                        need_update = self.is_cmis_application_update_required(api, host_lane_count, host_lanes_mask, host_speed)
+                        need_update = self.is_cmis_application_update_required(api, appl, host_lanes_mask)
 
                         # For ZR module, Datapath needes to be re-initlialized on new channel selection
                         if api.is_coherent_module():
@@ -1592,7 +1604,7 @@ class CmisManagerTask(threading.Thread):
                                 self.log_notice("{}: timeout for 'ConfigSuccess'".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
                             continue
-                        
+
                         if hasattr(api, 'get_cmis_rev'):
                             # Check datapath init pending on module that supports CMIS 5.x
                             majorRev = int(api.get_cmis_rev().split('.')[0])

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1109,8 +1109,8 @@ class CmisManagerTask(threading.Thread):
             host_lane_count:
                 Integer, number of lanes on the host side
             subport:
-                Integer, subport id of the group which the host lanes belong to (1 based),
-                0 means port is a non-breakout port
+                Integer, 1-based logical port number of the physical port after breakout
+                         0 means port is a non-breakout port
 
         Returns:
             Integer, a mask of the active lanes on the host side

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1459,13 +1459,6 @@ class CmisManagerTask(threading.Thread):
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
                         continue
 
-                    host_lanes = self.get_cmis_host_lane_mask(api, host_lane_count, channel, speed)
-                    if host_lanes == 0:
-                        self.log_error("{}: Invalid lane mask received host_lane_count {} channel {} speed {}!".format(
-                                        lport, host_lane_count, channel, speed))
-                        self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
-                        continue
-
                     # Skip if it's not a paged memory device
                     if api.is_flat_memory():
                         self.log_notice("{}: skipping CMIS state machine for flat memory xcvr".format(lport))
@@ -1476,6 +1469,13 @@ class CmisManagerTask(threading.Thread):
                     type = api.get_module_type_abbreviation()
                     if (type is None) or (type not in self.CMIS_MODULE_TYPES):
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
+                        continue
+
+                    host_lanes = self.get_cmis_host_lane_mask(api, host_lane_count, channel, speed)
+                    if host_lanes == 0:
+                        self.log_error("{}: Invalid lane mask received host_lane_count {} channel {} speed {}!".format(
+                                        lport, host_lane_count, channel, speed))
+                        self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
                         continue
 
                     if api.is_coherent_module():

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1164,7 +1164,9 @@ class CmisManagerTask(threading.Thread):
             if app_old == 0:
                 app_old = api.get_application(lane)
             elif app_old != api.get_application(lane):
-                self.log_notice("Not all the lanes are in the same application mode")
+                self.log_notice("Not all the lanes are in the same application mode "
+                                "app_old {} current app {} lane {} host_lanes_mask {}".format(
+                                app_old, api.get_application(lane), lane, host_lanes_mask))
                 self.log_notice("Forcing application update...")
                 return True
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1596,14 +1596,6 @@ class CmisManagerTask(threading.Thread):
                             self.force_cmis_reinit(lport, retries + 1)
                             continue
 
-                        if getattr(api, 'get_cmis_rev', None):
-                            # Check datapath init pending on module that supports CMIS 5.x
-                            majorRev = int(api.get_cmis_rev().split('.')[0])
-                            if majorRev >= 5 and not self.check_datapath_init_pending(api, host_lanes):
-                                self.log_notice("{}: datapath init not pending".format(lport))
-                                self.force_cmis_reinit(lport, retries + 1)
-                                continue
-
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_DP_INIT
                     elif state == self.CMIS_STATE_DP_INIT:
                         if not self.check_config_error(api, host_lanes, ['ConfigSuccess']):
@@ -1611,6 +1603,14 @@ class CmisManagerTask(threading.Thread):
                                 self.log_notice("{}: timeout for 'ConfigSuccess'".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
                             continue
+
+                        if getattr(api, 'get_cmis_rev', None):
+                            # Check datapath init pending on module that supports CMIS 5.x
+                            majorRev = int(api.get_cmis_rev().split('.')[0])
+                            if majorRev >= 5 and not self.check_datapath_init_pending(api, host_lanes):
+                                self.log_notice("{}: datapath init not pending".format(lport))
+                                self.force_cmis_reinit(lport, retries + 1)
+                                continue
 
                         # Ensure the Datapath is NOT Activated unless the host Tx siganl is good.
                         # NOTE: Some CMIS compliant modules may have 'auto-squelch' feature where

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1130,16 +1130,9 @@ class CmisManagerTask(threading.Thread):
                 return host_lane_mask
 
             host_lane_assignment_option = api.get_host_lane_assignment_option(appl)
-            curr_channel_num = 0
-            for bit in range(8):
-                mask = 1 << bit
-                if host_lane_assignment_option & mask != 0:
-                    curr_channel_num += 1
-                    if curr_channel_num == channel:
-                        for i in range(host_lane_count):
-                            host_lane_mask |= mask
-                            mask = mask << 1
-                        break
+            host_lane_start_bit = (host_lane_count * (channel - 1))
+            if host_lane_assignment_option & (1 << host_lane_start_bit):
+                host_lane_mask = ((1 << host_lane_count) - 1) << host_lane_start_bit
         else:
             host_lane_mask = (1 << host_lane_count) - 1
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
The changes with this PR needs to be merged along with sonic-net/sonic-platform-common#352

#### Description
<!--
     Describe your changes in detail
-->
Currently, xcvrd has a fixed logic to calculate active host lanes for a port. This needs to be changed to support ports with breakout cable.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The fixed host lane mapping will now be replaced by reading the subport from the CONFIG_DB. The subport will then be used to calculate active host lanes by reading the Application Descriptors.

Finding the desired application
The HostInterfaceID and HostLaneCount from Application Descriptors will be used to find the desired application for the port with breakout cable by comparing these with speed and lanes retrieved from CONFIG_DB.

Finding active host lane
Once the desired application is found, the HostLaneAssignmentOptions (bitmap of active host lanes) for the corresponding application and the subport from CONFIG_DB will be used to find the active host lanes.

In addition to the above, check_datapath_init_pending is now being called after ConfigStatusLane register has the value "ConfigSuccess". This has been done to be inline with the CMIS spec.

**Note**
Once the port_config.ini file has a new column for subport, the CONFIG_DB will be updated with the corresponding subport values (requires minigraph reload though).
The field "subport" will have the below value:
0 - This means the xcvr in non-breakout type
non-zero - The value here corresponds to the subport group (formed by a group of active lanes) to which the port belongs to

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Testcase summary
The value of host_lanes can be seen in the logs by finding lanemask.
400G related TCs
1. SFP EEPROM dump
2. show int status
3. LLDP o/p
4. Log dump for CMIS init

200G breakout related TCs - 200G side
1. SFP EEPROM dump
2. show int status
3. LLDP o/p
4. Log dump for CMIS init

200G breakout related TCs - 100G side
1. SFP EEPROM dump
2. show int status
3. LLDP o/p
4. Log dump for CMIS init

5. Shut/no shut on subports (200G and 100G sides)
6. config reload (of Fixed chassis) with both native and break-out optics inserted
7. reboot (of Fixed chassis) with both native and break-out optics inserted
8. Remove and re-insert 2x100G break-out optic at run-time (system running)
9. xcvrd restart - Ensure link flap is not seen
10. PMON restart - Ensure link flap is not seen
11. SWSS restart
12. SYNCD restart
13. CONFIG_DB for a port after adding subport to port_config.ini

For additional details, please refer to [Unit-test_breakout_channel_v5.txt](https://github.com/sonic-net/sonic-platform-daemons/files/11081746/Unit-test_breakout_channel_v5.txt)


The code changes have been tested on a chassis with 200G AOC breakout cable.
Also, the code changes have been tested on a chassis with 400ZR transceiver and 10GBase-SR

#### Additional Information (Optional)
