### PR TITLE
Separate periodic v/s fixed EEPROM reads between threads and optimize xcvrd boot-up time

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -394,7 +394,7 @@ class TestXcvrdScript(object):
                                                                                     'tx7power': '0.7',
                                                                                     'tx8power': '0.7', }))
     @patch('swsscommon.swsscommon.WarmStart', MagicMock())
-    def test_post_port_sfp_info_dom_thr_to_db_during_xcvrd_boootup(self):
+    def test_post_port_sfp_info_dom_thr_to_db_during_xcvrd_bootup(self):
         port_mapping = PortMapping()
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         port_mapping.handle_port_change_event(port_change_event)
@@ -402,7 +402,7 @@ class TestXcvrdScript(object):
         xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         sfp_error_event = threading.Event()
         task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
-        task._post_port_sfp_info_dom_thr_to_db_during_xcvrd_boootup(port_mapping, xcvr_table_helper, stop_event)
+        task._post_port_sfp_info_dom_thr_to_db_during_xcvrd_bootup(port_mapping, xcvr_table_helper, stop_event)
 
     @patch('xcvrd.xcvrd_utilities.port_mapping.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd.platform_sfputil', MagicMock(return_value=[0]))

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -396,8 +396,10 @@ class TestXcvrdScript(object):
     @patch('swsscommon.swsscommon.WarmStart', MagicMock())
     def test_post_port_sfp_info_dom_thr_to_db_during_xcvrd_boootup(self):
         port_mapping = PortMapping()
-        xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
+        port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
+        port_mapping.handle_port_change_event(port_change_event)
         stop_event = threading.Event()
+        xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         sfp_error_event = threading.Event()
         task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
         task._post_port_sfp_info_dom_thr_to_db_during_xcvrd_boootup(port_mapping, xcvr_table_helper, stop_event)

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -409,8 +409,10 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     def test_init_port_sfp_status_tbl(self):
         port_mapping = PortMapping()
-        xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
+        port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
+        port_mapping.handle_port_change_event(port_change_event)
         stop_event = threading.Event()
+        xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         sfp_error_event = threading.Event()
         task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
         task._init_port_sfp_status_tbl(port_mapping, xcvr_table_helper, stop_event)

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -84,13 +84,13 @@ class TestXcvrdThreadException(object):
         assert("sonic-xcvrd/xcvrd/xcvrd.py" in str(trace))
         assert("subscribe_port_config_change" in str(trace))
 
+    @patch('xcvrd.xcvrd.SfpStateUpdateTask.init', MagicMock())
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_config_change', MagicMock(side_effect = NotImplementedError))
     def test_SfpStateUpdateTask_task_run_with_exception(self):
         port_mapping = PortMapping()
-        retry_eeprom_set = set()
         stop_event = threading.Event()
         sfp_error_event = threading.Event()
-        sfp_state_update = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, retry_eeprom_set, stop_event, sfp_error_event)
+        sfp_state_update = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
         exception_received = None
         trace = None
         try:
@@ -393,13 +393,14 @@ class TestXcvrdScript(object):
                                                                                     'tx6power': '0.7',
                                                                                     'tx7power': '0.7',
                                                                                     'tx8power': '0.7', }))
-    def test_post_port_sfp_dom_info_to_db(self):
+    @patch('swsscommon.swsscommon.WarmStart', MagicMock())
+    def test_post_port_sfp_info_dom_thr_to_db_during_xcvrd_boootup(self):
         port_mapping = PortMapping()
-        port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
-        port_mapping.handle_port_change_event(port_change_event)
-        stop_event = threading.Event()
         xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
-        post_port_sfp_dom_info_to_db(True, port_mapping, xcvr_table_helper, stop_event)
+        stop_event = threading.Event()
+        sfp_error_event = threading.Event()
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
+        task._post_port_sfp_info_dom_thr_to_db_during_xcvrd_boootup(port_mapping, xcvr_table_helper, stop_event)
 
     @patch('xcvrd.xcvrd_utilities.port_mapping.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd.platform_sfputil', MagicMock(return_value=[0]))
@@ -408,11 +409,11 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     def test_init_port_sfp_status_tbl(self):
         port_mapping = PortMapping()
-        port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
-        port_mapping.handle_port_change_event(port_change_event)
-        stop_event = threading.Event()
         xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
-        init_port_sfp_status_tbl(port_mapping, xcvr_table_helper, stop_event)
+        stop_event = threading.Event()
+        sfp_error_event = threading.Event()
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
+        task._init_port_sfp_status_tbl(port_mapping, xcvr_table_helper, stop_event)
 
     def test_get_media_settings_key(self):
         xcvr_info_dict = {
@@ -943,14 +944,13 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     @patch('xcvrd.xcvrd_utilities.sfp_status_helper.detect_port_in_error_status')
     @patch('xcvrd.xcvrd.post_port_dom_info_to_db')
-    @patch('xcvrd.xcvrd.post_port_dom_threshold_info_to_db')
     @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
     @patch('swsscommon.swsscommon.SubscriberStateTable')
     @patch('swsscommon.swsscommon.Select.select')
     @patch('xcvrd.xcvrd.update_port_transceiver_status_table_hw')
     @patch('xcvrd.xcvrd.post_port_pm_info_to_db')
     def test_DomInfoUpdateTask_task_worker(self, mock_post_pm_info, mock_update_status_hw,
-                                           mock_select, mock_sub_table, mock_post_dom_th,
+                                           mock_select, mock_sub_table,
                                            mock_post_dom_info, mock_detect_error):
         mock_selectable = MagicMock()
         mock_selectable.pop = MagicMock(
@@ -969,14 +969,12 @@ class TestXcvrdScript(object):
         assert task.port_mapping.get_asic_id_for_logical_port('Ethernet0') == 0
         assert task.port_mapping.get_physical_to_logical(1) == ['Ethernet0']
         assert task.port_mapping.get_logical_to_physical('Ethernet0') == [1]
-        assert mock_post_dom_th.call_count == 0
         assert mock_post_dom_info.call_count == 0
         assert mock_update_status_hw.call_count == 0
         assert mock_post_pm_info.call_count == 0
         mock_detect_error.return_value = False
         task.task_stopping_event.wait = MagicMock(side_effect=[False, True])
         task.task_worker()
-        assert mock_post_dom_th.call_count == 1
         assert mock_post_dom_info.call_count == 1
         assert mock_update_status_hw.call_count == 1
         assert mock_post_pm_info.call_count == 1
@@ -994,8 +992,7 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         sfp_error_event = threading.Event()
         port_mapping = PortMapping()
-        retry_eeprom_set = set()
-        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, retry_eeprom_set, stop_event, sfp_error_event)
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl = mock_table_helper.get_status_tbl
         task.xcvr_table_helper.get_intf_tbl = mock_table_helper.get_intf_tbl
@@ -1031,10 +1028,9 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_config_change', MagicMock(return_value=(None, None)))
     def test_SfpStateUpdateTask_task_run_stop(self):
         port_mapping = PortMapping()
-        retry_eeprom_set = set()
         stop_event = threading.Event()
         sfp_error_event = threading.Event()
-        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, retry_eeprom_set, stop_event, sfp_error_event)
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
         task.start()
         assert wait_until(5, 1, task.is_alive)
         task.raise_exception()
@@ -1043,23 +1039,19 @@ class TestXcvrdScript(object):
 
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')
-    @patch('xcvrd.xcvrd.update_port_transceiver_status_table_hw')
-    def test_SfpStateUpdateTask_retry_eeprom_reading(self, mock_update_status_hw, mock_post_sfp_info):
+    def test_SfpStateUpdateTask_retry_eeprom_reading(self, mock_post_sfp_info):
         mock_table = MagicMock()
         mock_table.get = MagicMock(return_value=(False, None))
 
         port_mapping = PortMapping()
-        retry_eeprom_set = set()
         stop_event = threading.Event()
         sfp_error_event = threading.Event()
-        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, retry_eeprom_set, stop_event, sfp_error_event)
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=mock_table)
-        task.xcvr_table_helper.get_dom_tbl = MagicMock(return_value=mock_table)
         task.xcvr_table_helper.get_dom_threshold_tbl = MagicMock(return_value=mock_table)
         task.xcvr_table_helper.get_app_port_tbl = MagicMock(return_value=mock_table)
         task.xcvr_table_helper.get_status_tbl = MagicMock(return_value=mock_table)
-        task.xcvr_table_helper.get_pm_tbl = MagicMock(return_value=mock_table)
         task.retry_eeprom_reading()
         assert mock_post_sfp_info.call_count == 0
 
@@ -1067,26 +1059,22 @@ class TestXcvrdScript(object):
         task.last_retry_eeprom_time = time.time()
         task.retry_eeprom_reading()
         assert mock_post_sfp_info.call_count == 0
-        assert mock_update_status_hw.call_count == 0
 
         task.last_retry_eeprom_time = 0
         mock_post_sfp_info.return_value = SFP_EEPROM_NOT_READY
         task.retry_eeprom_reading()
         assert 'Ethernet0' in task.retry_eeprom_set
-        assert mock_update_status_hw.call_count == 0
 
         task.last_retry_eeprom_time = 0
         mock_post_sfp_info.return_value = None
         task.retry_eeprom_reading()
         assert 'Ethernet0' not in task.retry_eeprom_set
-        assert mock_update_status_hw.call_count == 1
 
     def test_SfpStateUpdateTask_mapping_event_from_change_event(self):
         port_mapping = PortMapping()
-        retry_eeprom_set = set()
         stop_event = threading.Event()
         sfp_error_event = threading.Event()
-        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, retry_eeprom_set, stop_event, sfp_error_event)
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
         port_dict = {}
         assert task._mapping_event_from_change_event(False, port_dict) == SYSTEM_FAIL
         assert port_dict[EVENT_ON_ALL_SFP] == SYSTEM_FAIL
@@ -1106,26 +1094,23 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd._wrapper_soak_sfp_insert_event', MagicMock())
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_config_change', MagicMock(return_value=(None, None)))
     @patch('xcvrd.xcvrd_utilities.port_mapping.handle_port_config_change', MagicMock())
+    @patch('xcvrd.xcvrd.SfpStateUpdateTask.init', MagicMock())
     @patch('os.kill')
     @patch('xcvrd.xcvrd.SfpStateUpdateTask._mapping_event_from_change_event')
     @patch('xcvrd.xcvrd._wrapper_get_transceiver_change_event')
     @patch('xcvrd.xcvrd.del_port_sfp_dom_info_from_db')
     @patch('xcvrd.xcvrd.notify_media_setting')
     @patch('xcvrd.xcvrd.post_port_dom_threshold_info_to_db')
-    @patch('xcvrd.xcvrd.post_port_dom_info_to_db')
     @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')
     @patch('xcvrd.xcvrd.update_port_transceiver_status_table_sw')
-    @patch('xcvrd.xcvrd.update_port_transceiver_status_table_hw')
     @patch('xcvrd.xcvrd.delete_port_from_status_table_hw')
-    @patch('xcvrd.xcvrd.post_port_pm_info_to_db')
-    def test_SfpStateUpdateTask_task_worker(self, mock_post_pm_info, mock_del_status_hw, mock_update_status_hw,
-            mock_update_status, mock_post_sfp_info, mock_post_dom_info, mock_post_dom_th, mock_update_media_setting,
+    def test_SfpStateUpdateTask_task_worker(self, mock_del_status_hw,
+            mock_update_status, mock_post_sfp_info, mock_post_dom_th, mock_update_media_setting,
             mock_del_dom, mock_change_event, mock_mapping_event, mock_os_kill):
         port_mapping = PortMapping()
-        retry_eeprom_set = set()
         stop_event = threading.Event()
         sfp_error_event = threading.Event()
-        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, retry_eeprom_set, stop_event, sfp_error_event)
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         mock_change_event.return_value = (True, {0: 0}, {})
         mock_mapping_event.return_value = SYSTEM_NOT_READY
@@ -1171,10 +1156,7 @@ class TestXcvrdScript(object):
         task.task_worker(stop_event, sfp_error_event)
         assert mock_update_status.call_count == 1
         assert mock_post_sfp_info.call_count == 2  # first call and retry call
-        assert mock_post_dom_info.call_count == 0
         assert mock_post_dom_th.call_count == 0
-        assert mock_update_status_hw.call_count == 0
-        assert mock_post_pm_info.call_count == 0
         assert mock_update_media_setting.call_count == 0
         assert 'Ethernet0' in task.retry_eeprom_set
         task.retry_eeprom_set.clear()
@@ -1187,20 +1169,15 @@ class TestXcvrdScript(object):
         task.task_worker(stop_event, sfp_error_event)
         assert mock_update_status.call_count == 1
         assert mock_post_sfp_info.call_count == 1
-        assert mock_post_dom_info.call_count == 1
         assert mock_post_dom_th.call_count == 1
-        assert mock_update_status_hw.call_count == 1
-        assert mock_post_pm_info.call_count == 1
         assert mock_update_media_setting.call_count == 1
 
         stop_event.is_set = MagicMock(side_effect=[False, True])
         mock_change_event.return_value = (True, {1: SFP_STATUS_REMOVED}, {})
         mock_update_status.reset_mock()
-        mock_update_status_hw.reset_mock()
         # Test state machine: handle SFP remove event
         task.task_worker(stop_event, sfp_error_event)
         assert mock_update_status.call_count == 1
-        assert mock_update_status_hw.call_count == 0 # only SW fields are updated
         assert mock_del_dom.call_count == 1
         assert mock_del_status_hw.call_count == 1
 
@@ -1208,13 +1185,11 @@ class TestXcvrdScript(object):
         error = int(SFP_STATUS_INSERTED) | SfpBase.SFP_ERROR_BIT_BLOCKING | SfpBase.SFP_ERROR_BIT_POWER_BUDGET_EXCEEDED
         mock_change_event.return_value = (True, {1: error}, {})
         mock_update_status.reset_mock()
-        mock_update_status_hw.reset_mock()
         mock_del_dom.reset_mock()
         mock_del_status_hw.reset_mock()
         # Test state machine: handle SFP error event
         task.task_worker(stop_event, sfp_error_event)
         assert mock_update_status.call_count == 1
-        assert mock_update_status_hw.call_count == 0 # only SW fields are updated
         assert mock_del_dom.call_count == 1
         assert mock_del_status_hw.call_count == 1
 
@@ -1222,10 +1197,9 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd._wrapper_get_presence')
     @patch('xcvrd.xcvrd.notify_media_setting')
     @patch('xcvrd.xcvrd.post_port_dom_threshold_info_to_db')
-    @patch('xcvrd.xcvrd.post_port_dom_info_to_db')
     @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')
     @patch('xcvrd.xcvrd.update_port_transceiver_status_table_sw')
-    def test_SfpStateUpdateTask_on_add_logical_port(self, mock_update_status, mock_post_sfp_info, mock_post_dom_info,
+    def test_SfpStateUpdateTask_on_add_logical_port(self, mock_update_status, mock_post_sfp_info,
             mock_post_dom_th, mock_update_media_setting, mock_get_presence, mock_table_helper):
         class MockTable:
             pass
@@ -1236,26 +1210,20 @@ class TestXcvrdScript(object):
         int_tbl = MockTable()
         int_tbl.get = MagicMock(return_value=(True, (('key2', 'value2'),)))
         int_tbl.set = MagicMock()
-        dom_tbl = MockTable()
-        dom_tbl.get = MagicMock(return_value=(True, (('key3', 'value3'),)))
-        dom_tbl.set = MagicMock()
         dom_threshold_tbl = MockTable()
         dom_threshold_tbl.get = MagicMock(return_value=(True, (('key4', 'value4'),)))
         dom_threshold_tbl.set = MagicMock()
         mock_table_helper.get_status_tbl = MagicMock(return_value=status_tbl)
         mock_table_helper.get_intf_tbl = MagicMock(return_value=int_tbl)
-        mock_table_helper.get_dom_tbl = MagicMock(return_value=dom_tbl)
         mock_table_helper.get_dom_threshold_tbl = MagicMock(return_value=dom_threshold_tbl)
 
         port_mapping = PortMapping()
-        retry_eeprom_set = set()
         stop_event = threading.Event()
         sfp_error_event = threading.Event()
-        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, retry_eeprom_set, stop_event, sfp_error_event)
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl = mock_table_helper.get_status_tbl
         task.xcvr_table_helper.get_intf_tbl = mock_table_helper.get_intf_tbl
-        task.xcvr_table_helper.get_dom_tbl = mock_table_helper.get_dom_tbl
         task.xcvr_table_helper.get_dom_threshold_tbl = mock_table_helper.get_dom_threshold_tbl
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         task.port_mapping.handle_port_change_event(port_change_event)
@@ -1269,7 +1237,6 @@ class TestXcvrdScript(object):
         mock_update_status.assert_called_with('Ethernet0', status_tbl, SFP_STATUS_INSERTED, 'N/A')
         assert mock_post_sfp_info.call_count == 1
         mock_post_sfp_info.assert_called_with('Ethernet0', task.port_mapping, int_tbl, {})
-        assert mock_post_dom_info.call_count == 0
         assert mock_post_dom_th.call_count == 0
         assert mock_update_media_setting.call_count == 0
         assert 'Ethernet0' in task.retry_eeprom_set
@@ -1284,8 +1251,6 @@ class TestXcvrdScript(object):
         mock_update_status.assert_called_with('Ethernet0', status_tbl, SFP_STATUS_INSERTED, 'N/A')
         assert mock_post_sfp_info.call_count == 1
         mock_post_sfp_info.assert_called_with('Ethernet0', task.port_mapping, int_tbl, {})
-        assert mock_post_dom_info.call_count == 1
-        mock_post_dom_info.assert_called_with('Ethernet0', task.port_mapping, dom_tbl)
         assert mock_post_dom_th.call_count == 1
         mock_post_dom_th.assert_called_with('Ethernet0', task.port_mapping, dom_threshold_tbl)
         assert mock_update_media_setting.call_count == 1

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -394,7 +394,7 @@ class TestXcvrdScript(object):
                                                                                     'tx7power': '0.7',
                                                                                     'tx8power': '0.7', }))
     @patch('swsscommon.swsscommon.WarmStart', MagicMock())
-    def test_post_port_sfp_info_dom_thr_to_db_during_xcvrd_bootup(self):
+    def test_post_port_sfp_info_and_dom_thr_to_db_once(self):
         port_mapping = PortMapping()
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         port_mapping.handle_port_change_event(port_change_event)
@@ -402,7 +402,7 @@ class TestXcvrdScript(object):
         xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         sfp_error_event = threading.Event()
         task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
-        task._post_port_sfp_info_dom_thr_to_db_during_xcvrd_bootup(port_mapping, xcvr_table_helper, stop_event)
+        task._post_port_sfp_info_and_dom_thr_to_db_once(port_mapping, xcvr_table_helper, stop_event)
 
     @patch('xcvrd.xcvrd_utilities.port_mapping.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd.platform_sfputil', MagicMock(return_value=[0]))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1832,7 +1832,7 @@ class SfpStateUpdateTask(threading.Thread):
         return event
 
     # Update port sfp info and dom threshold in db during xcvrd bootup
-    def _post_port_sfp_info_dom_thr_to_db_during_xcvrd_bootup(self, port_mapping, xcvr_table_helper, stop_event=threading.Event()):
+    def _post_port_sfp_info_and_dom_thr_to_db_once(self, port_mapping, xcvr_table_helper, stop_event=threading.Event()):
         # Connect to STATE_DB and create transceiver dom/sfp info tables
         transceiver_dict = {}
         retry_eeprom_set = set()
@@ -1898,7 +1898,7 @@ class SfpStateUpdateTask(threading.Thread):
         port_mapping_data = port_mapping.get_port_mapping(self.namespaces)
 
         # Post all the current interface sfp/dom threshold info to STATE_DB
-        self.retry_eeprom_set = self._post_port_sfp_info_dom_thr_to_db_during_xcvrd_bootup(port_mapping_data, self.xcvr_table_helper, self.main_thread_stop_event)
+        self.retry_eeprom_set = self._post_port_sfp_info_and_dom_thr_to_db_once(port_mapping_data, self.xcvr_table_helper, self.main_thread_stop_event)
         helper_logger.log_notice("SfpStateUpdateTask: Posted all port DOM/SFP info to DB")
 
         # Init port sfp status table

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2413,6 +2413,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         for namespace in self.namespaces:
             self.wait_for_port_config_done(namespace)
 
+        self.log_notice("XCVRD INIT: After port config is done")
         return port_mapping.get_port_mapping(self.namespaces)
 
     # Deinitialize daemon

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -544,44 +544,6 @@ def post_port_pm_info_to_db(logical_port_name, port_mapping, table, stop_event=t
         else:
             return SFP_EEPROM_NOT_READY
 
-# Update port dom/sfp info in db
-
-
-def post_port_sfp_dom_info_to_db(is_warm_start, port_mapping, xcvr_table_helper, stop_event=threading.Event()):
-    # Connect to STATE_DB and create transceiver dom/sfp info tables
-    transceiver_dict = {}
-    retry_eeprom_set = set()
-
-    # Post all the current interface dom/sfp info to STATE_DB
-    logical_port_list = port_mapping.logical_port_list
-    for logical_port_name in logical_port_list:
-        if stop_event.is_set():
-            break
-
-        # Get the asic to which this port belongs
-        asic_index = port_mapping.get_asic_id_for_logical_port(logical_port_name)
-        if asic_index is None:
-            helper_logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
-            continue
-        rc = post_port_sfp_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict, stop_event)
-        if rc != SFP_EEPROM_NOT_READY:
-            post_port_dom_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_dom_tbl(asic_index), stop_event)
-            post_port_dom_threshold_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_dom_threshold_tbl(asic_index), stop_event)
-            update_port_transceiver_status_table_hw(logical_port_name,
-                                                    port_mapping,
-                                                    xcvr_table_helper.get_status_tbl(asic_index),
-                                                    stop_event)
-            post_port_pm_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_pm_tbl(asic_index), stop_event)
-
-            # Do not notify media settings during warm reboot to avoid dataplane traffic impact
-            if is_warm_start == False:
-                notify_media_setting(logical_port_name, transceiver_dict, xcvr_table_helper.get_app_port_tbl(asic_index), port_mapping)
-                transceiver_dict.clear()
-        else:
-            retry_eeprom_set.add(logical_port_name)
-
-    return retry_eeprom_set
-
 # Delete port dom/sfp info from db
 
 
@@ -889,36 +851,6 @@ def delete_port_from_status_table_hw(logical_port_name, port_mapping, status_tbl
             if f in TRANSCEIVER_STATUS_TABLE_SW_FIELDS:
                 continue
             status_tbl.hdel(physical_port_name, f)
-
-# Init TRANSCEIVER_STATUS table
-
-
-def init_port_sfp_status_tbl(port_mapping, xcvr_table_helper, stop_event=threading.Event()):
-    # Init TRANSCEIVER_STATUS table
-    logical_port_list = port_mapping.logical_port_list
-    for logical_port_name in logical_port_list:
-        if stop_event.is_set():
-            break
-
-        # Get the asic to which this port belongs
-        asic_index = port_mapping.get_asic_id_for_logical_port(logical_port_name)
-        if asic_index is None:
-            helper_logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
-            continue
-
-        physical_port_list = port_mapping.logical_port_name_to_physical_port_list(logical_port_name)
-        if physical_port_list is None:
-            helper_logger.log_error("No physical ports found for logical port '{}'".format(logical_port_name))
-            update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_tbl(asic_index), sfp_status_helper.SFP_STATUS_REMOVED)
-
-        for physical_port in physical_port_list:
-            if stop_event.is_set():
-                break
-
-            if not _wrapper_get_presence(physical_port):
-                update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_tbl(asic_index), sfp_status_helper.SFP_STATUS_REMOVED)
-            else:
-                update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_tbl(asic_index), sfp_status_helper.SFP_STATUS_INSERTED)
 
 def is_fast_reboot_enabled():
     fastboot_enabled = subprocess.check_output('sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable', shell=True, universal_newlines=True)
@@ -1781,14 +1713,17 @@ class DomInfoUpdateTask(threading.Thread):
                     continue
 
                 if not sfp_status_helper.detect_port_in_error_status(logical_port_name, self.xcvr_table_helper.get_status_tbl(asic_index)):
-                    post_port_dom_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_dom_tbl(asic_index), self.task_stopping_event, dom_info_cache=dom_info_cache)
-                    post_port_dom_threshold_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_dom_threshold_tbl(asic_index), self.task_stopping_event, dom_th_info_cache=dom_th_info_cache)
-                    update_port_transceiver_status_table_hw(logical_port_name,
-                                                            self.port_mapping,
-                                                            self.xcvr_table_helper.get_status_tbl(asic_index),
-                                                            self.task_stopping_event,
-                                                            transceiver_status_cache=transceiver_status_cache)
-                    post_port_pm_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_pm_tbl(asic_index), self.task_stopping_event, pm_info_cache=pm_info_cache)
+                    try:
+                        post_port_dom_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_dom_tbl(asic_index), self.task_stopping_event, dom_info_cache=dom_info_cache)
+                        update_port_transceiver_status_table_hw(logical_port_name,
+                                                                self.port_mapping,
+                                                                self.xcvr_table_helper.get_status_tbl(asic_index),
+                                                                self.task_stopping_event,
+                                                                transceiver_status_cache=transceiver_status_cache)
+                        post_port_pm_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_pm_tbl(asic_index), self.task_stopping_event, pm_info_cache=pm_info_cache)
+                    except (KeyError, TypeError):
+                        #continue to process next port since execption could be raised due to port reset, transceiver removal
+                        continue
 
         helper_logger.log_info("Stop DOM monitoring loop")
 
@@ -1824,14 +1759,14 @@ class DomInfoUpdateTask(threading.Thread):
         Args:
             port_change_event (object): port change event
         """
-        # To avoid race condition, remove the entry TRANSCEIVER_DOM_INFO table.
-        # This thread only update TRANSCEIVER_DOM_INFO table, so we don't have to remove entries from
-        # TRANSCEIVER_INFO and TRANSCEIVER_STATUS_INFO
+        # To avoid race condition, remove the entry TRANSCEIVER_DOM_SENSOR, TRANSCEIVER_PM and HW section of TRANSCEIVER_STATUS table.
+        # This thread only updates TRANSCEIVER_DOM_SENSOR, TRANSCEIVER_PM and HW section of TRANSCEIVER_STATUS table,
+        # so we don't have to remove entries from TRANSCEIVER_INFO and TRANSCEIVER_DOM_THRESHOLD
         del_port_sfp_dom_info_from_db(port_change_event.port_name,
                                       self.port_mapping,
                                       None,
                                       self.xcvr_table_helper.get_dom_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_dom_threshold_tbl(port_change_event.asic_id),
+                                      None,
                                       self.xcvr_table_helper.get_pm_tbl(port_change_event.asic_id))
         delete_port_from_status_table_hw(port_change_event.port_name,
                                       self.port_mapping,
@@ -1843,7 +1778,7 @@ class DomInfoUpdateTask(threading.Thread):
 
 class SfpStateUpdateTask(threading.Thread):
     RETRY_EEPROM_READING_INTERVAL = 60
-    def __init__(self, namespaces, port_mapping, retry_eeprom_set, main_thread_stop_event, sfp_error_event):
+    def __init__(self, namespaces, port_mapping, main_thread_stop_event, sfp_error_event):
         threading.Thread.__init__(self)
         self.name = "SfpStateUpdateTask"
         self.exc = None
@@ -1852,7 +1787,7 @@ class SfpStateUpdateTask(threading.Thread):
         self.sfp_error_event = sfp_error_event
         self.port_mapping = copy.deepcopy(port_mapping)
         # A set to hold those logical port name who fail to read EEPROM
-        self.retry_eeprom_set = retry_eeprom_set
+        self.retry_eeprom_set = set()
         # To avoid retry EEPROM read too fast, record the last EEPROM read timestamp in this member
         self.last_retry_eeprom_time = 0
         # A dict to hold SFP error event, for SFP insert/remove event, it is not necessary to cache them
@@ -1884,6 +1819,80 @@ class SfpStateUpdateTask(threading.Thread):
 
         helper_logger.log_debug("mapping from {} {} to {}".format(status, port_dict, event))
         return event
+
+    # Update port sfp info and dom threshold in db during xcvrd bootup
+    def _post_port_sfp_info_dom_thr_to_db_during_xcvrd_boootup(self, port_mapping, xcvr_table_helper, stop_event=threading.Event()):
+        # Connect to STATE_DB and create transceiver dom/sfp info tables
+        transceiver_dict = {}
+        retry_eeprom_set = set()
+
+        warmstart = swsscommon.WarmStart()
+        warmstart.initialize("xcvrd", "pmon")
+        warmstart.checkWarmStart("xcvrd", "pmon", False)
+        is_warm_start = warmstart.isWarmStart()
+
+        # Post all the current interface sfp/dom threshold info to STATE_DB
+        logical_port_list = port_mapping.logical_port_list
+        for logical_port_name in logical_port_list:
+            if stop_event.is_set():
+                break
+
+            # Get the asic to which this port belongs
+            asic_index = port_mapping.get_asic_id_for_logical_port(logical_port_name)
+            if asic_index is None:
+                helper_logger.log_warning("Got invalid asic index for {}, ignored while posting SFP info during boot-up".format(logical_port_name))
+                continue
+            rc = post_port_sfp_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict, stop_event)
+            if rc != SFP_EEPROM_NOT_READY:
+                post_port_dom_threshold_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_dom_threshold_tbl(asic_index), stop_event)
+
+                # Do not notify media settings during warm reboot to avoid dataplane traffic impact
+                if is_warm_start == False:
+                    notify_media_setting(logical_port_name, transceiver_dict, xcvr_table_helper.get_app_port_tbl(asic_index), port_mapping)
+                    transceiver_dict.clear()
+            else:
+                retry_eeprom_set.add(logical_port_name)
+
+        return retry_eeprom_set
+
+    # Init TRANSCEIVER_STATUS table
+    def _init_port_sfp_status_tbl(self, port_mapping, xcvr_table_helper, stop_event=threading.Event()):
+        # Init TRANSCEIVER_STATUS table
+        logical_port_list = port_mapping.logical_port_list
+        for logical_port_name in logical_port_list:
+            if stop_event.is_set():
+                break
+
+            # Get the asic to which this port belongs
+            asic_index = port_mapping.get_asic_id_for_logical_port(logical_port_name)
+            if asic_index is None:
+                helper_logger.log_warning("Got invalid asic index for {}, ignored during sfp status table init".format(logical_port_name))
+                continue
+
+            physical_port_list = port_mapping.logical_port_name_to_physical_port_list(logical_port_name)
+            if physical_port_list is None:
+                helper_logger.log_error("No physical ports found for logical port '{}' during sfp status table init".format(logical_port_name))
+                update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_tbl(asic_index), sfp_status_helper.SFP_STATUS_REMOVED)
+
+            for physical_port in physical_port_list:
+                if stop_event.is_set():
+                    break
+
+                if not _wrapper_get_presence(physical_port):
+                    update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_tbl(asic_index), sfp_status_helper.SFP_STATUS_REMOVED)
+                else:
+                    update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_tbl(asic_index), sfp_status_helper.SFP_STATUS_INSERTED)
+
+    def init(self):
+        port_mapping_data = port_mapping.get_port_mapping(self.namespaces)
+
+        # Post all the current interface sfp/dom threshold info to STATE_DB
+        self.retry_eeprom_set = self._post_port_sfp_info_dom_thr_to_db_during_xcvrd_boootup(port_mapping_data, self.xcvr_table_helper, self.main_thread_stop_event)
+        helper_logger.log_notice("SfpStateUpdateTask: Posted all port DOM/SFP info to DB")
+
+        # Init port sfp status table
+        self._init_port_sfp_status_tbl(port_mapping_data, self.xcvr_table_helper, self.main_thread_stop_event)
+        helper_logger.log_notice("SfpStateUpdateTask: Initialized port sfp status table")
 
     def task_worker(self, stopping_event, sfp_error_event):
         self.xcvr_table_helper = XcvrTableHelper(self.namespaces)
@@ -1960,6 +1969,8 @@ class SfpStateUpdateTask(threading.Thread):
         retry = 0
         timeout = RETRY_PERIOD_FOR_SYSTEM_READY_MSECS
         state = STATE_INIT
+        self.init()
+
         sel, asic_context = port_mapping.subscribe_port_config_change(self.namespaces)
         while not stopping_event.is_set():
             port_mapping.handle_port_config_change(sel, asic_context, stopping_event, self.port_mapping, helper_logger, self.on_port_config_change)
@@ -2058,10 +2069,7 @@ class SfpStateUpdateTask(threading.Thread):
                                         self.retry_eeprom_set.add(logical_port)
 
                                 if rc != SFP_EEPROM_NOT_READY:
-                                    post_port_dom_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_dom_tbl(asic_index))
                                     post_port_dom_threshold_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_dom_threshold_tbl(asic_index))
-                                    update_port_transceiver_status_table_hw(logical_port, self.port_mapping, self.xcvr_table_helper.get_status_tbl(asic_index))
-                                    post_port_pm_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_pm_tbl(asic_index))
                                     notify_media_setting(logical_port, transceiver_dict, self.xcvr_table_helper.get_app_port_tbl(asic_index), self.port_mapping)
                                     transceiver_dict.clear()
                             elif value == sfp_status_helper.SFP_STATUS_REMOVED:
@@ -2226,9 +2234,7 @@ class SfpStateUpdateTask(threading.Thread):
         #  3. SFP is not present. Only update TRANSCEIVER_STATUS_INFO table.
         status_tbl = self.xcvr_table_helper.get_status_tbl(port_change_event.asic_id)
         int_tbl = self.xcvr_table_helper.get_intf_tbl(port_change_event.asic_id)
-        dom_tbl = self.xcvr_table_helper.get_dom_tbl(port_change_event.asic_id)
         dom_threshold_tbl = self.xcvr_table_helper.get_dom_threshold_tbl(port_change_event.asic_id)
-        pm_tbl = self.xcvr_table_helper.get_pm_tbl(port_change_event.asic_id)
 
         error_description = 'N/A'
         status = None
@@ -2262,12 +2268,7 @@ class SfpStateUpdateTask(threading.Thread):
                 # Failed to read EEPROM, put it to retry set
                 self.retry_eeprom_set.add(port_change_event.port_name)
             else:
-                post_port_dom_info_to_db(port_change_event.port_name, self.port_mapping, dom_tbl)
                 post_port_dom_threshold_info_to_db(port_change_event.port_name, self.port_mapping, dom_threshold_tbl)
-                update_port_transceiver_status_table_hw(port_change_event.port_name,
-                                                        self.port_mapping,
-                                                        status_tbl)
-                post_port_pm_info_to_db(port_change_event.port_name, self.port_mapping, pm_tbl)
                 notify_media_setting(port_change_event.port_name, transceiver_dict, self.xcvr_table_helper.get_app_port_tbl(port_change_event.asic_id), self.port_mapping)
         else:
             status = sfp_status_helper.SFP_STATUS_REMOVED if not status else status
@@ -2293,10 +2294,7 @@ class SfpStateUpdateTask(threading.Thread):
             asic_index = self.port_mapping.get_asic_id_for_logical_port(logical_port)
             rc = post_port_sfp_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict)
             if rc != SFP_EEPROM_NOT_READY:
-                post_port_dom_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_dom_tbl(asic_index))
                 post_port_dom_threshold_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_dom_threshold_tbl(asic_index))
-                update_port_transceiver_status_table_hw(logical_port, self.port_mapping, self.xcvr_table_helper.get_status_tbl(asic_index))
-                post_port_pm_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_pm_tbl(asic_index))
                 notify_media_setting(logical_port, transceiver_dict, self.xcvr_table_helper.get_app_port_tbl(asic_index), self.port_mapping)
                 transceiver_dict.clear()
                 retry_success_set.add(logical_port)
@@ -2370,7 +2368,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         global platform_sfputil
         global platform_chassis
 
-        self.log_info("Start daemon init...")
+        self.log_notice("XCVRD INIT: Start daemon init...")
 
         # Load new platform api class
         try:
@@ -2410,27 +2408,12 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         else:
             self.load_media_settings()
 
-        warmstart = swsscommon.WarmStart()
-        warmstart.initialize("xcvrd", "pmon")
-        warmstart.checkWarmStart("xcvrd", "pmon", False)
-        is_warm_start = warmstart.isWarmStart()
-
         # Make sure this daemon started after all port configured
-        self.log_info("Wait for port config is done")
+        self.log_notice("XCVRD INIT: Wait for port config is done")
         for namespace in self.namespaces:
             self.wait_for_port_config_done(namespace)
 
-        port_mapping_data = port_mapping.get_port_mapping(self.namespaces)
-
-        # Post all the current interface dom/sfp info to STATE_DB
-        self.log_info("Post all port DOM/SFP info to DB")
-        retry_eeprom_set = post_port_sfp_dom_info_to_db(is_warm_start, port_mapping_data, self.xcvr_table_helper, self.stop_event)
-
-        # Init port sfp status table
-        self.log_info("Init port sfp status table")
-        init_port_sfp_status_tbl(port_mapping_data, self.xcvr_table_helper, self.stop_event)
-
-        return port_mapping_data, retry_eeprom_set
+        return port_mapping.get_port_mapping(self.namespaces)
 
     # Deinitialize daemon
     def deinit(self):
@@ -2460,10 +2443,10 @@ class DaemonXcvrd(daemon_base.DaemonBase):
     # Run daemon
 
     def run(self):
-        self.log_info("Starting up...")
+        self.log_notice("Starting up...")
 
         # Start daemon initialization sequence
-        port_mapping_data, retry_eeprom_set = self.init()
+        port_mapping_data = self.init()
 
         # Start the CMIS manager
         cmis_manager = CmisManagerTask(self.namespaces, port_mapping_data, self.stop_event, self.skip_cmis_mgr)
@@ -2477,7 +2460,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         self.threads.append(dom_info_update)
 
         # Start the sfp state info update thread
-        sfp_state_update = SfpStateUpdateTask(self.namespaces, port_mapping_data, retry_eeprom_set, self.stop_event, self.sfp_error_event)
+        sfp_state_update = SfpStateUpdateTask(self.namespaces, port_mapping_data, self.stop_event, self.sfp_error_event)
         sfp_state_update.start()
         self.threads.append(sfp_state_update)
 

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/sfp_status_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/sfp_status_helper.py
@@ -32,6 +32,9 @@ def detect_port_in_error_status(logical_port_name, status_tbl):
     if rec:
         status_dict = dict(fvp)
         error = status_dict.get('error')
-        return SfpBase.SFP_ERROR_DESCRIPTION_BLOCKING in error
+        if error is not None:
+            return SfpBase.SFP_ERROR_DESCRIPTION_BLOCKING in error
+        else:
+            return False
     return False
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
It seems that currently, xcvrd consumes a lot of time (in the order of minutes) during the init phase to update the STATE_DB with information from transceiver EEPROM followed by spawning threads.
This initial update to state DB is a blocking call in the xcvrd main thread and hence, it increases the overall time to spawn threads. Hence, we need to ensure that CMIS init executes soon after xcvrd is spawned and parallelly proceed with STATE_DB updates with the relevant thread.
We also need to separate periodic v/s fixed EEPROM reads between threads to ensure that the DomInfoUpdateTask thread polls information from EEPROM which changes periodically and SfpStateUpdateTask updates STATE_DB with information which remains static after transceiver detection.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
1. Ensuring EEPROM fields which require to be periodically updated in State DB is driven by DomInfoUpdateTask and fields which remain constant after transceiver detection are updated in the state DB through SfpStateUpdateTask thread. Following is the summary of the changeset to achieve this
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr;border-width:100%'>

<div style='direction:ltr;margin-top:0in;margin-left:0in;width:6.6173in'>

<div style='direction:ltr;margin-top:0in;margin-left:0in;width:6.6173in'>

<div style='direction:ltr'>



State DB update   type | Periodic polling   required | Handler Thread
-- | -- | --
post_port_sfp_info_to_db   (Update TRANSCEIVER_INFO) | N | SfpStateUpdateTask
post_port_dom_threshold_info_to_db   (Update TRANSCEIVER_DOM_THRESHOLD) | N | SfpStateUpdateTask
update_port_transceiver_status_table_sw   (Update SW portion of TRANSCEIVER_STATUS) | N | SfpStateUpdateTask
post_port_dom_info_to_db   (Update TRANSCEIVER_DOM_SENSOR) | Y | DomInfoUpdateTask
post_port_pm_info_to_db   (Update TRANSCEIVER_PM) | Y | DomInfoUpdateTask
update_port_transceiver_status_table_hw   (Update HW portion of TRANSCEIVER_STATUS) | Y | DomInfoUpdateTask



</div>

</div>

</div>

</div>

<!--EndFragment-->
</body>

</html>


2. We are now skipping updating State DB for periodic EEPROM reads during xcvrd boot-up
3. Handling KeyError and TypeError exceptions as part of polling through DomInfoUpdateTask thread to avoid xcvrd crash during transceiver removal and "sfputil reset".
4. Fixed crash in detect_port_in_error_status when status_dict returns None if the key 'error' is not present

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Ensured that the o/p of transceiver EEPROM related CLIs (based on using data through redis-db) still displays the o/p without any changes to the previous behavior. This has been verified for 400ZR, 400G, 100G and 10G optics.
The below CLI o/p was captured before and after transceiver removal and insertion to ensure that the o/p is displayed correctly.
show int transceiver info $port_num
show int transceiver eeprom -d $port_num
show int transceiver pm $port_num

redis-cli -n 6 hgetall "TRANSCEIVER_INFO|$port_num
redis-cli -n 6 hgetall "TRANSCEIVER_DOM_SENSOR|$port_num
redis-cli -n 6 hgetall "TRANSCEIVER_DOM_THRESHOLD|$port_num
redis-cli -n 6 hgetall "TRANSCEIVER_PM|$port_num
redis-cli -n 6 hgetall "TRANSCEIVER_STATUS|$port_num

**o/p for 10G transceiver removal and insertion**
```
Logs after xcvr removal
root@sonic:/var/log# docker exec pmon supervisorctl status | grep xcvrd
DY
xcvrd                            RUNNING   pid 30, uptime 2:46:35
root@sonic:/var/log# cat syslog | grep "Got SFP"
May 30 22:58:19.399800 sonic NOTICE pmon#xcvrd[30]: Ethernet160: Got SFP removed event
May 30 23:00:10.015619 sonic NOTICE pmon#xcvrd[30]: Ethernet256: Got SFP removed event
root@sonic:/var/log#

root@sonic:/var/log# port_num=Ethernet256
root@sonic:/var/log# show int transceiver info $port_num
ow int transceiver pm $port_num
show int transceiver status $port_num
show int status $port_num
redis-cli -n 6 hgetall "TRANSCEIVER_INFO|$port_num";printf "\n";redis-cli -n 6 hgetall "TRANSCEIVER_DOM_SENSOR|$port_num";printf "\n";redis-cli -n 6 hgetall "TRANSCEIVER_DOM_THRESHOLD|$port_num";printf "\n";redis-cli -n 6 hgetall "TRANSCEIVER_PM|$port_num";printf "\n";redis-cli -n 6 hgetall "TRANSCEIVER_STATUS|$port_num";printf "\n";show lldp table
Ethernet256: SFP EEPROM Not detected
root@sonic:/var/log# show int transceiver eeprom -d $port_num
Ethernet256: SFP EEPROM Not detected
root@sonic:/var/log# show int transceiver pm $port_num
Ethernet256: Transceiver performance monitoring not applicable
root@sonic:/var/log# show int transceiver status $port_num
Usage: show int transceiver [OPTIONS] COMMAND [ARGS]...
Try "show int transceiver -h" for help.

Error: No such command "status".
root@sonic:/var/log# show int status $port_num
  Interface    Lanes    Speed    MTU    FEC       Alias    Vlan    Oper    Admin    Type    Asym PFC
-----------  -------  -------  -----  -----  ----------  ------  ------  -------  ------  ----------
Ethernet256      258      10G   9100    N/A  Ethernet33   trunk    down       up     N/A         N/A
root@sonic:/var/log# redis-cli -n 6 hgetall "TRANSCEIVER_INFO|$port_num";printf "\n";redis-cli -n 6 hgetall "TRANSCEIVER_DOM_SENSOR|$port_num";printf "\n";redis-cli -n 6 hgetall "TRANSCEIVER_DOM_THRESHOLD|$port_num";printf "\n";redis-cli -n 6 hgetall "TRANSCEIVER_PM|$port_num";printf "\n";redis-cli -n 6 hgetall "TRANSCEIVER_STATUS|$port_num";printf "\n";show lldp table
(empty array)

(empty array)

(empty array)

(empty array)

1) "status"
2) "0"
3) "error"
4) "N/A"

Capability codes: (R) Router, (B) Bridge, (O) Other
LocalPort    RemoteDevice                  RemotePortID    Capability    RemotePortDescr
-----------  ----------------------------  --------------  ------------  ------------------------
eth0         STR43-0101-0100-01M0.phx.gbl  Ethernet1/31    BR            INFRA:MGMT:$Description$
--------------------------------------------------
Total entries displayed:  1
root@sonic:/var/log# 

Logs after xcvr insertion
root@sonic:/var/log# docker exec pmon supervisorctl status | grep xcvrd
DY
xcvrd                            RUNNING   pid 30, uptime 3:02:13
root@sonic:/var/log# cat syslog | grep "Got SFP"
May 30 22:58:19.399800 sonic NOTICE pmon#xcvrd[30]: Ethernet160: Got SFP removed event
May 30 23:00:10.015619 sonic NOTICE pmon#xcvrd[30]: Ethernet256: Got SFP removed event
May 30 23:17:12.749646 sonic NOTICE pmon#xcvrd[30]: Ethernet160: Got SFP inserted event
May 30 23:17:19.725857 sonic NOTICE pmon#xcvrd[30]: Ethernet256: Got SFP inserted event
root@sonic:/var/log# cat syslog | grep READY
May 30 20:20:53.591065 sonic NOTICE pmon#xcvrd[30]: CMIS: Ethernet16: READY
May 30 20:21:03.044395 sonic NOTICE pmon#xcvrd[30]: CMIS: Ethernet0: READY
May 30 20:21:04.029571 sonic NOTICE pmon#xcvrd[30]: CMIS: Ethernet40: READY
May 30 20:22:02.027164 sonic NOTICE pmon#xcvrd[30]: CMIS: Ethernet144: READY
May 30 20:22:03.050010 sonic NOTICE pmon#xcvrd[30]: CMIS: Ethernet160: READY
May 30 23:19:07.921322 sonic NOTICE pmon#xcvrd[30]: CMIS: Ethernet160: READY
root@sonic:/var/log#

root@sonic:/var/log# port_num=Ethernet256
root@sonic:/var/log# show int transceiver info $port_num
ow int transceiver pm $port_num
show int transceiver status $port_num
show int status $port_num
Ethernet256: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: LC
        Encoding: 64B/66B
        Extended Identifier: GBIC/SFP defined by two-wire interface ID
        Extended RateSelect Compliance: Unknown
        Identifier: SFP/SFP+/SFP28
        Length OM3(10m): 30.0
        Nominal Bit Rate(100Mbs): 103
        Specification compliance:
                10G Ethernet Compliance: 10GBASE-SR
                ESCON Compliance: Unknown
                Ethernet Compliance: Unknown
                Fibre Channel Link Length: Unknown
                Fibre Channel Speed: Unknown
                Fibre Channel Transmission Media: Unknown
                Fibre Channel Transmitter Technology: Unknown
                Infiniband Compliance: Unknown
                SFP+CableTechnology: Unknown
                SONET Compliance Codes: Unknown
        Vendor Date Code(YYYY-MM-DD Lot): 2009-06-27   
        Vendor Name: FINISAR CORP.   
        Vendor OUI: 00-90-65
        Vendor PN: FTLX8571D3BCL   
        Vendor Rev: A   
        Vendor SN: UFS073Z         
root@sonic:/var/log# show int transceiver eeprom -d $port_num
Ethernet256: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: LC
        Encoding: 64B/66B
        Extended Identifier: GBIC/SFP defined by two-wire interface ID
        Extended RateSelect Compliance: Unknown
        Identifier: SFP/SFP+/SFP28
        Length OM3(10m): 30.0
        Nominal Bit Rate(100Mbs): 103
        Specification compliance:
                10G Ethernet Compliance: 10GBASE-SR
                ESCON Compliance: Unknown
                Ethernet Compliance: Unknown
                Fibre Channel Link Length: Unknown
                Fibre Channel Speed: Unknown
                Fibre Channel Transmission Media: Unknown
                Fibre Channel Transmitter Technology: Unknown
                Infiniband Compliance: Unknown
                SFP+CableTechnology: Unknown
                SONET Compliance Codes: Unknown
        Vendor Date Code(YYYY-MM-DD Lot): 2009-06-27   
        Vendor Name: FINISAR CORP.   
        Vendor OUI: 00-90-65
        Vendor PN: FTLX8571D3BCL   
        Vendor Rev: A   
        Vendor SN: UFS073Z         
        MonitorData:
                RXPower: 0.678dBm
                TXBias: 7.138mA
                TXPower: 0.521dBm
                Temperature: 21.02C
                Vcc: 3.375Volts
        ThresholdData:
                TempHighAlarm  : 78.0C
                TempHighWarning: 73.0C
                TempLowAlarm   : -13.0C
                TempLowWarning : -8.0C
                VccHighAlarm   : 3.7Volts
                VccHighWarning : 3.6Volts
                VccLowAlarm    : 2.9Volts
                VccLowWarning  : 3.0Volts
                RxPowerHighAlarm  : 0.0dBm
                RxPowerHighWarning: -1.0dBm
                RxPowerLowAlarm   : -20.0dBm
                RxPowerLowWarning : -18.013dBm
                TxBiasHighAlarm   : 11.8mA
                TxBiasHighWarning : 10.8mA
                TxBiasLowAlarm    : 4.0mA
                TxBiasLowWarning  : 5.0mA
                TxPowerHighAlarm  : -0.8dBm
                TxPowerHighWarning: -1.8dBm
                TxPowerLowAlarm   : -6.0dBm
                TxPowerLowWarning : -5.0dBm
root@sonic:/var/log# show int transceiver pm $port_num
Ethernet256: Transceiver performance monitoring not applicable
root@sonic:/var/log# show int transceiver status $port_num
Usage: show int transceiver [OPTIONS] COMMAND [ARGS]...
Try "show int transceiver -h" for help.

Error: No such command "status".
root@sonic:/var/log# show int status $port_num
  Interface    Lanes    Speed    MTU    FEC       Alias    Vlan    Oper    Admin            Type    Asym PFC
-----------  -------  -------  -----  -----  ----------  ------  ------  -------  --------------  ----------
Ethernet256      258      10G   9100    N/A  Ethernet33   trunk      up       up  SFP/SFP+/SFP28         N/A
root@sonic:/var/log#
root@sonic:/var/log# redis-cli -n 6 hgetall "TRANSCEIVER_INFO|$port_num";printf "\n";redis-cli -n 6 hgetall "TRANSCEIVER_DOM_SENSOR|$port_num";printf "\n";redis-cli -n 6 hgetall "TRANSCEIVER_DOM_THRESHOLD|$port_num";printf "\n";redis-cli -n 6 hgetall "TRANSCEIVER_PM|$port_num";printf "\n";redis-cli -n 6 hgetall "TRANSCEIVER_STATUS|$port_num";printf "\n";show lldp table
 1) "nominal_bit_rate"
 2) "103"
 3) "vendor_rev"
 4) "A   "
 5) "application_advertisement"
 6) "N/A"
 7) "model"
 8) "FTLX8571D3BCL   "
 9) "vendor_date"
10) "2009-06-27   "
11) "specification_compliance"
12) "{'10G Ethernet Compliance': '10GBASE-SR', 'Infiniband Compliance': 'Unknown', 'ESCON Compliance': 'Unknown', 'SONET Compliance Codes': 'Unknown', 'Ethernet Compliance': 'Unknown', 'Fibre Channel Link Length': 'Unknown', 'Fibre Channel Transmitter Technology': 'Unknown', 'SFP+CableTechnology': 'Unknown', 'Fibre Channel Transmission Media': 'Unknown', 'Fibre Channel Speed': 'Unknown'}"
13) "vendor_oui"
14) "00-90-65"
15) "serial"
16) "UFS073Z         "
17) "type"
18) "SFP/SFP+/SFP28"
19) "encoding"
20) "64B/66B"
21) "cable_length"
22) "30.0"
23) "manufacturer"
24) "FINISAR CORP.   "
25) "dom_capability"
26) "N/A"
27) "connector"
28) "LC"
29) "is_replaceable"
30) "True"
31) "ext_rateselect_compliance"
32) "Unknown"
33) "cable_type"
34) "Length OM3(10m)"
35) "ext_identifier"
36) "GBIC/SFP defined by two-wire interface ID"

 1) "rx_los"
 2) "False"
 3) "tx_fault"
 4) "False"
 5) "tx_disable"
 6) "False"
 7) "tx_disabled_channel"
 8) "0"
 9) "temperature"
10) "21.02"
11) "voltage"
12) "3.375"
13) "tx1bias"
14) "7.138"
15) "rx1power"
16) "0.678"
17) "tx1power"
18) "0.521"
19) "tx2bias"
20) "N/A"
21) "rx2power"
22) "N/A"
23) "tx2power"
24) "N/A"
25) "tx3bias"
26) "N/A"
27) "rx3power"
28) "N/A"
29) "tx3power"
30) "N/A"
31) "tx4bias"
32) "N/A"
33) "rx4power"
34) "N/A"
35) "tx4power"
36) "N/A"

 1) "temphighalarm"
 2) "78.0"
 3) "templowalarm"
 4) "-13.0"
 5) "temphighwarning"
 6) "73.0"
 7) "templowwarning"
 8) "-8.0"
 9) "vcchighalarm"
10) "3.7"
11) "vcclowalarm"
12) "2.9"
13) "vcchighwarning"
14) "3.6"
15) "vcclowwarning"
16) "3.0"
17) "rxpowerhighalarm"
18) "0.0"
19) "rxpowerlowalarm"
20) "-20.0"
21) "rxpowerhighwarning"
22) "-1.0"
23) "rxpowerlowwarning"
24) "-18.013"
25) "txpowerhighalarm"
26) "-0.8"
27) "txpowerlowalarm"
28) "-6.0"
29) "txpowerhighwarning"
30) "-1.8"
31) "txpowerlowwarning"
32) "-5.0"
33) "txbiashighalarm"
34) "11.8"
35) "txbiaslowalarm"
36) "4.0"
37) "txbiashighwarning"
38) "10.8"
39) "txbiaslowwarning"
40) "5.0"

(empty array)

1) "status"
2) "1"
3) "error"
4) "N/A"

Capability codes: (R) Router, (B) Bridge, (O) Other
LocalPort    RemoteDevice                  RemotePortID    Capability    RemotePortDescr
-----------  ----------------------------  --------------  ------------  ------------------------
Ethernet144  sonic                         Ethernet21/1    BR            Ethernet160
Ethernet160  sonic                         Ethernet19/1    BR            Ethernet144
Ethernet256  sonic                         Ethernet34      BR            Ethernet260
Ethernet260  sonic                         Ethernet33      BR            Ethernet256
eth0         STR43-0101-0100-01M0.phx.gbl  Ethernet1/31    BR            INFRA:MGMT:$Description$
--------------------------------------------------
Total entries displayed:  5
root@sonic:/var/log#

```
#### Additional Information (Optional)
