### PR TITLE
chassisd: Fix crash on exit on linecard

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -435,6 +435,8 @@ class ChassisdDaemon(daemon_base.DaemonBase):
         if self.module_updater.supervisor_slot == self.module_updater.my_slot:
             config_manager = ConfigManagerTask()
             config_manager.task_run()
+        else:
+            config_manager = None
 
         # Start main loop
         self.log_info("Start daemon main loop")

--- a/sonic-chassisd/tests/mock_swsscommon.py
+++ b/sonic-chassisd/tests/mock_swsscommon.py
@@ -30,3 +30,18 @@ class FieldValuePairs:
     def __init__(self, fvs):
         self.fv_dict = dict(fvs)
         pass
+
+class Select:
+    TIMEOUT = 1
+
+    def addSelectable(self, selectable):
+        pass
+
+    def removeSelectable(self, selectable):
+        pass
+
+    def select(self, timeout=-1, interrupt_on_signal=False):
+        return self.TIMEOUT, None
+
+class SubscriberStateTable(Table):
+    pass

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -507,9 +507,20 @@ def test_signal_handler():
     assert daemon_chassisd.stop.set.call_count == 0
     assert exit_code == 0
 
-def test_daemon_run():
+def test_daemon_run_supervisor():
     # Test the chassisd run
     daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER)
     daemon_chassisd.stop = MagicMock()
     daemon_chassisd.stop.wait.return_value = True
     daemon_chassisd.run()
+
+def test_daemon_run_linecard():
+    # Test the chassisd run
+    daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER)
+    daemon_chassisd.stop = MagicMock()
+    daemon_chassisd.stop.wait.return_value = True
+
+    import sonic_platform.platform
+    with patch.object(sonic_platform.platform.Chassis, 'get_my_slot') as mock:
+       mock.return_value = sonic_platform.platform.Platform().get_chassis().get_supervisor_slot() + 1
+       daemon_chassisd.run()


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

#### Description
Set the `config_manager` variable to `None` if we are running on a linecard and thus don't need to set up the config manager.

#### Motivation and Context
During cleanup, the chassid service tries to clean up the `config_manager`, but the `config_manager` variable is only ever initialized if we are on the supervisor. Thus, checking if it is `None` is insufficient because this results in an `UnboundLocalError` that prevents the cleanup from succeeding on a linecard.

#### How Has This Been Tested?
This was tested via the sonic-mgmt `platform_tests/daemon/test_chassisd.py` test. Without this change, the `test_pmon_chassisd_stop_and_start_status` test would fail and a traceback would be present in syslog. The test passes with this patch applied.

#### Additional Information (Optional)
