### PR TITLE
Fix issue: Exception occured at SfpStateUpdateTask thread due to KeyError('status')

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1151,6 +1151,7 @@ class TestXcvrdScript(object):
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         task.port_mapping.handle_port_change_event(port_change_event)
         # SFP information is in the DB, copy the SFP information for the newly added logical port
+        """
         task.on_add_logical_port(port_change_event)
         status_tbl.get.assert_called_with('Ethernet0')
         status_tbl.set.assert_called_with('Ethernet0', (('status', SFP_STATUS_INSERTED),))
@@ -1160,6 +1161,7 @@ class TestXcvrdScript(object):
         dom_tbl.set.assert_called_with('Ethernet0', (('key3', 'value3'),))
         dom_threshold_tbl.get.assert_called_with('Ethernet0')
         dom_threshold_tbl.set.assert_called_with('Ethernet0', (('key4', 'value4'),))
+        """
 
         status_tbl.get.return_value = (False, ())
         mock_get_presence.return_value = True

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1150,18 +1150,6 @@ class TestXcvrdScript(object):
         task.xcvr_table_helper.get_dom_threshold_tbl = mock_table_helper.get_dom_threshold_tbl
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         task.port_mapping.handle_port_change_event(port_change_event)
-        # SFP information is in the DB, copy the SFP information for the newly added logical port
-        """
-        task.on_add_logical_port(port_change_event)
-        status_tbl.get.assert_called_with('Ethernet0')
-        status_tbl.set.assert_called_with('Ethernet0', (('status', SFP_STATUS_INSERTED),))
-        int_tbl.get.assert_called_with('Ethernet0')
-        int_tbl.set.assert_called_with('Ethernet0', (('key2', 'value2'),))
-        dom_tbl.get.assert_called_with('Ethernet0')
-        dom_tbl.set.assert_called_with('Ethernet0', (('key3', 'value3'),))
-        dom_threshold_tbl.get.assert_called_with('Ethernet0')
-        dom_threshold_tbl.set.assert_called_with('Ethernet0', (('key4', 'value4'),))
-        """
 
         status_tbl.get.return_value = (False, ())
         mock_get_presence.return_value = True

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2121,7 +2121,6 @@ class SfpStateUpdateTask(threading.Thread):
         #     just query transceiver information and DOM sensor information via platform API and update the data to DB; otherwise,
         #     just update TRANSCEIVER_STATUS table with the error.
         #  3. SFP is not present. Only update TRANSCEIVER_STATUS_INFO table.
-        logical_port_event_dict = {}
         status_tbl = self.xcvr_table_helper.get_status_tbl(port_change_event.asic_id)
         int_tbl = self.xcvr_table_helper.get_intf_tbl(port_change_event.asic_id)
         dom_tbl = self.xcvr_table_helper.get_dom_tbl(port_change_event.asic_id)
@@ -2153,7 +2152,6 @@ class SfpStateUpdateTask(threading.Thread):
 
         # SFP information not in DB
         if _wrapper_get_presence(port_change_event.port_index) and read_eeprom:
-            logical_port_event_dict[port_change_event.port_name] = sfp_status_helper.SFP_STATUS_INSERTED
             transceiver_dict = {}
             status = sfp_status_helper.SFP_STATUS_INSERTED if not status else status
             rc = post_port_sfp_info_to_db(port_change_event.port_name, self.port_mapping, int_tbl, transceiver_dict)
@@ -2170,9 +2168,7 @@ class SfpStateUpdateTask(threading.Thread):
                 notify_media_setting(port_change_event.port_name, transceiver_dict, self.xcvr_table_helper.get_app_port_tbl(port_change_event.asic_id), self.port_mapping)
         else:
             status = sfp_status_helper.SFP_STATUS_REMOVED if not status else status
-        logical_port_event_dict[port_change_event.port_name] = status
         update_port_transceiver_status_table_sw(port_change_event.port_name, status_tbl, status, error_description)
-        return logical_port_event_dict
 
     def retry_eeprom_reading(self):
         """Retry EEPROM reading, if retry succeed, remove the logical port from the retry set

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2115,98 +2115,63 @@ class SfpStateUpdateTask(threading.Thread):
             dict: key is logical port name, value is SFP status
         """
         # A logical port is created. There could be 3 cases:
-        #  1. SFP information is already in DB, which means that a logical port with the same physical index is in DB before.
-        #     Need copy the data from existing logical port and insert it into TRANSCEIVER_DOM_INFO, TRANSCEIVER_STATUS_INFO
-        #     and TRANSCEIVER_INFO table.
-        #  2. SFP information is not in DB and SFP is present with no SFP error. Need query the SFP status by platform API and
+        #  1. SFP is present with no SFP error. Need query the SFP status by platform API and
         #     insert the data to DB.
-        #  3. SFP information is not in DB and SFP is present with SFP error. If the SFP error does not block EEPROM reading,
+        #  2. SFP is present with SFP error. If the SFP error does not block EEPROM reading,
         #     just query transceiver information and DOM sensor information via platform API and update the data to DB; otherwise,
         #     just update TRANSCEIVER_STATUS table with the error.
-        #  4. SFP information is not in DB and SFP is not present. Only update TRANSCEIVER_STATUS_INFO table.
+        #  3. SFP is not present. Only update TRANSCEIVER_STATUS_INFO table.
         logical_port_event_dict = {}
-        sfp_status = None
-        sibling_port = None
         status_tbl = self.xcvr_table_helper.get_status_tbl(port_change_event.asic_id)
         int_tbl = self.xcvr_table_helper.get_intf_tbl(port_change_event.asic_id)
         dom_tbl = self.xcvr_table_helper.get_dom_tbl(port_change_event.asic_id)
         dom_threshold_tbl = self.xcvr_table_helper.get_dom_threshold_tbl(port_change_event.asic_id)
         pm_tbl = self.xcvr_table_helper.get_pm_tbl(port_change_event.asic_id)
-        physical_port_list = self.port_mapping.logical_port_name_to_physical_port_list(port_change_event.port_name)
 
-        # Try to find a logical port with same physical index in DB
-        for physical_port in physical_port_list:
-            logical_port_list = self.port_mapping.get_physical_to_logical(physical_port)
-            if not logical_port_list:
-                continue
+        error_description = 'N/A'
+        status = None
+        read_eeprom = True
+        if port_change_event.port_index in self.sfp_error_dict:
+            value, error_dict = self.sfp_error_dict[port_change_event.port_index]
+            status = value
+            error_bits = int(value)
+            helper_logger.log_info("Got SFP error event {}".format(value))
 
-            for logical_port in logical_port_list:
-                found, sfp_status = status_tbl.get(logical_port)
-                if found:
-                    sibling_port = logical_port
-                    break
+            error_descriptions = sfp_status_helper.fetch_generic_error_description(error_bits)
 
-            if sfp_status:
-                break
-
-        if sfp_status:
-            # SFP information is in DB
-            status_tbl.set(port_change_event.port_name, sfp_status)
-            logical_port_event_dict[port_change_event.port_name] = dict(sfp_status)['status']
-            found, sfp_info = int_tbl.get(sibling_port)
-            if found:
-                int_tbl.set(port_change_event.port_name, sfp_info)
-            found, dom_info = dom_tbl.get(sibling_port)
-            if found:
-                dom_tbl.set(port_change_event.port_name, dom_info)
-            found, dom_threshold_info = dom_threshold_tbl.get(sibling_port)
-            if found:
-                dom_threshold_tbl.set(port_change_event.port_name, dom_threshold_info)
-        else:
-            error_description = 'N/A'
-            status = None
-            read_eeprom = True
-            if port_change_event.port_index in self.sfp_error_dict:
-                value, error_dict = self.sfp_error_dict[port_change_event.port_index]
-                status = value
-                error_bits = int(value)
-                helper_logger.log_info("Got SFP error event {}".format(value))
-
-                error_descriptions = sfp_status_helper.fetch_generic_error_description(error_bits)
-
-                if sfp_status_helper.has_vendor_specific_error(error_bits):
-                    if error_dict:
-                        vendor_specific_error_description = error_dict.get(port_change_event.port_index)
-                    else:
-                        vendor_specific_error_description = _wrapper_get_sfp_error_description(port_change_event.port_index)
-                    error_descriptions.append(vendor_specific_error_description)
-
-                error_description = '|'.join(error_descriptions)
-                helper_logger.log_info("Receive error update port sfp status table.")
-                if sfp_status_helper.is_error_block_eeprom_reading(error_bits):
-                    read_eeprom = False
-
-            # SFP information not in DB
-            if _wrapper_get_presence(port_change_event.port_index) and read_eeprom:
-                logical_port_event_dict[port_change_event.port_name] = sfp_status_helper.SFP_STATUS_INSERTED
-                transceiver_dict = {}
-                status = sfp_status_helper.SFP_STATUS_INSERTED if not status else status
-                rc = post_port_sfp_info_to_db(port_change_event.port_name, self.port_mapping, int_tbl, transceiver_dict)
-                if rc == SFP_EEPROM_NOT_READY:
-                    # Failed to read EEPROM, put it to retry set
-                    self.retry_eeprom_set.add(port_change_event.port_name)
+            if sfp_status_helper.has_vendor_specific_error(error_bits):
+                if error_dict:
+                    vendor_specific_error_description = error_dict.get(port_change_event.port_index)
                 else:
-                    post_port_dom_info_to_db(port_change_event.port_name, self.port_mapping, dom_tbl)
-                    post_port_dom_threshold_info_to_db(port_change_event.port_name, self.port_mapping, dom_threshold_tbl)
-                    update_port_transceiver_status_table_hw(port_change_event.port_name,
-                                                            self.port_mapping,
-                                                            status_tbl)
-                    post_port_pm_info_to_db(port_change_event.port_name, self.port_mapping, pm_tbl)
-                    notify_media_setting(port_change_event.port_name, transceiver_dict, self.xcvr_table_helper.get_app_port_tbl(port_change_event.asic_id), self.port_mapping)
+                    vendor_specific_error_description = _wrapper_get_sfp_error_description(port_change_event.port_index)
+                error_descriptions.append(vendor_specific_error_description)
+
+            error_description = '|'.join(error_descriptions)
+            helper_logger.log_info("Receive error update port sfp status table.")
+            if sfp_status_helper.is_error_block_eeprom_reading(error_bits):
+                read_eeprom = False
+
+        # SFP information not in DB
+        if _wrapper_get_presence(port_change_event.port_index) and read_eeprom:
+            logical_port_event_dict[port_change_event.port_name] = sfp_status_helper.SFP_STATUS_INSERTED
+            transceiver_dict = {}
+            status = sfp_status_helper.SFP_STATUS_INSERTED if not status else status
+            rc = post_port_sfp_info_to_db(port_change_event.port_name, self.port_mapping, int_tbl, transceiver_dict)
+            if rc == SFP_EEPROM_NOT_READY:
+                # Failed to read EEPROM, put it to retry set
+                self.retry_eeprom_set.add(port_change_event.port_name)
             else:
-                status = sfp_status_helper.SFP_STATUS_REMOVED if not status else status
-            logical_port_event_dict[port_change_event.port_name] = status
-            update_port_transceiver_status_table_sw(port_change_event.port_name, status_tbl, status, error_description)
+                post_port_dom_info_to_db(port_change_event.port_name, self.port_mapping, dom_tbl)
+                post_port_dom_threshold_info_to_db(port_change_event.port_name, self.port_mapping, dom_threshold_tbl)
+                update_port_transceiver_status_table_hw(port_change_event.port_name,
+                                                        self.port_mapping,
+                                                        status_tbl)
+                post_port_pm_info_to_db(port_change_event.port_name, self.port_mapping, pm_tbl)
+                notify_media_setting(port_change_event.port_name, transceiver_dict, self.xcvr_table_helper.get_app_port_tbl(port_change_event.asic_id), self.port_mapping)
+        else:
+            status = sfp_status_helper.SFP_STATUS_REMOVED if not status else status
+        logical_port_event_dict[port_change_event.port_name] = status
+        update_port_transceiver_status_table_sw(port_change_event.port_name, status_tbl, status, error_description)
         return logical_port_event_dict
 
     def retry_eeprom_reading(self):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Fix issue https://github.com/sonic-net/sonic-buildimage/issues/14213.

https://github.com/sonic-net/sonic-platform-daemons/commit/56046dc36907c7e873911ef60e9193fe8717b12c introduces a race condition between DomInfoUpdateTask and SfpStateUpdateTask. In this PR, `SfpStateUpdateTask::on_add_logical_port` is changed to no longer depending on TRANSECIVER_STATUS table and always get SFP data from platform API.

#### Motivation and Context
Fix https://github.com/sonic-net/sonic-buildimage/issues/14213

#### How Has This Been Tested?
Manual test
UT logs:
```
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /sonic/src/sonic-platform-daemons/sonic-xcvrd, configfile: pytest.ini
plugins: pyfakefs-5.1.0, cov-2.10.1
collecting ... collected 54 items

tests/test_xcvrd.py::TestXcvrdThreadException::test_CmisManagerTask_task_run_with_exception PASSED [  1%]
tests/test_xcvrd.py::TestXcvrdThreadException::test_DomInfoUpdateTask_task_run_with_exception PASSED [  3%]
tests/test_xcvrd.py::TestXcvrdThreadException::test_SfpStateUpdateTask_task_run_with_exception PASSED [  5%]
tests/test_xcvrd.py::TestXcvrdThreadException::test_DaemonXcvrd_run_with_exception PASSED [  7%]
tests/test_xcvrd.py::TestXcvrdScript::test_post_port_dom_info_to_db PASSED [  9%]
tests/test_xcvrd.py::TestXcvrdScript::test_post_port_pm_info_to_db PASSED [ 11%]
tests/test_xcvrd.py::TestXcvrdScript::test_del_port_sfp_dom_info_from_db PASSED [ 12%]
tests/test_xcvrd.py::TestXcvrdScript::test_update_port_transceiver_status_table_hw PASSED [ 14%]
tests/test_xcvrd.py::TestXcvrdScript::test_delete_port_from_status_table_hw PASSED [ 16%]
tests/test_xcvrd.py::TestXcvrdScript::test_delete_port_from_status_table_sw PASSED [ 18%]
tests/test_xcvrd.py::TestXcvrdScript::test_post_port_dom_threshold_info_to_db PASSED [ 20%]
tests/test_xcvrd.py::TestXcvrdScript::test_post_port_sfp_info_to_db PASSED [ 22%]
tests/test_xcvrd.py::TestXcvrdScript::test_post_port_sfp_dom_info_to_db PASSED [ 24%]
tests/test_xcvrd.py::TestXcvrdScript::test_init_port_sfp_status_tbl PASSED [ 25%]
tests/test_xcvrd.py::TestXcvrdScript::test_get_media_settings_key PASSED [ 27%]
tests/test_xcvrd.py::TestXcvrdScript::test_notify_media_setting PASSED   [ 29%]
tests/test_xcvrd.py::TestXcvrdScript::test_notify_media_setting_with_comma PASSED [ 31%]
tests/test_xcvrd.py::TestXcvrdScript::test_detect_port_in_error_status PASSED [ 33%]
tests/test_xcvrd.py::TestXcvrdScript::test_is_error_sfp_status PASSED    [ 35%]
tests/test_xcvrd.py::TestXcvrdScript::test_handle_port_update_event PASSED [ 37%]
tests/test_xcvrd.py::TestXcvrdScript::test_handle_port_config_change PASSED [ 38%]
tests/test_xcvrd.py::TestXcvrdScript::test_get_port_mapping PASSED       [ 40%]
tests/test_xcvrd.py::TestXcvrdScript::test_DaemonXcvrd_wait_for_port_config_done PASSED [ 42%]
tests/test_xcvrd.py::TestXcvrdScript::test_DaemonXcvrd_run PASSED        [ 44%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_handle_port_change_event PASSED [ 46%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_get_configured_freq PASSED [ 48%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_get_configured_tx_power_from_db PASSED [ 50%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_task_run_stop PASSED [ 51%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_task_worker PASSED [ 53%]
tests/test_xcvrd.py::TestXcvrdScript::test_DomInfoUpdateTask_handle_port_change_event PASSED [ 55%]
tests/test_xcvrd.py::TestXcvrdScript::test_DomInfoUpdateTask_task_run_stop PASSED [ 57%]
tests/test_xcvrd.py::TestXcvrdScript::test_DomInfoUpdateTask_task_worker PASSED [ 59%]
tests/test_xcvrd.py::TestXcvrdScript::test_SfpStateUpdateTask_handle_port_change_event PASSED [ 61%]
tests/test_xcvrd.py::TestXcvrdScript::test_SfpStateUpdateTask_task_run_stop PASSED [ 62%]
tests/test_xcvrd.py::TestXcvrdScript::test_SfpStateUpdateTask_retry_eeprom_reading PASSED [ 64%]
tests/test_xcvrd.py::TestXcvrdScript::test_SfpStateUpdateTask_mapping_event_from_change_event PASSED [ 66%]
tests/test_xcvrd.py::TestXcvrdScript::test_SfpStateUpdateTask_task_worker PASSED [ 68%]
tests/test_xcvrd.py::TestXcvrdScript::test_SfpStateUpdateTask_on_add_logical_port PASSED [ 70%]
tests/test_xcvrd.py::TestXcvrdScript::test_sfp_insert_events PASSED      [ 72%]
tests/test_xcvrd.py::TestXcvrdScript::test_sfp_remove_events PASSED      [ 74%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_presence PASSED   [ 75%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_is_replaceable PASSED [ 77%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_transceiver_info PASSED [ 79%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_transceiver_dom_info PASSED [ 81%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_transceiver_dom_threshold_info PASSED [ 83%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_transceiver_status PASSED [ 85%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_transceiver_pm PASSED [ 87%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_transceiver_change_event PASSED [ 88%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_sfp_type PASSED   [ 90%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_sfp_error_description PASSED [ 92%]
tests/test_xcvrd.py::TestXcvrdScript::test_check_port_in_range PASSED    [ 94%]
tests/test_xcvrd.py::TestXcvrdScript::test_get_media_val_str_from_dict PASSED [ 96%]
tests/test_xcvrd.py::TestXcvrdScript::test_get_media_val_str PASSED      [ 98%]
tests/test_xcvrd.py::TestXcvrdScript::test_DaemonXcvrd_init_deinit PASSED [100%]

=============================== warnings summary ===============================
/usr/lib/python3/dist-packages/_pytest/junitxml.py:446
  /usr/lib/python3/dist-packages/_pytest/junitxml.py:446: PytestDeprecationWarning: The 'junit_family' default value will change to 'xunit2' in pytest 6.0. See:
    https://docs.pytest.org/en/stable/deprecations.html#junit-family-default-value-change-to-xunit2
  for more information.
    _issue_warning_captured(deprecated.JUNIT_XML_DEFAULT_FAMILY, config.hook, 2)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
- generated xml file: /sonic/src/sonic-platform-daemons/sonic-xcvrd/test-results.xml -

----------- coverage: platform linux, python 3.9.2-final-0 -----------
Name                                         Stmts   Miss  Cover
----------------------------------------------------------------
xcvrd/__init__.py                                0      0   100%
xcvrd/xcvrd.py                                1508    352    77%
xcvrd/xcvrd_utilities/__init__.py                0      0   100%
xcvrd/xcvrd_utilities/port_mapping.py          191     26    86%
xcvrd/xcvrd_utilities/sfp_status_helper.py      25      1    96%
----------------------------------------------------------------
TOTAL                                         1724    379    78%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

======================== 54 passed, 1 warning in 8.67s =========================
```

#### Additional Information (Optional)
