### PR TITLE
[202205] Update xcvrd to use new STATE_DB FAST_REBOOT entry

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1423,12 +1423,30 @@ class TestXcvrdScript(object):
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', None)))
     @patch('swsscommon.swsscommon.WarmStart', MagicMock())
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
-    def test_DaemonXcvrd_init_deinit(self):
+    def test_DaemonXcvrd_init_deinit_fastboot_enabled(self):
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
-        xcvrd.init()
-        xcvrd.deinit()
-        # TODO: fow now we only simply call xcvrd.init/deinit without any further check, it only makes sure that
-        # xcvrd.init/deinit will not raise unexpected exception. In future, probably more check will be added
+        with mock.patch("subprocess.check_output") as mock_run:
+            mock_run.return_value = "true"
+
+            xcvrd.init()
+            xcvrd.deinit()
+            # TODO: fow now we only simply call xcvrd.init/deinit without any further check, it only makes sure that
+            # xcvrd.init/deinit will not raise unexpected exception. In future, probably more check will be added
+
+
+    @patch('xcvrd.xcvrd.DaemonXcvrd.load_platform_util', MagicMock())
+    @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', None)))
+    @patch('swsscommon.swsscommon.WarmStart', MagicMock())
+    @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
+    def test_DaemonXcvrd_init_deinit_fastboot_disabled(self):
+        xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
+        with mock.patch("subprocess.check_output") as mock_run:
+            mock_run.return_value = "false"
+
+            xcvrd.init()
+            xcvrd.deinit()
+            # TODO: fow now we only simply call xcvrd.init/deinit without any further check, it only makes sure that
+            # xcvrd.init/deinit will not raise unexpected exception. In future, probably more check will be added
 
 
 def wait_until(total_wait_time, interval, call_back, *args, **kwargs):

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1425,7 +1425,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
     def test_DaemonXcvrd_init_deinit_fastboot_enabled(self):
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
-        with patch("subprocess.check_output('sonic-db-cli STATE_DB hget \"FAST_RESTART_ENABLE_TABLE|system\" enable', shell=True, universal_newlines=True)") as mock_run:
+        with patch("subprocess.check_output") as mock_run:
             mock_run.return_value = "true"
 
             xcvrd.init()
@@ -1440,7 +1440,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
     def test_DaemonXcvrd_init_deinit_fastboot_disabled(self):
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
-        with patch("subprocess.check_output('sonic-db-cli STATE_DB hget \"FAST_RESTART_ENABLE_TABLE|system\" enable', shell=True, universal_newlines=True)") as mock_run:
+        with patch("subprocess.check_output") as mock_run:
             mock_run.return_value = "false"
 
             xcvrd.init()

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1434,21 +1434,6 @@ class TestXcvrdScript(object):
             # xcvrd.init/deinit will not raise unexpected exception. In future, probably more check will be added
 
 
-    @patch('xcvrd.xcvrd.DaemonXcvrd.load_platform_util', MagicMock())
-    @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', None)))
-    @patch('swsscommon.swsscommon.WarmStart', MagicMock())
-    @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
-    def test_DaemonXcvrd_init_deinit_fastboot_disabled(self):
-        xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
-        with patch("subprocess.check_output") as mock_run:
-            mock_run.return_value = "false"
-
-            xcvrd.init()
-            xcvrd.deinit()
-            # TODO: fow now we only simply call xcvrd.init/deinit without any further check, it only makes sure that
-            # xcvrd.init/deinit will not raise unexpected exception. In future, probably more check will be added
-
-
 def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
     wait_time = 0
     while wait_time <= total_wait_time:

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1425,7 +1425,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
     def test_DaemonXcvrd_init_deinit_fastboot_enabled(self):
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
-        with mock.patch("subprocess.check_output") as mock_run:
+        with patch("subprocess.check_output") as mock_run:
             mock_run.return_value = "true"
 
             xcvrd.init()
@@ -1440,7 +1440,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
     def test_DaemonXcvrd_init_deinit_fastboot_disabled(self):
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
-        with mock.patch("subprocess.check_output") as mock_run:
+        with patch("subprocess.check_output") as mock_run:
             mock_run.return_value = "false"
 
             xcvrd.init()

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1425,7 +1425,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
     def test_DaemonXcvrd_init_deinit_fastboot_enabled(self):
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
-        with patch("subprocess.check_output") as mock_run:
+        with patch("subprocess.check_output('sonic-db-cli STATE_DB hget \"FAST_RESTART_ENABLE_TABLE|system\" enable', shell=True, universal_newlines=True)") as mock_run:
             mock_run.return_value = "true"
 
             xcvrd.init()
@@ -1440,7 +1440,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
     def test_DaemonXcvrd_init_deinit_fastboot_disabled(self):
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
-        with patch("subprocess.check_output") as mock_run:
+        with patch("subprocess.check_output('sonic-db-cli STATE_DB hget \"FAST_RESTART_ENABLE_TABLE|system\" enable', shell=True, universal_newlines=True)") as mock_run:
             mock_run.return_value = "false"
 
             xcvrd.init()

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -923,12 +923,12 @@ def init_port_sfp_status_tbl(port_mapping, xcvr_table_helper, stop_event=threadi
 def is_fast_reboot_enabled():
     fastboot_enabled = False
     state_db_host =  daemon_base.db_connect("STATE_DB")
-    fastboot_tbl = swsscommon.Table(state_db_host, 'FAST_REBOOT')
+    fastboot_tbl = swsscommon.Table(state_db_host, 'FAST_RESTART_ENABLE_TABLE')
     keys = fastboot_tbl.getKeys()
 
     if "system" in keys:
-        output = subprocess.check_output('sonic-db-cli STATE_DB get "FAST_REBOOT|system"', shell=True, universal_newlines=True)
-        if "1" in output:
+        output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'hget', "FAST_RESTART_ENABLE_TABLE|system", 'enable'], universal_newlines=True)
+        if "true" in output:
             fastboot_enabled = True
 
     return fastboot_enabled

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -921,17 +921,9 @@ def init_port_sfp_status_tbl(port_mapping, xcvr_table_helper, stop_event=threadi
                 update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_tbl(asic_index), sfp_status_helper.SFP_STATUS_INSERTED)
 
 def is_fast_reboot_enabled():
-    fastboot_enabled = False
-    state_db_host =  daemon_base.db_connect("STATE_DB")
-    fastboot_tbl = swsscommon.Table(state_db_host, 'FAST_RESTART_ENABLE_TABLE')
-    keys = fastboot_tbl.getKeys()
+    fastboot_enabled = subprocess.check_output('sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable', shell=True, universal_newlines=True)
+    return "true" in fastboot_enabled
 
-    if "system" in keys:
-        output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'hget', "FAST_RESTART_ENABLE_TABLE|system", 'enable'], universal_newlines=True)
-        if "true" in output:
-            fastboot_enabled = True
-
-    return fastboot_enabled
 
 #
 # Helper classes ===============================================================


### PR DESCRIPTION
This PR is similar to https://github.com/sonic-net/sonic-platform-daemons/pull/335, dedicated to 202205 branch.

Update xcvrd to check if fast-reboot is enabled according to the new value for FAST_REBOOT entry in STATE_DB.

This PR should come along with the following PRs:
https://github.com/sonic-net/sonic-buildimage/pull/14143
https://github.com/sonic-net/sonic-sairedis/pull/1217
https://github.com/sonic-net/sonic-utilities/pull/2724

This set of PRs solves the issue https://github.com/sonic-net/sonic-buildimage/issues/13251

Description
Update xcvrd to check the updated form of fast-reboot entry in state-db as it was changed.

Motivation and Context
Introducing fast-reboot finalizer on top of warmboot-finalizer, fast-reboot entry in STATE_DB is now changed from "1"/None to "enable: true/false".

How Has This Been Tested?
Existing tests, and fast-reboot.

Additional Information (Optional)