### PR TITLE
[xcvrd] Reduce vendor_key to vendor_name for media_settings lookup

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -649,6 +649,8 @@ def get_media_settings_value(physical_port, key):
             # fetch those values
             if key[0] in media_dict:
                 return media_dict[key[0]]
+            elif key[0].split('-')[0] in media_dict:
+                return media_dict[key[0].split('-')[0]]
             elif key[1] in media_dict:
                 return media_dict[key[1]]
             elif DEFAULT_KEY in media_dict:
@@ -671,6 +673,8 @@ def get_media_settings_value(physical_port, key):
 
         if key[0] in media_dict:
             return media_dict[key[0]]
+        elif key[0].split('-')[0] in media_dict:
+            return media_dict[key[0].split('-')[0]]
         elif key[1] in media_dict:
             return media_dict[key[1]]
         elif DEFAULT_KEY in media_dict:


### PR DESCRIPTION
Upstream xcvrd issue: https://github.com/sonic-net/sonic-platform-daemons/issues/358

#### Description
As per Media-based port settings [HLD](https://github.com/sonic-net/SONiC/blob/master/doc/media-settings/Media-based-Port-settings.md), if 'vendor_key = vendor_name + vendor_PN' lookup fails, then reduce 'vendor_key = vendor_name' and search again for media_settings.

#### Motivation and Context
Simply add Optics' vendor name in platform media_settings.json if the SI params apply to all modules for that vendor.

#### How Has This Been Tested?
Added "<vendor_name>" media_settings (without vendor PN) for Cisco 8111 and validated that SI params were notified for all variations of <vendor_name> cables.

swss/sairedis snippet showing that xcvrd notified media_settings (based on "<vendor_name>" alone) to OA/syncd:
```
root@sonic:/home/cisco# grep idriver /var/log/swss/swss.rec
2023-05-31.19:42:37.473147|PORT_TABLE:Ethernet104|SET|idriver:0x6,0x6,0x6,0x6
2023-05-31.19:43:10.419941|PORT_TABLE:Ethernet4|SET|idriver:0x6,0x6,0x6,0x6
2023-05-31.19:43:14.370826|PORT_TABLE:Ethernet108|SET|idriver:0x6,0x6,0x6,0x6
2023-05-31.19:43:26.599775|PORT_TABLE:Ethernet80|SET|idriver:0x6,0x6,0x6,0x6
2023-05-31.19:43:30.565230|PORT_TABLE:Ethernet8|SET|idriver:0x6,0x6,0x6,0x6
2023-05-31.19:43:38.689406|PORT_TABLE:Ethernet92|SET|idriver:0x6,0x6,0x6,0x6
2023-05-31.19:43:59.291916|PORT_TABLE:Ethernet84|SET|idriver:0x6,0x6,0x6,0x6
2023-05-31.19:44:07.390232|PORT_TABLE:Ethernet0|SET|idriver:0x6,0x6,0x6,0x6

root@sonic:/home/cisco# grep IDRIVER /var/log/swss/sairedis.rec
2023-05-31.19:42:37.544921|c|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x57000000000977|SAI_PORT_SERDES_ATTR_PORT_ID=oid:0x100000000001c|SAI_PORT_SERDES_ATTR_IDRIVER=4:6,6,6,6
2023-05-31.19:43:10.491514|c|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x57000000000978|SAI_PORT_SERDES_ATTR_PORT_ID=oid:0x1000000000003|SAI_PORT_SERDES_ATTR_IDRIVER=4:6,6,6,6
2023-05-31.19:43:14.442475|c|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x57000000000979|SAI_PORT_SERDES_ATTR_PORT_ID=oid:0x100000000001d|SAI_PORT_SERDES_ATTR_IDRIVER=4:6,6,6,6
2023-05-31.19:43:26.671126|c|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x5700000000097a|SAI_PORT_SERDES_ATTR_PORT_ID=oid:0x1000000000016|SAI_PORT_SERDES_ATTR_IDRIVER=4:6,6,6,6
2023-05-31.19:43:30.637955|c|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x5700000000097b|SAI_PORT_SERDES_ATTR_PORT_ID=oid:0x1000000000004|SAI_PORT_SERDES_ATTR_IDRIVER=4:6,6,6,6
2023-05-31.19:43:38.747015|c|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x5700000000097c|SAI_PORT_SERDES_ATTR_PORT_ID=oid:0x1000000000019|SAI_PORT_SERDES_ATTR_IDRIVER=4:6,6,6,6
2023-05-31.19:43:59.363086|c|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x5700000000097d|SAI_PORT_SERDES_ATTR_PORT_ID=oid:0x1000000000017|SAI_PORT_SERDES_ATTR_IDRIVER=4:6,6,6,6
2023-05-31.19:44:07.461200|c|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x5700000000097e|SAI_PORT_SERDES_ATTR_PORT_ID=oid:0x1000000000002|SAI_PORT_SERDES_ATTR_IDRIVER=4:6,6,6,6

```