### PR TITLE
Fix index out of range in the error log of invalid media lane mask re…

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1530,8 +1530,8 @@ class CmisManagerTask(threading.Thread):
                                                                         appl, lport, subport)
                         if self.port_dict[lport]['media_lanes_mask'] <= 0:
                             self.log_error("{}: Invalid media lane mask received - media_lane_count {} "
-                                            "media_lane_assignment_options {} lport{} subport {}"
-                                            " appl {}!".format(media_lane_count,media_lane_assignment_options,lport,subport,appl))
+                                            "media_lane_assignment_options {} subport {}"
+                                            " appl {}!".format(lport, media_lane_count, media_lane_assignment_options, subport, appl))
                             self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_FAILED
                             continue
                         media_lanes_mask = self.port_dict[lport]['media_lanes_mask']


### PR DESCRIPTION
…ceived

<!-- Provide a general summary of your changes in the Title above -->
In the error log format string, there are 6 placeholders but only 5 values are provided.

#### Description
<!--
     Describe your changes in detail
-->
Add lport at the beginning of the values and remove the redundant lport in the format.
So there are 5 placeholders and 5 values.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
There will be an IndexError exception like below.
```
Exception occured at CmisManagerTask thread due to IndexError('Replacement index 5 out of range for positional args tuple')
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1878, in run
    self.task_worker()
  File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1672, in task_worker
    self.log_error("{}: Invalid media lane mask received - media_lane_count {} "
IndexError: Replacement index 5 out of range for positional args tuple
Xcvrd: exception found at child thread CmisManagerTask due to IndexError('Replacement index 5 out of range for positional args tuple')
Exiting main loop as child thread raised exception!
```
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Fake the error to check if the error log can be printed as expected.
```
CMIS: Ethernet162: Invalid media lane mask received - media_lane_count 1 media_lane_assignment_options 85 subport 0 appl 2!
```
#### Additional Information (Optional)
