### PR TITLE
[dualtor] Fix command `show mux status`

### DIFF
--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3861,7 +3861,7 @@ class YCableCliUpdateTask(threading.Thread):
                     break
 
                 if fvp:
-                    handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, self.cli_table_helper.port_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_rsp_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+                    handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, self.cli_table_helper.port_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_rsp_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_res_tbl, self.cli_table_helper.hw_mux_cable_tbl, asic_index, port)
                     break
 
             while True:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Fixes: #361
Fix the tardy command `show mux status`:
```
Jun  5 08:07:20.524687 lab-device-01 ERR pmon#CCmisApi: Exception occured at child thread YcableCliUpdateTask due to TypeError("handle_show_hwmode_state_cmd_arg_tbl_notification() missing 1 required positional argument: 'port'") Traceback (most recent call last):#012  File "/usr/local/lib/python3.9/dist-packages/ycable/ycable_utilities/y_cable_helper.py", line 4000, in run#012    self.task_cli_worker()#012  File "/usr/local/lib/python3.9/dist-packages/ycable/ycable_utilities/y_cable_helper.py", line 3864, in task_cli_worker#012    handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, self.cli_table_helper.port_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_rsp_tbl, self.cli_table_helper.xcvrd_show_hwmode_dir_res_tbl, asic_index, port)#012TypeError: handle_show_hwmode_state_cmd_arg_tbl_notification() missing 1 required positional argument: 'port'
```
MSFT:ADO: 24178563

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
