### PR TITLE
[CMIS] Add power up duration for power up timeout

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -671,6 +671,7 @@ class TestXcvrdScript(object):
         mock_xcvr_api.get_laser_config_freq = MagicMock(return_value=0)
         mock_xcvr_api.get_module_type_abbreviation = MagicMock(return_value='QSFP-DD')
         mock_xcvr_api.get_datapath_init_duration = MagicMock(return_value=60000.0)
+        mock_xcvr_api.get_module_up_duration = MagicMock(return_value=70000.0)
         mock_xcvr_api.get_datapath_deinit_duration = MagicMock(return_value=600000.0)
         mock_xcvr_api.get_cmis_rev = MagicMock(return_value='5.0')
         mock_xcvr_api.get_dpinit_pending = MagicMock(return_value={

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -671,7 +671,7 @@ class TestXcvrdScript(object):
         mock_xcvr_api.get_laser_config_freq = MagicMock(return_value=0)
         mock_xcvr_api.get_module_type_abbreviation = MagicMock(return_value='QSFP-DD')
         mock_xcvr_api.get_datapath_init_duration = MagicMock(return_value=60000.0)
-        mock_xcvr_api.get_module_up_duration = MagicMock(return_value=70000.0)
+        mock_xcvr_api.get_module_pwr_up_duration = MagicMock(return_value=70000.0)
         mock_xcvr_api.get_datapath_deinit_duration = MagicMock(return_value=600000.0)
         mock_xcvr_api.get_cmis_rev = MagicMock(return_value='5.0')
         mock_xcvr_api.get_dpinit_pending = MagicMock(return_value={

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1103,10 +1103,10 @@ class CmisManagerTask(threading.Thread):
         return api.get_datapath_deinit_duration()/1000
 
     def get_cmis_module_power_up_duration_secs(self, api):
-        return api.get_module_up_duration()/1000
+        return api.get_module_pwr_up_duration()/1000
 
     def get_cmis_module_power_down_duration_secs(self, api):
-        return api.get_module_down_duration()/1000
+        return api.get_module_pwr_down_duration()/1000
 
     def is_cmis_application_update_required(self, api, channel, speed):
         """

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1102,6 +1102,12 @@ class CmisManagerTask(threading.Thread):
     def get_cmis_dp_deinit_duration_secs(self, api):
         return api.get_datapath_deinit_duration()/1000
 
+    def get_cmis_module_power_up_duration_secs(self, api):
+        return api.get_module_up_duration()/1000
+
+    def get_cmis_module_power_down_duration_secs(self, api):
+        return api.get_module_down_duration()/1000
+
     def is_cmis_application_update_required(self, api, channel, speed):
         """
         Check if the CMIS application update is required
@@ -1514,8 +1520,9 @@ class CmisManagerTask(threading.Thread):
                         api.set_lpmode(False)
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_AP_CONF
                         dpDeinitDuration = self.get_cmis_dp_deinit_duration_secs(api)
-                        self.log_notice("{} DpDeinit duration {} secs".format(lport, dpDeinitDuration))
-                        self.port_dict[lport]['cmis_expired'] = now + datetime.timedelta(seconds=dpDeinitDuration)
+                        modulePwrUpDuration = self.get_cmis_module_power_up_duration_secs(api)
+                        self.log_notice("{} DpDeinit duration {} secs, modulePwrUp duration {} secs".format(lport, dpDeinitDuration, modulePwrUpDuration))
+                        self.port_dict[lport]['cmis_expired'] = now + datetime.timedelta(seconds = max(modulePwrUpDuration, dpDeinitDuration))
                     elif state == self.CMIS_STATE_AP_CONF:
                         # TODO: Use fine grained time when the CMIS memory map is available
                         if not self.check_module_state(api, ['ModuleReady']):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
For Neo ZR, it can't do CMIS init due to timeout
```
Feb  1 10:58:10.936128 as9736-64d-2 NOTICE pmon#xcvrd: CMIS: Ethernet496: force Datapath reinit
Feb  1 10:58:12.032012 as9736-64d-2 NOTICE pmon#xcvrd: CMIS: Ethernet496: 100G, lanemask=0xf, state=DP_DEINIT, retries=2
Feb  1 10:58:13.476090 as9736-64d-2 NOTICE pmon#xcvrd: CMIS: Ethernet496 DpDeinit duration 5.0 secs
Feb  1 10:58:14.572104 as9736-64d-2 NOTICE pmon#xcvrd: CMIS: Ethernet496: 100G, lanemask=0xf, state=AP_CONFIGURED, retries=2
Feb  1 10:58:17.956000 as9736-64d-2 NOTICE pmon#xcvrd: message repeated 3 times: [ CMIS: Ethernet496: 100G, lanemask=0xf, state=AP_CONFIGURED, retries=2]
Feb  1 10:58:17.956000 as9736-64d-2 NOTICE pmon#xcvrd: CMIS: Ethernet496: timeout for 'ModuleReady'
```
For Neo ZR, the DpDeinit duration is 5 seconds and module power up duration is 300 seconds.
It needs more time to do module power up.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Insert Neo ZR and check it can do CMIS init.
```
Mar 10 01:05:44.881677 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=INSERTED, retries=0
Mar 10 01:05:45.917054 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: force Datapath reinit
Mar 10 01:05:50.249165 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=DP_DEINIT, retries=0
Mar 10 01:05:51.765200 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416 DpDeinit duration 5.0 secs, modulePwrUp duration 300.0 secs
Mar 10 01:05:53.757119 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=AP_CONFIGURED, retries=0
Mar 10 01:05:56.345249 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=AP_CONFIGURED, retries=0
Mar 10 01:05:59.393198 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=AP_CONFIGURED, retries=0
Mar 10 01:06:00.777161 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=AP_CONFIGURED, retries=0
Mar 10 01:06:03.025123 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=AP_CONFIGURED, retries=0
Mar 10 01:06:05.757165 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=AP_CONFIGURED, retries=0
Mar 10 01:06:06.997207 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=AP_CONFIGURED, retries=0
Mar 10 01:06:09.249117 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=AP_CONFIGURED, retries=0
Mar 10 01:06:11.985255 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=AP_CONFIGURED, retries=0
Mar 10 01:06:13.225155 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=AP_CONFIGURED, retries=0
Mar 10 01:06:14.441107 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=AP_CONFIGURED, retries=0
Mar 10 01:06:39.680221 sonic NOTICE pmon#xcvrd: message repeated 22 times: [ CMIS: Ethernet416: 400G, lanemask=0xff, state=AP_CONFIGURED, retries=0]
Mar 10 01:06:39.777226 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=AP_CONFIGURED, retries=0
Mar 10 01:06:40.549080 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=DP_INIT, retries=0
Mar 10 01:06:40.777143 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416 DpInit duration 60.0 secs
Mar 10 01:06:40.873169 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=DP_TXON, retries=0
Mar 10 01:06:54.181098 sonic NOTICE pmon#xcvrd: message repeated 10 times: [ CMIS: Ethernet416: 400G, lanemask=0xff, state=DP_TXON, retries=0]
Mar 10 01:06:54.181098 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: Turning ON tx power
Mar 10 01:06:55.284993 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: 400G, lanemask=0xff, state=DP_ACTIVATION, retries=0
Mar 10 01:06:55.377142 sonic NOTICE pmon#xcvrd: CMIS: Ethernet416: READY
```

#### Additional Information (Optional)
Please don't merge this PR until the dependency PR https://github.com/sonic-net/sonic-platform-common/pull/354 gets merged.
