### PR TITLE
[show][chassis]: Add support for serial field to show chassis module status CLI

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -49,6 +49,7 @@ CHASSIS_MODULE_INFO_SLOT_FIELD = 'slot'
 CHASSIS_MODULE_INFO_OPERSTATUS_FIELD = 'oper_status'
 CHASSIS_MODULE_INFO_NUM_ASICS_FIELD = 'num_asics'
 CHASSIS_MODULE_INFO_ASICS = 'asics'
+CHASSIS_MODULE_INFO_SERIAL_FIELD = 'serial'
 
 CHASSIS_ASIC_INFO_TABLE = 'CHASSIS_ASIC_TABLE'
 CHASSIS_FABRIC_ASIC_INFO_TABLE = 'CHASSIS_FABRIC_ASIC_TABLE'
@@ -178,6 +179,7 @@ class ModuleUpdater(logger.Logger):
         self.info_dict_keys = [CHASSIS_MODULE_INFO_NAME_FIELD,
                                CHASSIS_MODULE_INFO_DESC_FIELD,
                                CHASSIS_MODULE_INFO_SLOT_FIELD,
+                               CHASSIS_MODULE_INFO_SERIAL_FIELD,
                                CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
         self.chassis_state_db = daemon_base.db_connect("CHASSIS_STATE_DB")
@@ -245,7 +247,8 @@ class ModuleUpdater(logger.Logger):
                                                   (CHASSIS_MODULE_INFO_SLOT_FIELD,
                                                    module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD]),
                                                   (CHASSIS_MODULE_INFO_OPERSTATUS_FIELD, module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]),
-                                                  (CHASSIS_MODULE_INFO_NUM_ASICS_FIELD, str(len(module_info_dict[CHASSIS_MODULE_INFO_ASICS])))])
+                                                  (CHASSIS_MODULE_INFO_NUM_ASICS_FIELD, str(len(module_info_dict[CHASSIS_MODULE_INFO_ASICS]))),
+                                                  (CHASSIS_MODULE_INFO_SERIAL_FIELD, module_info_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD])])
                 self.module_table.set(key, fvs)
 
                 if module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD] != str(ModuleBase.MODULE_STATUS_ONLINE):
@@ -285,12 +288,14 @@ class ModuleUpdater(logger.Logger):
                          default=ModuleBase.MODULE_STATUS_OFFLINE)
         asics = try_get(self.chassis.get_module(module_index).get_all_asics,
                         default=[])
+        serial = try_get(self.chassis.get_module(module_index).get_serial)
 
         module_info_dict[CHASSIS_MODULE_INFO_NAME_FIELD] = name
         module_info_dict[CHASSIS_MODULE_INFO_DESC_FIELD] = str(desc)
         module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD] = str(slot)
         module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD] = str(status)
         module_info_dict[CHASSIS_MODULE_INFO_ASICS] = asics
+        module_info_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD] = str(serial)
 
         return module_info_dict
 

--- a/sonic-chassisd/tests/mock_platform.py
+++ b/sonic-chassisd/tests/mock_platform.py
@@ -20,7 +20,7 @@ class MockDevice:
 
 class MockModule(MockDevice):
     def __init__(self, module_index, module_name, module_desc, module_type, module_slot,
-                 asic_list=[]):
+                 module_serial, asic_list=[]):
         self.module_index = module_index
         self.module_name = module_name
         self.module_desc = module_desc
@@ -31,6 +31,7 @@ class MockModule(MockDevice):
         self.supervisor_slot = 16
         self.midplane_access = False
         self.asic_list = asic_list
+        self.module_serial = module_serial
  
     def get_name(self):
         return self.module_name
@@ -73,6 +74,9 @@ class MockModule(MockDevice):
 
     def get_all_asics(self):
         return self.asic_list
+
+    def get_serial(self):
+        return self.module_serial
 
 class MockChassis:
     def __init__(self):

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -32,6 +32,7 @@ CHASSIS_MODULE_INFO_NAME_FIELD = 'name'
 CHASSIS_MODULE_INFO_DESC_FIELD = 'desc'
 CHASSIS_MODULE_INFO_SLOT_FIELD = 'slot'
 CHASSIS_MODULE_INFO_OPERSTATUS_FIELD = 'oper_status'
+CHASSIS_MODULE_INFO_SERIAL_FIELD = 'serial'
 
 CHASSIS_INFO_KEY_TEMPLATE = 'CHASSIS {}'
 CHASSIS_INFO_CARD_NUM_FIELD = 'module_num'
@@ -55,8 +56,9 @@ def test_moduleupdater_check_valid_fields():
     name = "FABRIC-CARD0"
     desc = "Switch Fabric Module"
     slot = 10
+    serial = "FC1000101"
     module_type = ModuleBase.MODULE_TYPE_FABRIC
-    module = MockModule(index, name, desc, module_type, slot)
+    module = MockModule(index, name, desc, module_type, slot, serial)
 
     # Set initial state
     status = ModuleBase.MODULE_STATUS_ONLINE
@@ -71,6 +73,7 @@ def test_moduleupdater_check_valid_fields():
     assert desc == fvs[CHASSIS_MODULE_INFO_DESC_FIELD]
     assert slot == int(fvs[CHASSIS_MODULE_INFO_SLOT_FIELD])
     assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    assert serial == fvs[CHASSIS_MODULE_INFO_SERIAL_FIELD]
 
 
 def test_moduleupdater_check_invalid_name():
@@ -79,8 +82,9 @@ def test_moduleupdater_check_invalid_name():
     name = "TEST-CARD0"
     desc = "36 port 400G card"
     slot = 2
+    serial = "TS1000101"
     module_type = ModuleBase.MODULE_TYPE_LINE
-    module = MockModule(index, name, desc, module_type, slot)
+    module = MockModule(index, name, desc, module_type, slot, serial)
 
     # Set initial state
     status = ModuleBase.MODULE_STATUS_PRESENT
@@ -101,8 +105,9 @@ def test_moduleupdater_check_status_update():
     name = "LINE-CARD0"
     desc = "36 port 400G card"
     slot = 1
+    serial = "LC1000101"
     module_type = ModuleBase.MODULE_TYPE_LINE
-    module = MockModule(index, name, desc, module_type, slot)
+    module = MockModule(index, name, desc, module_type, slot, serial)
 
     # Set initial state
     status = ModuleBase.MODULE_STATUS_ONLINE
@@ -136,8 +141,9 @@ def test_moduleupdater_check_deinit():
     name = "LINE-CARD0"
     desc = "36 port 400G card"
     slot = 1
+    serial = "LC1000101"
     module_type = ModuleBase.MODULE_TYPE_LINE
-    module = MockModule(index, name, desc, module_type, slot)
+    module = MockModule(index, name, desc, module_type, slot, serial)
 
     # Set initial state
     status = ModuleBase.MODULE_STATUS_ONLINE
@@ -163,8 +169,9 @@ def test_configupdater_check_valid_names():
     name = "TEST-CARD0"
     desc = "36 port 400G card"
     slot = 1
+    serial = "TC1000101"
     module_type = ModuleBase.MODULE_TYPE_LINE
-    module = MockModule(index, name, desc, module_type, slot)
+    module = MockModule(index, name, desc, module_type, slot, serial)
 
     # Set initial state
     status = ModuleBase.MODULE_STATUS_ONLINE
@@ -185,8 +192,9 @@ def test_configupdater_check_valid_index():
     name = "LINE-CARD0"
     desc = "36 port 400G card"
     slot = 1
+    serial = "LC1000101"
     module_type = ModuleBase.MODULE_TYPE_LINE
-    module = MockModule(index, name, desc, module_type, slot)
+    module = MockModule(index, name, desc, module_type, slot, serial)
 
     # Set initial state
     status = ModuleBase.MODULE_STATUS_ONLINE
@@ -207,8 +215,9 @@ def test_configupdater_check_admin_state():
     name = "LINE-CARD0"
     desc = "36 port 400G card"
     slot = 1
+    serial = "LC1000101"
     module_type = ModuleBase.MODULE_TYPE_LINE
-    module = MockModule(index, name, desc, module_type, slot)
+    module = MockModule(index, name, desc, module_type, slot, serial)
 
     # Set initial state
     status = ModuleBase.MODULE_STATUS_ONLINE
@@ -231,8 +240,9 @@ def test_configupdater_check_num_modules():
     name = "LINE-CARD0"
     desc = "36 port 400G card"
     slot = 1
+    serial = "LC1000101"
     module_type = ModuleBase.MODULE_TYPE_LINE
-    module = MockModule(index, name, desc, module_type, slot)
+    module = MockModule(index, name, desc, module_type, slot, serial)
 
     # No modules
     module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
@@ -259,8 +269,9 @@ def test_midplane_presence_modules():
     name = "SUPERVISOR0"
     desc = "Supervisor card"
     slot = 16
+    serial = "RP1000101"
     module_type = ModuleBase.MODULE_TYPE_SUPERVISOR
-    supervisor = MockModule(index, name, desc, module_type, slot)
+    supervisor = MockModule(index, name, desc, module_type, slot, serial)
     supervisor.set_midplane_ip()
     chassis.module_list.append(supervisor)
 
@@ -269,8 +280,9 @@ def test_midplane_presence_modules():
     name = "LINE-CARD0"
     desc = "36 port 400G card"
     slot = 1
+    serial = "LC1000101"
     module_type = ModuleBase.MODULE_TYPE_LINE
-    module = MockModule(index, name, desc, module_type, slot)
+    module = MockModule(index, name, desc, module_type, slot, serial)
     module.set_midplane_ip()
     chassis.module_list.append(module)
 
@@ -279,8 +291,9 @@ def test_midplane_presence_modules():
     name = "FABRIC-CARD0"
     desc = "Switch fabric card"
     slot = 17
+    serial = "FC1000101"
     module_type = ModuleBase.MODULE_TYPE_FABRIC
-    fabric = MockModule(index, name, desc, module_type, slot)
+    fabric = MockModule(index, name, desc, module_type, slot, serial)
     chassis.module_list.append(fabric)
 
     #Run on supervisor
@@ -324,8 +337,9 @@ def test_midplane_presence_supervisor():
     name = "SUPERVISOR0"
     desc = "Supervisor card"
     slot = 16
+    serial = "RP1000101"
     module_type = ModuleBase.MODULE_TYPE_SUPERVISOR
-    supervisor = MockModule(index, name, desc, module_type, slot)
+    supervisor = MockModule(index, name, desc, module_type, slot, serial)
     supervisor.set_midplane_ip()
     chassis.module_list.append(supervisor)
 
@@ -334,8 +348,9 @@ def test_midplane_presence_supervisor():
     name = "LINE-CARD0"
     desc = "36 port 400G card"
     slot = 1
+    serial = "LC1000101"
     module_type = ModuleBase.MODULE_TYPE_LINE
-    module = MockModule(index, name, desc, module_type, slot)
+    module = MockModule(index, name, desc, module_type, slot, serial)
     module.set_midplane_ip()
     chassis.module_list.append(module)
 
@@ -344,8 +359,9 @@ def test_midplane_presence_supervisor():
     name = "FABRIC-CARD0"
     desc = "Switch fabric card"
     slot = 17
+    serial = "FC1000101"
     module_type = ModuleBase.MODULE_TYPE_FABRIC
-    fabric = MockModule(index, name, desc, module_type, slot)
+    fabric = MockModule(index, name, desc, module_type, slot, serial)
     chassis.module_list.append(fabric)
 
     #Run on supervisor
@@ -389,8 +405,9 @@ def test_asic_presence():
     name = "SUPERVISOR0"
     desc = "Supervisor card"
     slot = 16
+    serial = "RP1000101"
     module_type = ModuleBase.MODULE_TYPE_SUPERVISOR
-    supervisor = MockModule(index, name, desc, module_type, slot)
+    supervisor = MockModule(index, name, desc, module_type, slot, serial)
     supervisor.set_midplane_ip()
     chassis.module_list.append(supervisor)
 
@@ -399,8 +416,9 @@ def test_asic_presence():
     name = "LINE-CARD0"
     desc = "36 port 400G card"
     slot = 1
+    serial = "LC1000101"
     module_type = ModuleBase.MODULE_TYPE_LINE
-    module = MockModule(index, name, desc, module_type, slot)
+    module = MockModule(index, name, desc, module_type, slot, serial)
     module.set_midplane_ip()
     chassis.module_list.append(module)
 
@@ -409,9 +427,10 @@ def test_asic_presence():
     name = "FABRIC-CARD0"
     desc = "Switch fabric card"
     slot = 17
+    serial = "FC1000101"
     module_type = ModuleBase.MODULE_TYPE_FABRIC
     fabric_asic_list = [("4", "0000:04:00.0"), ("5", "0000:05:00.0")]
-    fabric = MockModule(index, name, desc, module_type, slot, fabric_asic_list)
+    fabric = MockModule(index, name, desc, module_type, slot, serial, fabric_asic_list)
     chassis.module_list.append(fabric)
 
     #Run on supervisor


### PR DESCRIPTION
#### Description
Enhancement request: https://migsonic.atlassian.net/browse/MIGSMSFT-209

- Add enhancement to the "show chassis modules status" CLI to see a new column added at the end to show each card's serial number
- Store another field - serial in chassis module table for each card, which is to be fetched and displayed for above CLI
- Dependent PR in sonic-utilities to accommodate the display for serial field, both PRs <363> and <2858> need to go together and submodule versions need to be updated 
   (https://github.com/amulyan7/sonic-utilities/pull/1)

Expectation:
RP: CLI should display all fields (including serial) for all module types (Supervisor, Fabric card, Line card) that are present
LC: Useful to show self (LC) and Supervisor module to allow monitoring of operation status of the corresponding supervisor, and serial is a good-to-have field

#### Motivation and Context
This is an enhancement request for the CLI

Microsoft ADO: https://msazure.visualstudio.com/One/_workitems/edit/17320021

#### How Has This Been Tested?
Through the CLI: show chassis modules status
RP
```
root@sonic:/home/cisco# show chassis modules status
        Name                             Description    Physical-Slot    Oper-Status    Admin-Status       Serial
------------  --------------------------------------  ---------------  -------------  --------------  -----------
FABRIC-CARD0                        8808 Fabric Card               18         Online              up  FOC2201N3EM
FABRIC-CARD1  Cisco 8808  8-Slot Chassis Fabric Card               19         Online              up  FOC2220NXFA
FABRIC-CARD2                                     N/A               20          Empty              up          N/A
FABRIC-CARD3                                     N/A               21          Empty              up          N/A
FABRIC-CARD4                                     N/A               22          Empty              up          N/A
FABRIC-CARD5                                     N/A               23          Empty              up          N/A
FABRIC-CARD6                                     N/A               24          Empty              up          N/A
FABRIC-CARD7                                     N/A               25          Empty              up          N/A
  LINE-CARD0       8800-LC 48x100GE QSFP28 Line Card                2         Online              up  FOC2210N8U4
  LINE-CARD1    Cisco 8800 48x100GE QSFP28 Line Card                4         Online              up  FOC2211NKP3
  LINE-CARD2                                     N/A                6          Empty              up          N/A
  LINE-CARD3                                     N/A                8          Empty              up          N/A
  LINE-CARD4                                     N/A               10          Empty              up          N/A
  LINE-CARD5                                     N/A               12          Empty              up          N/A
  LINE-CARD6                                     N/A               14          Empty              up          N/A
  LINE-CARD7                                     N/A               16          Empty              up          N/A
 SUPERVISOR0       Cisco 8800 Route Processor - Open               30         Online              up  FOC2144N6W3
 SUPERVISOR1                                     N/A               31          Empty              up          N/A
 ```
LC
```
root@sonic:/home/cisco# show chassis modules status
       Name                        Description    Physical-Slot    Oper-Status    Admin-Status       Serial
-----------  ---------------------------------  ---------------  -------------  --------------  -----------
 LINE-CARD0  8800-LC 48x100GE QSFP28 Line Card                2         Online              up  FOC2210N8U4
SUPERVISOR0  Cisco 8800 Route Processor - Open               30         Online              up  FOC2144N6W3
```