### PR TITLE
[xcvrd] Fix crash with subinterfaces

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -984,7 +984,7 @@ class CmisManagerTask(threading.Thread):
             return
 
         # Skip if it's not a physical port
-        if not lport.startswith('Ethernet'):
+        if not re.match('^Ethernet[0-9]*$', lport):
             return
 
         # Skip if the physical index is not available


### PR DESCRIPTION
#### Description

Fix xcvrd crash in case configuration has subinterfaces

#### Motivation and Context

xcvrd crashes if logical port is subinterface, e.g. Ethernet8.20

```
Apr 28 14:52:36.951523 lab-x1-abq51 ERR pmon#sfp: Exception occured at CmisManagerTask thread due to KeyError(None)
Apr 28 14:52:36.952579 lab-x1-abq51 ERR pmon#sfp: Traceback (most recent call last):
Apr 28 14:52:36.952579 lab-x1-abq51 ERR pmon#sfp:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1622, in run
Apr 28 14:52:36.952603 lab-x1-abq51 ERR pmon#sfp:     self.task_worker()
Apr 28 14:52:36.952659 lab-x1-abq51 ERR pmon#sfp:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1387, in task_worker
Apr 28 14:52:36.952690 lab-x1-abq51 ERR pmon#sfp:     self.port_dict[lport]['host_tx_ready'] = self.get_host_tx_status(lport)
Apr 28 14:52:36.952719 lab-x1-abq51 ERR pmon#sfp:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1292, in get_host_tx_status
Apr 28 14:52:36.952778 lab-x1-abq51 ERR pmon#sfp:     state_port_tbl = self.xcvr_table_helper.get_state_port_tbl(asic_index)
Apr 28 14:52:36.952807 lab-x1-abq51 ERR pmon#sfp:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 2511, in get_state_port_tbl
Apr 28 14:52:36.952839 lab-x1-abq51 ERR pmon#sfp:     return self.state_port_tbl[asic_id]
Apr 28 14:52:36.952864 lab-x1-abq51 ERR pmon#sfp: KeyError: None
Apr 28 14:52:36.952958 lab-x1-abq51 ERR pmon#sfp: Xcvrd: exception found at child thread CmisManagerTask due to KeyError(None)
Apr 28 14:52:36.953000 lab-x1-abq51 ERR pmon#sfp: Exiting main loop as child thread raised exception!
```

#### How Has This Been Tested?
Manual test

```
============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /sonic/src/sonic-platform-daemons/sonic-xcvrd, inifile: pytest.ini
plugins: pyfakefs-5.1.0, cov-2.6.0
collecting ... collected 70 items

tests/test_xcvrd.py::TestXcvrdThreadException::test_CmisManagerTask_task_run_with_exception PASSED [  1%] 
tests/test_xcvrd.py::TestXcvrdThreadException::test_DomInfoUpdateTask_task_run_with_exception PASSED [  2%] 
tests/test_xcvrd.py::TestXcvrdThreadException::test_SfpStateUpdateTask_task_run_with_exception PASSED [  4%] 
tests/test_xcvrd.py::TestXcvrdThreadException::test_DaemonXcvrd_run_with_exception PASSED [  5%] 
tests/test_xcvrd.py::TestXcvrdScript::test_post_port_dom_info_to_db PASSED [  7%] 
tests/test_xcvrd.py::TestXcvrdScript::test_post_port_pm_info_to_db PASSED [  8%] 
tests/test_xcvrd.py::TestXcvrdScript::test_del_port_sfp_dom_info_from_db PASSED [ 10%]
tests/test_xcvrd.py::TestXcvrdScript::test_update_port_transceiver_status_table_hw PASSED [ 11%]
tests/test_xcvrd.py::TestXcvrdScript::test_delete_port_from_status_table_hw PASSED [ 12%]
tests/test_xcvrd.py::TestXcvrdScript::test_delete_port_from_status_table_sw PASSED [ 14%]
tests/test_xcvrd.py::TestXcvrdScript::test_post_port_dom_threshold_info_to_db PASSED [ 15%]
tests/test_xcvrd.py::TestXcvrdScript::test_post_port_sfp_info_to_db PASSED [ 17%]
tests/test_xcvrd.py::TestXcvrdScript::test_post_port_sfp_dom_info_to_db PASSED [ 18%]
tests/test_xcvrd.py::TestXcvrdScript::test_init_port_sfp_status_tbl PASSED [ 20%]
tests/test_xcvrd.py::TestXcvrdScript::test_get_media_settings_key PASSED [ 21%]
tests/test_xcvrd.py::TestXcvrdScript::test_notify_media_setting PASSED   [ 22%]
tests/test_xcvrd.py::TestXcvrdScript::test_notify_media_setting_with_comma PASSED [ 24%]
tests/test_xcvrd.py::TestXcvrdScript::test_detect_port_in_error_status PASSED [ 25%]
tests/test_xcvrd.py::TestXcvrdScript::test_is_error_sfp_status PASSED    [ 27%]
tests/test_xcvrd.py::TestXcvrdScript::test_handle_port_update_event PASSED [ 28%]
tests/test_xcvrd.py::TestXcvrdScript::test_handle_port_config_change PASSED [ 30%]
tests/test_xcvrd.py::TestXcvrdScript::test_get_port_mapping PASSED       [ 31%]
tests/test_xcvrd.py::TestXcvrdScript::test_DaemonXcvrd_wait_for_port_config_done PASSED [ 32%]
tests/test_xcvrd.py::TestXcvrdScript::test_DaemonXcvrd_run PASSED        [ 34%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_handle_port_change_event PASSED [ 35%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_get_configured_freq PASSED [ 37%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_get_configured_tx_power_from_db PASSED [ 38%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_task_run_stop PASSED [ 40%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_is_cmis_application_update_required[1-15-lane_appl_code0-default_dp_state0-default_config_status0-False] PASSED [ 41%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_is_cmis_application_update_required[1-15-lane_appl_code1-default_dp_state1-default_config_status1-True] PASSED [ 42%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_is_cmis_application_update_required[1-240-lane_appl_code2-default_dp_state2-default_config_status2-False] PASSED [ 44%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_is_cmis_application_update_required[1-240-lane_appl_code3-default_dp_state3-default_config_status3-True] PASSED [ 45%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_is_cmis_application_update_required[1-240-lane_appl_code4-default_dp_state4-default_config_status4-True] PASSED [ 47%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_is_cmis_application_update_required[4-240-lane_appl_code5-default_dp_state5-default_config_status5-True] PASSED [ 48%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_is_cmis_application_update_required[3-192-lane_appl_code6-default_dp_state6-default_config_status6-False] PASSED [ 50%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_is_cmis_application_update_required[1-15-lane_appl_code7-default_dp_state7-default_config_status7-True] PASSED [ 51%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_is_cmis_application_update_required[-1-15-lane_appl_code8-default_dp_state8-default_config_status8-False] PASSED [ 52%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_get_cmis_host_lanes_mask[8-400000-0-255] PASSED [ 54%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_get_cmis_host_lanes_mask[4-100000-1-15] PASSED [ 55%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_get_cmis_host_lanes_mask[4-100000-2-240] PASSED [ 57%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_get_cmis_host_lanes_mask[4-100000-0-15] PASSED [ 58%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_get_cmis_host_lanes_mask[4-100000-9-0] PASSED [ 60%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_get_cmis_host_lanes_mask[1-50000-2-2] PASSED [ 61%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_get_cmis_host_lanes_mask[1-200000-2-0] PASSED [ 62%]
tests/test_xcvrd.py::TestXcvrdScript::test_CmisManagerTask_task_worker PASSED [ 64%]
tests/test_xcvrd.py::TestXcvrdScript::test_DomInfoUpdateTask_handle_port_change_event PASSED [ 65%]
tests/test_xcvrd.py::TestXcvrdScript::test_DomInfoUpdateTask_task_run_stop PASSED [ 67%]
tests/test_xcvrd.py::TestXcvrdScript::test_DomInfoUpdateTask_task_worker PASSED [ 68%]
tests/test_xcvrd.py::TestXcvrdScript::test_SfpStateUpdateTask_handle_port_change_event PASSED [ 70%]
tests/test_xcvrd.py::TestXcvrdScript::test_SfpStateUpdateTask_task_run_stop PASSED [ 71%]
tests/test_xcvrd.py::TestXcvrdScript::test_SfpStateUpdateTask_retry_eeprom_reading PASSED [ 72%]
tests/test_xcvrd.py::TestXcvrdScript::test_SfpStateUpdateTask_mapping_event_from_change_event PASSED [ 74%]
tests/test_xcvrd.py::TestXcvrdScript::test_SfpStateUpdateTask_task_worker PASSED [ 75%]
tests/test_xcvrd.py::TestXcvrdScript::test_SfpStateUpdateTask_on_add_logical_port PASSED [ 77%]
tests/test_xcvrd.py::TestXcvrdScript::test_sfp_insert_events PASSED      [ 78%]
tests/test_xcvrd.py::TestXcvrdScript::test_sfp_remove_events PASSED      [ 80%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_presence PASSED   [ 81%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_is_replaceable PASSED [ 82%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_transceiver_info PASSED [ 84%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_transceiver_dom_info PASSED [ 85%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_transceiver_dom_threshold_info PASSED [ 87%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_transceiver_status PASSED [ 88%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_transceiver_pm PASSED [ 90%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_transceiver_change_event PASSED [ 91%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_sfp_type PASSED   [ 92%]
tests/test_xcvrd.py::TestXcvrdScript::test_wrapper_get_sfp_error_description PASSED [ 94%]
tests/test_xcvrd.py::TestXcvrdScript::test_check_port_in_range PASSED    [ 95%]
tests/test_xcvrd.py::TestXcvrdScript::test_get_media_val_str_from_dict PASSED [ 97%]
tests/test_xcvrd.py::TestXcvrdScript::test_get_media_val_str PASSED      [ 98%]
tests/test_xcvrd.py::TestXcvrdScript::test_DaemonXcvrd_init_deinit_fastboot_enabled PASSED [100%]

 generated xml file: /sonic/src/sonic-platform-daemons/sonic-xcvrd/test-results.xml

----------- coverage: platform linux, python 3.7.3-final-0 -----------
Name                                         Stmts   Miss  Cover
----------------------------------------------------------------
xcvrd/__init__.py                                0      0   100%
xcvrd/xcvrd.py                                1544    340    78%
xcvrd/xcvrd_utilities/__init__.py                0      0   100%
xcvrd/xcvrd_utilities/port_mapping.py          193     26    87%
xcvrd/xcvrd_utilities/sfp_status_helper.py      25      1    96%
----------------------------------------------------------------
TOTAL                                         1762    367    79%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

========================== 70 passed in 8.22 seconds ===========================
```

