### PR TITLE
[ycabled][active-active] no initialize Async Client, when no active-active cable type; fix names for all ycabled threads

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5752,6 +5752,7 @@ class TestYCableScript(object):
 
         xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+        hw_mux_cable_tbl = mock_swsscommon_table
 
         asic_index = 0
         task_download_firmware_thread = {}
@@ -5759,7 +5760,7 @@ class TestYCableScript(object):
         fvp = {"config": "active"}
 
         rc = handle_config_hwmode_state_cmd_arg_tbl_notification(
-            fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
+            fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, hw_mux_cable_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('swsscommon.swsscommon.Table')
@@ -5776,6 +5777,7 @@ class TestYCableScript(object):
 
         xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+        hw_mux_cable_tbl = mock_swsscommon_table
 
         asic_index = 0
         task_download_firmware_thread = {}
@@ -5783,7 +5785,7 @@ class TestYCableScript(object):
         fvp = {"down_firmware": "null"}
 
         rc = handle_config_hwmode_state_cmd_arg_tbl_notification(
-            fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
+            fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, hw_mux_cable_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('swsscommon.swsscommon.Table')
@@ -5804,6 +5806,7 @@ class TestYCableScript(object):
 
         xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+        hw_mux_cable_tbl = mock_swsscommon_table
         asic_index = 0
         task_download_firmware_thread = {}
         port = "Ethernet0"
@@ -5838,7 +5841,7 @@ class TestYCableScript(object):
 
             patched_util.get.return_value = PortInstanceHelper()
             rc = handle_config_hwmode_state_cmd_arg_tbl_notification(
-                fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
+                fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, hw_mux_cable_tbl, asic_index, port)
             assert(rc == None)
 
     @patch('swsscommon.swsscommon.Table')
@@ -5859,6 +5862,7 @@ class TestYCableScript(object):
 
         xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+        hw_mux_cable_tbl = mock_swsscommon_table
         asic_index = 0
         task_download_firmware_thread = {}
         port = "Ethernet0"
@@ -5893,7 +5897,7 @@ class TestYCableScript(object):
 
             patched_util.get.return_value = PortInstanceHelper()
             rc = handle_config_hwmode_state_cmd_arg_tbl_notification(
-                fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
+                fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, hw_mux_cable_tbl, asic_index, port)
             assert(rc == -1)
 
     @patch('swsscommon.swsscommon.Table')
@@ -5910,6 +5914,7 @@ class TestYCableScript(object):
 
         xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+        hw_mux_cable_tbl = mock_swsscommon_table
 
         asic_index = 0
         task_download_firmware_thread = {}
@@ -5917,7 +5922,7 @@ class TestYCableScript(object):
         fvp = {"config": "active"}
 
         rc = handle_config_hwmode_state_cmd_arg_tbl_notification(
-            fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
+            fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, hw_mux_cable_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('swsscommon.swsscommon.Table')
@@ -5938,6 +5943,7 @@ class TestYCableScript(object):
 
         xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+        hw_mux_cable_tbl = mock_swsscommon_table
         asic_index = 0
         task_download_firmware_thread = {}
         port = "Ethernet0"
@@ -5972,7 +5978,7 @@ class TestYCableScript(object):
 
             patched_util.get.return_value = PortInstanceHelper()
             rc = handle_config_hwmode_state_cmd_arg_tbl_notification(
-                fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
+                fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, hw_mux_cable_tbl, asic_index, port)
             assert(rc == None)
 
     @patch('swsscommon.swsscommon.Table')

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -7157,7 +7157,7 @@ class TestYcableScriptExecution(object):
 
         mock_selectable = MagicMock()
         mock_selectable.pop = MagicMock(
-            side_effect=[('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False)])
+            side_effect=[('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False)])
         mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
         mock_sub_table.return_value = mock_selectable
 
@@ -7181,26 +7181,12 @@ class TestYcableScriptExecution(object):
         Y_cable_cli_task_n.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
 
         mock_selectable.pop = MagicMock(
-            side_effect=[(False, False, False), (False, False, False), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), (None, None, None), (None, None, None)])
-        mock_selectable.pop = MagicMock(
             side_effect=[('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False)])
         mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
 
         Y_cable_cli_task_n.task_cli_worker()
         assert swsscommon.Select.select.call_count == 2
 
-        """
-
-        Y_cable_cli_task_a = YCableCliUpdateTask()
-        Y_cable_cli_task_a.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
-
-        mock_selectable.pop = MagicMock(
-            side_effect=[(False, False, False), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), (None, None, None), (None, None, None)])
-        mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
-
-        Y_cable_cli_task_a.task_cli_worker()
-        assert swsscommon.Select.select.call_count == 3
-        """
 
 
     @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
@@ -7239,5 +7225,236 @@ class TestYcableScriptExecution(object):
             expected_exception_start  = e1
             trace = traceback.format_exc()
         """
+
+
+    @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
+    @patch('swsscommon.swsscommon.Select.TIMEOUT', MagicMock(return_value=None))
+    @patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj', MagicMock())
+    #@patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj.getDbConnector', MagicMock())
+    @patch('swsscommon.swsscommon.SubscriberStateTable')
+    @patch('swsscommon.swsscommon.Select.select')
+    #@patch('swsscommon.swsscommon.Table')
+    def test_ycable_helper_table_worker(self, mock_select, mock_sub_table):
+
+        mock_selectable = MagicMock()
+        mock_selectable.pop = MagicMock(
+            side_effect=[('Ethernet0', swsscommon.SET_COMMAND, (('state', 'active'), )), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False)])
+        mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
+        mock_sub_table.return_value = mock_selectable
+
+
+        Y_cable_task = YCableTableUpdateTask()
+        Y_cable_task.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
+        mock_table = MagicMock()
+        """mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
+        mock_table.get = MagicMock(
+            side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
+        mock_swsscommon_table.return_value = mock_table
+        """
+        Y_cable_task.hw_mux_cable_tbl_keys = MagicMock(side_effect={0:["Ethernet0", "Ethernet4"]})
+        Y_cable_task.task_worker()
+        assert swsscommon.Select.select.call_count == 1
+
+
+    @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
+    @patch('swsscommon.swsscommon.Select.TIMEOUT', MagicMock(return_value=None))
+    @patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj', MagicMock())
+    #@patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj.getDbConnector', MagicMock())
+    @patch('swsscommon.swsscommon.SubscriberStateTable')
+    @patch('swsscommon.swsscommon.Select.select')
+    @patch('ycable.ycable_utilities.y_cable_helper.check_mux_cable_port_type', MagicMock(return_value=(True,"active-active")))
+    def test_ycable_helper_table_worker_active_active(self, mock_select, mock_sub_table):
+
+        mock_selectable = MagicMock()
+        mock_selectable.pop = MagicMock(
+            side_effect=[('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False)])
+        mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
+        mock_sub_table.return_value = mock_selectable
+
+
+        Y_cable_task = YCableTableUpdateTask()
+        Y_cable_task.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
+        Y_cable_task.task_worker()
+        assert swsscommon.Select.select.call_count == 1
+
+
+
+    @patch('ycable.ycable_utilities.y_cable_helper.check_mux_cable_port_type', MagicMock(return_value=(True,"active-active")))
+    @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
+    @patch('swsscommon.swsscommon.Select.TIMEOUT', MagicMock(return_value=None))
+    @patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj', MagicMock())
+    @patch('ycable.ycable_utilities.y_cable_helper.grpc_port_stubs', MagicMock(return_value={}))
+    @patch('ycable.ycable_utilities.y_cable_helper.grpc_port_channels', MagicMock(return_value={}))
+    #@patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj.getDbConnector', MagicMock())
+    @patch('swsscommon.swsscommon.FieldValuePairs', MagicMock())
+    @patch('swsscommon.swsscommon.SubscriberStateTable')
+    @patch('swsscommon.swsscommon.Select.select')
+    #@patch('swsscommon.swsscommon.Table')
+    def test_ycable_helper_table_worker_probe_active_active(self, mock_select, mock_sub_table):
+
+        mock_selectable = MagicMock()
+        mock_selectable.pop = MagicMock(
+            side_effect=[(False, False, False), (False, False, False), (False, False, False), ('Ethernet0', swsscommon.SET_COMMAND, (('state', 'active'), )), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False)])
+        mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
+        mock_sub_table.return_value = mock_selectable
+
+
+        Y_cable_task = YCableTableUpdateTask()
+        Y_cable_task.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
+        """
+        mock_table = MagicMock()
+        mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
+        mock_table.get = MagicMock(
+            side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
+        mock_swsscommon_table.return_value = mock_table
+        """
+        
+        Y_cable_task.hw_mux_cable_tbl_keys = MagicMock(side_effect={0:["Ethernet0", "Ethernet4"]})
+        Y_cable_task.task_worker()
+        assert swsscommon.Select.select.call_count == 1
+
+
+
+
+
+
+
+    @patch('ycable.ycable_utilities.y_cable_helper.check_mux_cable_port_type', MagicMock(return_value=(True,"active-active")))
+    @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
+    @patch('swsscommon.swsscommon.Select.TIMEOUT', MagicMock(return_value=None))
+    @patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj', MagicMock())
+    @patch('ycable.ycable_utilities.y_cable_helper.grpc_port_stubs', MagicMock(return_value={}))
+    @patch('ycable.ycable_utilities.y_cable_helper.grpc_port_channels', MagicMock(return_value={}))
+    @patch('swsscommon.swsscommon.FieldValuePairs', MagicMock())
+    #@patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj.getDbConnector', MagicMock())
+    @patch('swsscommon.swsscommon.SubscriberStateTable')
+    @patch('swsscommon.swsscommon.Select.select')
+    #@patch('swsscommon.swsscommon.Table')
+    def test_ycable_helper_table_worker_probe_active(self, mock_select, mock_sub_table):
+
+        mock_selectable = MagicMock()
+        mock_selectable.pop = MagicMock(
+            side_effect=[(False, False, False), (False, False, False), ('Ethernet0', swsscommon.SET_COMMAND, (('state', 'active'), ('command', 'probe'),)), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False)])
+        mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
+        mock_sub_table.return_value = mock_selectable
+
+
+        Y_cable_task = YCableTableUpdateTask()
+        Y_cable_task.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
+        """
+        mock_table = MagicMock()
+        mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
+        mock_table.get = MagicMock(
+            side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
+        mock_swsscommon_table.return_value = mock_table
+        """
+        
+        Y_cable_task.hw_mux_cable_tbl_keys = MagicMock(side_effect={0:["Ethernet0", "Ethernet4"]})
+        Y_cable_task.task_worker()
+        assert swsscommon.Select.select.call_count == 1
+
+
+
+
+
+
+    @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
+    @patch('swsscommon.swsscommon.Select.TIMEOUT', MagicMock(return_value=None))
+    @patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj', MagicMock())
+    #@patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj.getDbConnector', MagicMock())
+    @patch('swsscommon.swsscommon.SubscriberStateTable')
+    @patch('swsscommon.swsscommon.Select.select')
+    #@patch('swsscommon.swsscommon.Table')
+    def test_ycable_helper_table_worker_probe(self, mock_select, mock_sub_table):
+
+        mock_selectable = MagicMock()
+        mock_selectable.pop = MagicMock(
+            side_effect=[(False, False, False), ('Ethernet0', swsscommon.SET_COMMAND, (('state', 'active'), )), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False)])
+        mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
+        mock_sub_table.return_value = mock_selectable
+
+
+        Y_cable_task = YCableTableUpdateTask()
+        Y_cable_task.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
+        #mock_table = MagicMock()
+        #mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
+        swsscommon.Table.return_value.get.return_value = (
+                True, {"read_side": "1", "state":"active"})
+        #mock_table.get = MagicMock(
+        #    side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
+        swsscommon.Table.return_value.getKeys.return_value = (
+            ['Ethernet0', 'Ethernet4'])
+        #mock_swsscommon_table.return_value = mock_table
+        
+        Y_cable_task.task_worker()
+        assert swsscommon.Select.select.call_count == 1
+
+
+    @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
+    @patch('swsscommon.swsscommon.Select.TIMEOUT', MagicMock(return_value=None))
+    @patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj', MagicMock())
+    #@patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj.getDbConnector', MagicMock())
+    @patch('swsscommon.swsscommon.SubscriberStateTable')
+    @patch('swsscommon.swsscommon.Select.select')
+    #@patch('swsscommon.swsscommon.Table')
+    def test_ycable_helper_table_worker_toggle(self, mock_select, mock_sub_table):
+
+        mock_selectable = MagicMock()
+        mock_selectable.pop = MagicMock(
+            side_effect=[('Ethernet0', swsscommon.SET_COMMAND, (('state', 'active'), )), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False)])
+        mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
+        mock_sub_table.return_value = mock_selectable
+
+
+        Y_cable_task = YCableTableUpdateTask()
+        Y_cable_task.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
+        #mock_table = MagicMock()
+        #mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
+        swsscommon.Table.return_value.get.return_value = (
+                True, {"read_side": "1", "state":"active"})
+        #mock_table.get = MagicMock(
+        #    side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
+        swsscommon.Table.return_value.getKeys.return_value = (
+            ['Ethernet0', 'Ethernet4'])
+        #mock_swsscommon_table.return_value = mock_table
+        
+        Y_cable_task.task_worker()
+        assert swsscommon.Select.select.call_count == 1
+
+
+    @patch('ycable.ycable_utilities.y_cable_helper.check_mux_cable_port_type', MagicMock(return_value=(True,"active-active")))
+    @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
+    @patch('swsscommon.swsscommon.Select.TIMEOUT', MagicMock(return_value=None))
+    @patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj', MagicMock())
+    @patch('ycable.ycable_utilities.y_cable_helper.grpc_port_stubs', MagicMock(return_value={}))
+    @patch('ycable.ycable_utilities.y_cable_helper.grpc_port_channels', MagicMock(return_value={}))
+    @patch('swsscommon.swsscommon.FieldValuePairs', MagicMock())
+    #@patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj.getDbConnector', MagicMock())
+    @patch('swsscommon.swsscommon.SubscriberStateTable')
+    @patch('swsscommon.swsscommon.Select.select')
+    #@patch('swsscommon.swsscommon.Table')
+    def test_ycable_helper_table_worker_toggle_active_active(self, mock_select, mock_sub_table):
+
+        mock_selectable = MagicMock()
+        mock_selectable.pop = MagicMock(
+            side_effect=[('Ethernet0', swsscommon.SET_COMMAND, (('state', 'active'), ("command", "probe"),)), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False)])
+        mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
+        mock_sub_table.return_value = mock_selectable
+
+
+        Y_cable_task = YCableTableUpdateTask()
+        Y_cable_task.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
+        #mock_table = MagicMock()
+        #mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
+        swsscommon.Table.return_value.get.return_value = (
+                True, {"read_side": "1", "state":"active"})
+        #mock_table.get = MagicMock(
+        #    side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
+        swsscommon.Table.return_value.getKeys.return_value = (
+            ['Ethernet0', 'Ethernet4'])
+        #mock_swsscommon_table.return_value = mock_table
+        
+        Y_cable_task.task_worker()
+        assert swsscommon.Select.select.call_count == 1
 
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -1731,6 +1731,7 @@ class TestYCableScript(object):
             return 0
 
         y_cable_presence = [True]
+        state_db = {}
         logical_port_dict = {'Ethernet0': '1'}
 
         mock_table = MagicMock()
@@ -1745,7 +1746,7 @@ class TestYCableScript(object):
             patched_util.get_asic_id_for_logical_port.return_value = 0
 
             rc = change_ports_status_for_y_cable_change_event(
-                logical_port_dict,  y_cable_presence, port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, stop_event=threading.Event())
+                logical_port_dict,  y_cable_presence, port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, state_db, stop_event=threading.Event())
 
             assert(rc == None)
 
@@ -1764,6 +1765,7 @@ class TestYCableScript(object):
 
         y_cable_presence = [True]
         logical_port_dict = {'Ethernet0': '1'}
+        state_db = {}
 
         mock_table = MagicMock()
         mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
@@ -1777,7 +1779,7 @@ class TestYCableScript(object):
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
             rc = change_ports_status_for_y_cable_change_event(
-                logical_port_dict,  y_cable_presence,  port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl,stop_event=threading.Event())
+                logical_port_dict,  y_cable_presence,  port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, state_db, stop_event=threading.Event())
 
             assert(rc == None)
 
@@ -1794,6 +1796,7 @@ class TestYCableScript(object):
 
         y_cable_presence = [True]
         logical_port_dict = {'Ethernet0': '2'}
+        state_db = {}
 
         mock_table = MagicMock()
         mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
@@ -1806,7 +1809,7 @@ class TestYCableScript(object):
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
             rc = change_ports_status_for_y_cable_change_event(
-                logical_port_dict,  y_cable_presence,port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, stop_event=threading.Event())
+                logical_port_dict,  y_cable_presence,port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, state_db, stop_event=threading.Event())
 
             assert(rc == None)
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -7144,3 +7144,78 @@ class TestYCableScript(object):
         read_side = 1
         Y_cable_restart_client = GracefulRestartClient("Ethernet48", None, read_side)
 
+
+class TestYcableScriptExecution(object):
+
+    @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
+    @patch('swsscommon.swsscommon.Select.TIMEOUT', MagicMock(return_value=None))
+    @patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj', MagicMock())
+    #@patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj.getDbConnector', MagicMock())
+    @patch('swsscommon.swsscommon.SubscriberStateTable')
+    @patch('swsscommon.swsscommon.Select.select')
+    def test_ycable_helper_cli_worker(self, mock_select, mock_sub_table):
+
+        mock_selectable = MagicMock()
+        mock_selectable.pop = MagicMock(
+            side_effect=[(False, False, False), (False, False, False), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), (None, None, None), (None, None, None)])
+        mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
+        mock_sub_table.return_value = mock_selectable
+
+        stop_event = threading.Event()
+        
+        asic_index = 0
+        Y_cable_cli_task = YCableCliUpdateTask()
+        Y_cable_cli_task.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
+        Y_cable_cli_task.cli_table_helper.xcvrd_show_hwmode_dir_cmd_tbl[asic_index].return_value = mock_selectable
+
+        #Y_cable_cli_task.task_stopping_event.is_set = MagicMock(side_effect=False)
+
+        expected_exception_start = None
+        expected_exception_join = None
+        trace = None
+        try:
+            #Y_cable_cli_task.start()
+            Y_cable_cli_task.task_cli_worker()
+            time.sleep(5)
+            Y_cable_cli_task.task_stopping_event.clear()
+        except Exception as e1:
+            expected_exception_start  = e1
+            trace = traceback.format_exc()
+
+
+    @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
+    @patch('swsscommon.swsscommon.Select.TIMEOUT', MagicMock(return_value=None))
+    @patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj', MagicMock())
+    #@patch('swsscommon.swsscommon.CastSelectableToRedisSelectObj.getDbConnector', MagicMock())
+    @patch('swsscommon.swsscommon.SubscriberStateTable')
+    @patch('swsscommon.swsscommon.Select.select')
+    def test_ycable_helper_cli_worker_execution(self, mock_select, mock_sub_table):
+
+        mock_selectable = MagicMock()
+        mock_selectable.pop = MagicMock(
+            side_effect=[(False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False) ,('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), (None, None, None), (None, None, None)])
+        mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
+        mock_sub_table.return_value = mock_selectable
+
+        stop_event = threading.Event()
+        
+        asic_index = 0
+        Y_cable_cli_task = YCableCliUpdateTask()
+        Y_cable_cli_task.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
+        Y_cable_cli_task.cli_table_helper.xcvrd_show_hwmode_dir_cmd_tbl[asic_index].return_value = mock_selectable
+
+        #Y_cable_cli_task.task_stopping_event.is_set = MagicMock(side_effect=False)
+
+        expected_exception_start = None
+        expected_exception_join = None
+        trace = None
+        try:
+            #Y_cable_cli_task.start()
+            Y_cable_cli_task.task_cli_worker()
+            time.sleep(5)
+            Y_cable_cli_task.task_stopping_event.clear()
+        except Exception as e1:
+            expected_exception_start  = e1
+            trace = traceback.format_exc()
+
+

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -1730,8 +1730,8 @@ class TestYCableScript(object):
         def mock_get_asic_id(mock_logical_port_name):
             return 0
 
-        y_cable_presence = [True]
         state_db = {}
+        y_cable_presence = [True]
         logical_port_dict = {'Ethernet0': '1'}
 
         mock_table = MagicMock()

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -7157,7 +7157,7 @@ class TestYcableScriptExecution(object):
 
         mock_selectable = MagicMock()
         mock_selectable.pop = MagicMock(
-            side_effect=[(False, False, False), (False, False, False), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), (None, None, None), (None, None, None)])
+            side_effect=[('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False)])
         mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
         mock_sub_table.return_value = mock_selectable
 
@@ -7166,21 +7166,41 @@ class TestYcableScriptExecution(object):
         asic_index = 0
         Y_cable_cli_task = YCableCliUpdateTask()
         Y_cable_cli_task.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
-        Y_cable_cli_task.cli_table_helper.xcvrd_show_hwmode_dir_cmd_tbl[asic_index].return_value = mock_selectable
 
         #Y_cable_cli_task.task_stopping_event.is_set = MagicMock(side_effect=False)
 
         expected_exception_start = None
         expected_exception_join = None
-        trace = None
-        try:
             #Y_cable_cli_task.start()
-            Y_cable_cli_task.task_cli_worker()
-            time.sleep(5)
-            Y_cable_cli_task.task_stopping_event.clear()
-        except Exception as e1:
-            expected_exception_start  = e1
-            trace = traceback.format_exc()
+        Y_cable_cli_task.task_cli_worker()
+        Y_cable_cli_task.task_stopping_event.clear()
+       
+        assert swsscommon.Select.select.call_count == 1
+        #y_cable_helper.handle_show_hwmode_state_cmd_arg_tbl_notification.assert_called() 
+        Y_cable_cli_task_n = YCableCliUpdateTask()
+        Y_cable_cli_task_n.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
+
+        mock_selectable.pop = MagicMock(
+            side_effect=[(False, False, False), (False, False, False), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), (None, None, None), (None, None, None)])
+        mock_selectable.pop = MagicMock(
+            side_effect=[('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False), (False, False, False)])
+        mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
+
+        Y_cable_cli_task_n.task_cli_worker()
+        assert swsscommon.Select.select.call_count == 2
+
+        """
+
+        Y_cable_cli_task_a = YCableCliUpdateTask()
+        Y_cable_cli_task_a.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
+
+        mock_selectable.pop = MagicMock(
+            side_effect=[(False, False, False), ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), )), (None, None, None), (None, None, None)])
+        mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
+
+        Y_cable_cli_task_a.task_cli_worker()
+        assert swsscommon.Select.select.call_count == 3
+        """
 
 
     @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
@@ -7209,6 +7229,7 @@ class TestYcableScriptExecution(object):
         expected_exception_start = None
         expected_exception_join = None
         trace = None
+        """
         try:
             #Y_cable_cli_task.start()
             Y_cable_cli_task.task_cli_worker()
@@ -7217,5 +7238,6 @@ class TestYcableScriptExecution(object):
         except Exception as e1:
             expected_exception_start  = e1
             trace = traceback.format_exc()
+        """
 
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -1730,8 +1730,8 @@ class TestYCableScript(object):
         def mock_get_asic_id(mock_logical_port_name):
             return 0
 
-        state_db = {}
         y_cable_presence = [True]
+        state_db = {}
         logical_port_dict = {'Ethernet0': '1'}
 
         mock_table = MagicMock()

--- a/sonic-ycabled/tests/test_ycable.py
+++ b/sonic-ycabled/tests/test_ycable.py
@@ -63,6 +63,7 @@ class TestYcableScript(object):
             except Exception as e:
                 pass
 
+    """
     @patch("swsscommon.swsscommon.Select", MagicMock())
     @patch("swsscommon.swsscommon.Select.addSelectable", MagicMock())
     @patch("swsscommon.swsscommon.Select.select", MagicMock())
@@ -82,6 +83,8 @@ class TestYcableScript(object):
         Y_cable_cli_task.task_cli_worker()
         Y_cable_cli_task.start()
         Y_cable_cli_task.join()
+    """
+
 
     @patch("swsscommon.swsscommon.Select", MagicMock())
     @patch("swsscommon.swsscommon.Select.addSelectable", MagicMock())
@@ -328,7 +331,7 @@ def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
     return False
 
 
-class TestYcableScriptException(object):
+"""class TestYcableScriptException(object):
 
     @patch("swsscommon.swsscommon.Select", MagicMock(side_effect=NotImplementedError))
     @patch("swsscommon.swsscommon.Select.addSelectable", MagicMock(side_effect=NotImplementedError))
@@ -354,19 +357,13 @@ class TestYcableScriptException(object):
         except Exception as e2:
             expected_exception_join = e2
 
-        """
-        #Handy debug Helpers or else use import logging
-        #f = open("newfile", "w")
-        #f.write(format(e2))
-        #f.write(format(m1))
-        #f.write(trace)
-        """
-
         assert(type(expected_exception_start) == type(expected_exception_join))
         assert(expected_exception_start.args == expected_exception_join.args)
         assert("NotImplementedError" in str(trace) and "effect" in str(trace))
         assert("sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py" in str(trace))
         assert("swsscommon.Select" in str(trace))
+"""
+
 
 class TestYcableAsyncScript(object):
 
@@ -400,4 +397,5 @@ class TestYcableAsyncScript(object):
         assert("NotImplementedError" in str(trace) and "effect" in str(trace))
         assert("sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py" in str(trace))
         assert("setup_grpc_channel_for_port" in str(trace))
+
 

--- a/sonic-ycabled/tests/test_ycable.py
+++ b/sonic-ycabled/tests/test_ycable.py
@@ -63,7 +63,6 @@ class TestYcableScript(object):
             except Exception as e:
                 pass
 
-    """
     @patch("swsscommon.swsscommon.Select", MagicMock())
     @patch("swsscommon.swsscommon.Select.addSelectable", MagicMock())
     @patch("swsscommon.swsscommon.Select.select", MagicMock())
@@ -83,7 +82,6 @@ class TestYcableScript(object):
         Y_cable_cli_task.task_cli_worker()
         Y_cable_cli_task.start()
         Y_cable_cli_task.join()
-    """
 
 
     @patch("swsscommon.swsscommon.Select", MagicMock())
@@ -331,7 +329,7 @@ def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
     return False
 
 
-"""class TestYcableScriptException(object):
+class TestYcableScriptException(object):
 
     @patch("swsscommon.swsscommon.Select", MagicMock(side_effect=NotImplementedError))
     @patch("swsscommon.swsscommon.Select.addSelectable", MagicMock(side_effect=NotImplementedError))
@@ -362,7 +360,6 @@ def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
         assert("NotImplementedError" in str(trace) and "effect" in str(trace))
         assert("sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py" in str(trace))
         assert("swsscommon.Select" in str(trace))
-"""
 
 
 class TestYcableAsyncScript(object):

--- a/sonic-ycabled/tests/test_ycable.py
+++ b/sonic-ycabled/tests/test_ycable.py
@@ -316,6 +316,7 @@ class TestYcableScript(object):
         assert(rc == None)
 
 
+
 def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
     wait_time = 0
     while wait_time <= total_wait_time:
@@ -395,4 +396,49 @@ class TestYcableAsyncScript(object):
         assert("sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py" in str(trace))
         assert("setup_grpc_channel_for_port" in str(trace))
 
+
+class TestYcableActiveActiveHelper(object):
+
+    @patch("ycable.ycable.platform_sfputil")
+    def test_check_presence_for_active_active_cable_type(self, sfputil):
+
+
+        y_cable_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        asic_index = 0
+        fvs = [('state', "auto"), ('read_side', 1), ('soc_ipv4', '192.168.0.1/32')]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+
+        sfputil.logical = ["Ethernet0", "Ethernet4"]
+        sfputil.get_asic_id_for_logical_port = MagicMock(return_value=0)
+        rc = check_presence_for_active_active_cable_type(y_cable_tbl)
+
+        assert(rc == False)
+
+    @patch('ycable.ycable_utilities.y_cable_helper.check_mux_cable_port_type', MagicMock(return_value=(True,"active-active")))
+    @patch("ycable.ycable.platform_sfputil")
+    def test_check_presence_for_active_active_cable_type(self, sfputil):
+
+
+        y_cable_tbl = {}
+        test_db = "TEST_DB"
+        status = True
+        asic_index = 0
+        fvs = [('state', "auto"), ('read_side', 1), ('soc_ipv4', '192.168.0.1/32')]
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "Y_CABLE_TABLE")
+        y_cable_tbl[asic_index].get.return_value = (status, fvs)
+
+        sfputil.logical = ["Ethernet0", "Ethernet4"]
+        sfputil.get_asic_id_for_logical_port = MagicMock(return_value=0)
+        rc = check_presence_for_active_active_cable_type(y_cable_tbl)
+
+        assert(rc == True)
 

--- a/sonic-ycabled/tests/test_ycable.py
+++ b/sonic-ycabled/tests/test_ycable.py
@@ -307,10 +307,11 @@ class TestYcableScript(object):
         
         port = "Ethernet0"
         fvp_dict = {}
+        state_db = {}
         y_cable_presence = False
         stopping_event = None
         port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl = {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
-        rc = handle_state_update_task(port, fvp_dict, y_cable_presence, port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, stopping_event)
+        rc = handle_state_update_task(port, fvp_dict, y_cable_presence, port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, state_db, stopping_event)
         assert(rc == None)
 
 

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -412,6 +412,7 @@ class DaemonYcable(daemon_base.DaemonBase):
             y_cable_cli_worker_update = y_cable_helper.YCableCliUpdateTask()
             y_cable_cli_worker_update.start()
             self.threads.append(y_cable_cli_worker_update)
+            # enable async client only if there are active-active cables
             active_active_cable_presence = check_presence_for_active_active_cable_type(self.table_helper.get_port_tbl())
             if active_active_cable_presence is True:
                 y_cable_async_noti_worker = y_cable_helper.YCableAsyncNotificationTask()

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -70,6 +70,26 @@ helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 # Helper functions =============================================================
 #
 
+
+def check_presence_for_active_active_cable_type(port_tbl):
+
+
+    logical_port_list = platform_sfputil.logical
+    for logical_port_name in logical_port_list:
+        # Get the asic to which this port belongs
+        asic_index = platform_sfputil.get_asic_id_for_logical_port(logical_port_name)
+        if asic_index is None:
+            continue
+
+        (status, cable_type) = y_cable_helper.check_mux_cable_port_type(logical_port_name, port_tbl, asic_index)
+
+        if status and cable_type == "active-active":
+            return True
+
+    return False
+
+
+
 def detect_port_in_error_status(logical_port_name, status_tbl):
     rec, fvp = status_tbl.get(logical_port_name)
     if rec:
@@ -81,13 +101,13 @@ def detect_port_in_error_status(logical_port_name, status_tbl):
     else:
         return False
 
-def handle_state_update_task(port, fvp_dict, y_cable_presence, port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, stopping_event):
+def handle_state_update_task(port, fvp_dict, y_cable_presence, port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, state_db, stopping_event):
 
     port_dict = {}
     port_dict[port] = fvp_dict.get('status', None)
 
     y_cable_helper.change_ports_status_for_y_cable_change_event(
-        port_dict, y_cable_presence, port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, stopping_event)
+        port_dict, y_cable_presence, port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, state_db, stopping_event)
 
 #
 # Helper classes ===============================================================
@@ -105,6 +125,7 @@ class YcableInfoUpdateTask(threading.Thread):
         self.task_stopping_event = threading.Event()
         self.y_cable_presence = y_cable_presence
         self.table_helper =  y_cable_table_helper.YcableInfoUpdateTableHelper()
+        self.name = "YcableInfoUpdateTask"
 
 
     def task_worker(self, y_cable_presence):
@@ -159,6 +180,7 @@ class YcableStateUpdateTask(threading.Thread):
         self.sfp_error_event = sfp_error_event
         self.y_cable_presence = y_cable_presence
         self.table_helper =  y_cable_table_helper.YcableStateUpdateTableHelper()
+        self.name = "YcableStateUpdateTask"
 
 
     def task_worker(self, stopping_event, sfp_error_event, y_cable_presence):
@@ -208,7 +230,7 @@ class YcableStateUpdateTask(threading.Thread):
                     continue
 
                 # Check if all tables are created in table_helper
-                handle_state_update_task(port, fvp_dict, y_cable_presence, self.table_helper.get_port_tbl(), self.table_helper.port_table_keys, self.table_helper.get_loopback_tbl(), self.table_helper.loopback_keys, self.table_helper.get_hw_mux_cable_tbl(), self.table_helper.get_hw_mux_cable_tbl_peer(), self.table_helper.get_y_cable_tbl(), self.table_helper.get_static_tbl(), self.table_helper.get_mux_tbl(), self.table_helper.get_grpc_config_tbl(), self.table_helper.get_fwd_state_response_tbl(), stopping_event)
+                handle_state_update_task(port, fvp_dict, y_cable_presence, self.table_helper.get_port_tbl(), self.table_helper.port_table_keys, self.table_helper.get_loopback_tbl(), self.table_helper.loopback_keys, self.table_helper.get_hw_mux_cable_tbl(), self.table_helper.get_hw_mux_cable_tbl_peer(), self.table_helper.get_y_cable_tbl(), self.table_helper.get_static_tbl(), self.table_helper.get_mux_tbl(), self.table_helper.get_grpc_config_tbl(), self.table_helper.get_fwd_state_response_tbl(), self.table_helper.state_db, stopping_event)
 
     def run(self):
         if self.task_stopping_event.is_set():
@@ -242,6 +264,7 @@ class DaemonYcable(daemon_base.DaemonBase):
         self.y_cable_presence = [False]
         self.table_helper =  y_cable_table_helper.DaemonYcableTableHelper()
         self.threads = []
+        self.name = "DaemonYcable"
 
     # Signal handler
     def signal_handler(self, sig, frame):
@@ -389,9 +412,11 @@ class DaemonYcable(daemon_base.DaemonBase):
             y_cable_cli_worker_update = y_cable_helper.YCableCliUpdateTask()
             y_cable_cli_worker_update.start()
             self.threads.append(y_cable_cli_worker_update)
-            y_cable_async_noti_worker = y_cable_helper.YCableAsyncNotificationTask()
-            y_cable_async_noti_worker.start()
-            self.threads.append(y_cable_async_noti_worker)
+            active_active_cable_presence = check_presence_for_active_active_cable_type(self.table_helper.get_port_tbl())
+            if active_active_cable_presence is True:
+                y_cable_async_noti_worker = y_cable_helper.YCableAsyncNotificationTask()
+                y_cable_async_noti_worker.start()
+                self.threads.append(y_cable_async_noti_worker)
 
         # Start main loop
         self.log_info("Start daemon main loop")

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3094,7 +3094,7 @@ def handle_show_hwmode_swmode_cmd_arg_tbl_notification(fvp, xcvrd_show_hwmode_sw
         helper_logger.log_error("Error: Incorrect input param for cli cmd show mux hwmode switchmode logical port {}".format(port))
         set_result_and_delete_port('state', 'unknown', xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
 
-def handle_config_hwmode_state_cmd_arg_tbl_notification(fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port):
+def handle_config_hwmode_state_cmd_arg_tbl_notification(fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, hw_mux_cable_tbl, asic_index, port):
 
     fvp_dict = dict(fvp)
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -387,10 +387,10 @@ def apply_grpc_secrets_configuration(SECRETS_PATH, grpc_config):
     if grpc_client_config is not None:
         config = grpc_client_config.get("config", None)
         if config is not None:
-            type = config.get("type",None)
+            type_chan = config.get("type",None)
             auth_level = config.get("auth_level",None)
             log_level = config.get("log_level", None)
-            fvs_updated = swsscommon.FieldValuePairs([('type', type),
+            fvs_updated = swsscommon.FieldValuePairs([('type', type_chan),
                                                       ('auth_level',auth_level ),
                                                       ('log_level',log_level)])
             grpc_config[asic_index].set('config', fvs_updated)
@@ -407,7 +407,7 @@ def apply_grpc_secrets_configuration(SECRETS_PATH, grpc_config):
             grpc_config[asic_index].set('certs', fvs_updated)
     
 
-def get_grpc_credentials(type, kvp):
+def get_grpc_credentials(type_chan, kvp):
 
     root_file = kvp.get("ca_crt", None)
     if root_file is not None and os.path.isfile(root_file): 
@@ -416,7 +416,7 @@ def get_grpc_credentials(type, kvp):
         helper_logger.log_error("grpc credential channel setup no root file in config_db")
         return None
 
-    if type == "mutual":
+    if type_chan == "mutual":
         cert_file = kvp.get("client_crt", None)
         if cert_file is not None and os.path.isfile(cert_file): 
             cert_chain = open(cert_file, 'rb').read()
@@ -435,7 +435,7 @@ def get_grpc_credentials(type, kvp):
                 root_certificates=root_cert,
                 private_key=key,
                 certificate_chain=cert_chain)
-    elif type == "server":
+    elif type_chan == "server":
         credential = grpc.ssl_channel_credentials(
                 root_certificates=root_cert)
     else:
@@ -458,7 +458,7 @@ def connect_channel(channel, stub, port):
         else:
             break
 
-def create_channel(type, level, kvp, soc_ip, port, asic_index, fwd_state_response_tbl, is_async):
+def create_channel(type_chan, level, kvp, soc_ip, port, asic_index, fwd_state_response_tbl, is_async):
 
     # Helper callback to get an channel connectivity state
     def wait_for_state_change(channel_connectivity):
@@ -487,7 +487,7 @@ def create_channel(type, level, kvp, soc_ip, port, asic_index, fwd_state_respons
             grpc_port_connectivity[port] = "SHUTDOWN"
 
 
-    if type == "secure": 
+    if type_chan == "secure":
         credential = get_grpc_credentials(level, kvp)
         target_name = kvp.get("grpc_ssl_credential", None)
         if credential is None or target_name is None:
@@ -497,18 +497,21 @@ def create_channel(type, level, kvp, soc_ip, port, asic_index, fwd_state_respons
 
         if is_async:
             channel = grpc.aio.secure_channel("{}:{}".format(soc_ip, GRPC_PORT), credential, options=GRPC_CLIENT_OPTIONS)
+            stub = linkmgr_grpc_driver_pb2_grpc.DualToRActiveStub(channel)
         else:
             channel = grpc.secure_channel("{}:{}".format(soc_ip, GRPC_PORT), credential, options=GRPC_CLIENT_OPTIONS)
+            stub = linkmgr_grpc_driver_pb2_grpc.DualToRActiveStub(channel)
 
 
     else:
         if is_async:
             channel = grpc.aio.insecure_channel("{}:{}".format(soc_ip, GRPC_PORT), options=GRPC_CLIENT_OPTIONS)
+            stub = linkmgr_grpc_driver_pb2_grpc.DualToRActiveStub(channel)
         else:
             channel = grpc.insecure_channel("{}:{}".format(soc_ip, GRPC_PORT), options=GRPC_CLIENT_OPTIONS)
+            stub = linkmgr_grpc_driver_pb2_grpc.DualToRActiveStub(channel)
 
 
-    stub = linkmgr_grpc_driver_pb2_grpc.DualToRActiveStub(channel)
 
 
     if not is_async and channel is not None:
@@ -541,7 +544,7 @@ def setup_grpc_channel_for_port(port, soc_ip, asic_index, grpc_config, fwd_state
 
 
     #if no config from config DB, treat channel to be as insecure
-    type = "insecure"
+    type_chan = "insecure"
     level = "server"
 
     (status, fvs) = grpc_config[asic_index].get("config")
@@ -550,12 +553,12 @@ def setup_grpc_channel_for_port(port, soc_ip, asic_index, grpc_config, fwd_state
             "Could not retreive fieldvalue pairs for {}, inside config_db table kvp config for {} for setting up channel type".format(port, grpc_config[asic_index].getTableName()))
     else:
         grpc_config_dict = dict(fvs)
-        type = grpc_config_dict.get("type", None)
+        type_chan = grpc_config_dict.get("type", None)
         level = grpc_config_dict.get("auth_level", None)
     
    
     kvp = {}
-    if type == "secure":
+    if type_chan == "secure":
         (status, fvs) = grpc_config[asic_index].get("certs")
         if status is False:
             helper_logger.log_warning(
@@ -565,7 +568,7 @@ def setup_grpc_channel_for_port(port, soc_ip, asic_index, grpc_config, fwd_state
         kvp = dict(fvs)
 
 
-    channel, stub = create_channel(type, level, kvp, soc_ip, port, asic_index, fwd_state_response_tbl, is_async) 
+    channel, stub = create_channel(type_chan, level, kvp, soc_ip, port, asic_index, fwd_state_response_tbl, is_async)
 
     if stub is None:
         helper_logger.log_warning("stub was not setup for gRPC soc ip {} port {}, no gRPC soc server running ?".format(soc_ip, port))
@@ -3713,6 +3716,7 @@ class YCableTableUpdateTask(threading.Thread):
                                 handle_hw_mux_cable_table_grpc_notification(
                                     fvp, self.table_helper.get_hw_mux_cable_tbl(), asic_index, self.table_helper.get_mux_metrics_tbl(), False, port, self.table_helper.get_port_tbl(), self.table_helper.get_grpc_config_tbl(), self.table_helper.get_fwd_state_response_tbl())
 
+
             while True:
                 (port_m, op_m, fvp_m) = self.table_helper.get_mux_cable_command_tbl()[asic_index].pop()
 
@@ -3819,10 +3823,12 @@ class YCableCliUpdateTask(threading.Thread):
             sel.addSelectable(self.cli_table_helper.xcvrd_show_ber_cmd_tbl[asic_id])
 
         # Listen indefinitely for changes to the XCVRD_CMD_TABLE in the Application DB's
-        while not self.task_stopping_event.is_set():
+        while True:
             # Use timeout to prevent ignoring the signals we want to handle
             # in signal_handler() (e.g. SIGTERM for graceful shutdown)
 
+            if self.task_stopping_event.is_set():
+                break
 
             (state, selectableObj) = sel.select(SELECT_TIMEOUT)
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -1384,7 +1384,7 @@ def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presen
                 "Could not retreive port inside config_db PORT table {} for Y-Cable initiation".format(logical_port_name))
 
 
-def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, stop_event=threading.Event()):
+def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, state_db, stop_event=threading.Event()):
 
     global read_side
     delete_change_event = [False]
@@ -4070,6 +4070,7 @@ class YCableAsyncNotificationTask(threading.Thread):
         self.task_stopping_event = threading.Event()
         self.table_helper =  y_cable_table_helper.YcableAsyncNotificationTableHelper()
         self.read_side = process_loopback_interface_and_get_read_side(self.table_helper.loopback_keys)
+        self.name = "xyz"
 
     async def task_worker(self):
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3823,8 +3823,8 @@ class YCableCliUpdateTask(threading.Thread):
             # Use timeout to prevent ignoring the signals we want to handle
             # in signal_handler() (e.g. SIGTERM for graceful shutdown)
 
+
             (state, selectableObj) = sel.select(SELECT_TIMEOUT)
-            self.exc = None
 
             if state == swsscommon.Select.TIMEOUT:
                 # Do not flood log when select times out
@@ -3991,8 +3991,6 @@ class YCableCliUpdateTask(threading.Thread):
                     handle_show_ber_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_show_ber_cmd_arg_tbl, self.cli_table_helper.xcvrd_show_ber_rsp_tbl, self.cli_table_helper.xcvrd_show_ber_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_ber_res_tbl, asic_index, port)
 
                     break
-            """
-            """
 
     def run(self):
         if self.task_stopping_event.is_set():

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3819,14 +3819,12 @@ class YCableCliUpdateTask(threading.Thread):
             sel.addSelectable(self.cli_table_helper.xcvrd_show_ber_cmd_tbl[asic_id])
 
         # Listen indefinitely for changes to the XCVRD_CMD_TABLE in the Application DB's
-        while True:
+        while not self.task_stopping_event.is_set():
             # Use timeout to prevent ignoring the signals we want to handle
             # in signal_handler() (e.g. SIGTERM for graceful shutdown)
 
-            if self.task_stopping_event.is_set():
-                break
-
             (state, selectableObj) = sel.select(SELECT_TIMEOUT)
+            self.exc = None
 
             if state == swsscommon.Select.TIMEOUT:
                 # Do not flood log when select times out
@@ -3842,6 +3840,7 @@ class YCableCliUpdateTask(threading.Thread):
             # Get the corresponding namespace from redisselect db connector object
             namespace = redisSelectObj.getDbConnector().getNamespace()
             asic_index = multi_asic.get_asic_index_from_namespace(namespace)
+
 
             while True:
                 (key, op_m, fvp_m) = self.cli_table_helper.xcvrd_log_tbl[asic_index].pop()
@@ -3992,6 +3991,8 @@ class YCableCliUpdateTask(threading.Thread):
                     handle_show_ber_cmd_arg_tbl_notification(fvp, self.cli_table_helper.xcvrd_show_ber_cmd_arg_tbl, self.cli_table_helper.xcvrd_show_ber_rsp_tbl, self.cli_table_helper.xcvrd_show_ber_cmd_sts_tbl, self.cli_table_helper.xcvrd_show_ber_res_tbl, asic_index, port)
 
                     break
+            """
+            """
 
     def run(self):
         if self.task_stopping_event.is_set():

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -493,19 +493,21 @@ def create_channel(type_chan, level, kvp, soc_ip, port, asic_index, fwd_state_re
         if credential is None or target_name is None:
             return (None, None)
 
-        GRPC_CLIENT_OPTIONS.append(('grpc.ssl_target_name_override', '{}'.format(target_name)))
 
         if is_async:
-            channel = grpc.aio.secure_channel("{}:{}".format(soc_ip, GRPC_PORT), credential, options=GRPC_CLIENT_OPTIONS)
+            ASYNC_GRPC_CLIENT_OPTIONS = []
+            ASYNC_GRPC_CLIENT_OPTIONS.append(('grpc.ssl_target_name_override', '{}'.format(target_name)))
+            channel = grpc.aio.secure_channel("{}:{}".format(soc_ip, GRPC_PORT), credential, options=ASYNC_GRPC_CLIENT_OPTIONS)
             stub = linkmgr_grpc_driver_pb2_grpc.DualToRActiveStub(channel)
         else:
+            GRPC_CLIENT_OPTIONS.append(('grpc.ssl_target_name_override', '{}'.format(target_name)))
             channel = grpc.secure_channel("{}:{}".format(soc_ip, GRPC_PORT), credential, options=GRPC_CLIENT_OPTIONS)
             stub = linkmgr_grpc_driver_pb2_grpc.DualToRActiveStub(channel)
 
 
     else:
         if is_async:
-            channel = grpc.aio.insecure_channel("{}:{}".format(soc_ip, GRPC_PORT), options=GRPC_CLIENT_OPTIONS)
+            channel = grpc.aio.insecure_channel("{}:{}".format(soc_ip, GRPC_PORT))
             stub = linkmgr_grpc_driver_pb2_grpc.DualToRActiveStub(channel)
         else:
             channel = grpc.insecure_channel("{}:{}".format(soc_ip, GRPC_PORT), options=GRPC_CLIENT_OPTIONS)

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -3788,6 +3788,7 @@ class YCableCliUpdateTask(threading.Thread):
         self.task_download_firmware_thread = {}
         self.task_stopping_event = threading.Event()
         self.cli_table_helper =  y_cable_table_helper.YcableCliUpdateTableHelper()
+        self.name = "YCableCliUpdateTask"
 
 
     def task_cli_worker(self):
@@ -4070,7 +4071,7 @@ class YCableAsyncNotificationTask(threading.Thread):
         self.task_stopping_event = threading.Event()
         self.table_helper =  y_cable_table_helper.YcableAsyncNotificationTableHelper()
         self.read_side = process_loopback_interface_and_get_read_side(self.table_helper.loopback_keys)
-        self.name = "xyz"
+        self.name = "YCableAsyncNotificationTask"
 
     async def task_worker(self):
 


### PR DESCRIPTION
This PR intends to not start sonic-ycabled's Asynchronous client, when there is no active-active cable type.
The Problem that we encounter is ycabled expects all threads to be working/running state all the time. 
Since there are no `active-active` cable_type Async client thread  exits gracefully, 
but by design this needs to be working if added to monitor loop thread. So this PR fixes this problem by runnig the Async Client only if configuration is `active-active` for atleast a cable. 

This PR also has all the infrastructure changes UT for all Classes having infinite loops in ycabled, thus helping in picking up cases if changes break the code. 
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Running on DUT and UT
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
