### PR TITLE
thermalctld: remove temperature diff threshold

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -439,8 +439,6 @@ class FanUpdater(logger.Logger):
 
 
 class TemperatureStatus(logger.Logger):
-    TEMPERATURE_DIFF_THRESHOLD = 10
-
     def __init__(self):
         super(TemperatureStatus, self).__init__(SYSLOG_IDENTIFIER)
 
@@ -461,15 +459,7 @@ class TemperatureStatus(logger.Logger):
                 self.temperature = None
             return
 
-        if self.temperature is None:
-            self.temperature = temperature
-        else:
-            diff = abs(temperature - self.temperature)
-            if diff > TemperatureStatus.TEMPERATURE_DIFF_THRESHOLD:
-                self.log_warning(
-                    'Temperature of {} changed too fast, from {} to {}, please check your hardware'.format(
-                        name, self.temperature, temperature))
-            self.temperature = temperature
+        self.temperature = temperature
 
     def _check_temperature_value_available(self, temperature, threshold, current_status):
         if temperature == NOT_AVAILABLE or threshold == NOT_AVAILABLE:


### PR DESCRIPTION
#### Description

Remove the thermalctld syslog when a sensor temperature has increased above 10C between 2 temperature polling iteration.

#### Motivation and Context

The temperature diff threshold is falsly reporting temperature issues for some sensors.
Because it is not configurable per sensor and only hardcoded to 10C some sensors might trigger the warning when there is actually no reason to worry.

Considering a CPU temperature sensors at idle ~40C and being given a 100% all core workload, its temperature can shoot and stabilize around 70C within seconds (while its high threshold is 90C). Given that a cooling algorithm iteration and temperature polling happens every 60s this threshold can be easily reached.
Even though the interval for the cooling algorithm can be adjusted, it would not prevent this issue from arising.

Was this check ever meaningful to anyone?
Having a sensor going beyond its high threshold should be a worrying sign and not some component warming up due to its usage while still hovering way lower that it's high threshold.

#### How Has This Been Tested?

Tested manually on a product experiencing this issue.
This product has a low CPU temperature during idle states.
When given a workload, the CPU temperature would rise up quickly within seconds until it reaches a stable state.

- start thermalctld
- assert low cpu temperuture
- run `stress -c 4`
- monitor syslog to see the 'check your hardware' message

```
Ambiant temperature: 40C
Stress temperature: 70C
High threshold: 90C
Critical threshold: 100C
```
