### PR TITLE
Fixed [pmon] [chassisd] supervisorctl stop and start testcase fail issue.

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -431,6 +431,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
             self.log_error("Chassisd not supported for this platform")
             sys.exit(CHASSIS_NOT_SUPPORTED)
 
+        config_manager = None
         # Start configuration manager task on supervisor module
         if self.module_updater.supervisor_slot == self.module_updater.my_slot:
             config_manager = ConfigManagerTask()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Fixed supervisorctl stop and start fail by initializing config_manager = None. This holds good for line card and the error is resolved.

#### Motivation and Context
Unable to stop and start chassisd.
Fixes : https://github.com/sonic-net/sonic-buildimage/issues/14374

#### How Has This Been Tested?
Run the below command.
```
docker exec pmon supervisorctl stop chassisd
```
#### Additional Information (Optional)
This fix should resolve the errors logged in syslog and also clear the table entries.