### PR TITLE
[thermalctld] Add check for psu presence to thermalctld when updating PSU thermals

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -592,6 +592,8 @@ class TemperatureUpdater(logger.Logger):
             self._refresh_temperature_status(CHASSIS_INFO_KEY, thermal, index)
 
         for psu_index, psu in enumerate(self.chassis.get_all_psus()):
+            if not psu.get_presence():
+                continue
             parent_name = 'PSU {}'.format(psu_index + 1)
             for thermal_index, thermal in enumerate(psu.get_all_thermals()):
                 if self.task_stopping_event.is_set():


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
issue https://github.com/sonic-net/sonic-platform-daemons/issues/384

For any nonpresent PSU, thermalctld will add its sensors to the redis database, with all values N/A.
thermalctld should check for PSU presence before adding their sensors to the db.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The empty non-present sensor entries are not necessary to be tracked, and causes test case failures as values are expected to be retrieved from the sensors.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
With the update to thermalctld, ran relevant CLI and checked the db.

show plat inv
```
Power Supplies
    psu0                8800-HV-TRAY    1.0             FOC2417N4X0     Cisco 8800 Power Tray for AC/HVAC/HVDC Power Supply
        psu0.0 -- not present
        psu0.1 -- not present
        psu0.2 -- not present
    psu1                8800-HV-TRAY    1.0             FOC2417N4VJ     Cisco 8800 Power Tray for AC/HVAC/HVDC Power Supply
        psu1.0 -- not present
        psu1.1 -- not present
        psu1.2 -- not present
    psu2                8800-HV-TRAY    1.0             FOC2417N4U6     Cisco 8800 Power Tray for AC/HVAC/HVDC Power Supply
        psu2.0          PSU6.3KW-20A-HV 1.0             DTM243501T9     6.3KW AC/HVAC/HVDC Power Supply-20A
        psu2.1          PSU6.3KW-20A-HV 1.0             DTM243501UV     6.3KW AC/HVAC/HVDC Power Supply-20A
        psu2.2          PSU6.3KW-20A-HV 1.0             DTM2435022V     6.3KW AC/HVAC/HVDC Power Supply-20A
    psu3 -- not present
    psu4 -- not present
    psu5 -- not present
```
show plat temp (no empty entries)
```
            PSU2.0 Outlet_Temp         48.992         97        -5             102            -10      False  20230228 13:58:20
            PSU2.1 Outlet_Temp         48.992         97        -5             102            -10      False  20230228 13:58:21
            PSU2.2 Outlet_Temp         48.992         97        -5             102            -10      False  20230228 13:58:21
```
db entries (no non present PSUs)
```
root@sonic:/home/cisco# redis-cli -n 6
127.0.0.1:6379[6]> keys TEMPERATURE_INFO|PSU*
1) "TEMPERATURE_INFO|PSU2.1 Outlet_Temp"
2) "TEMPERATURE_INFO|PSU2.2 Outlet_Temp"
3) "TEMPERATURE_INFO|PSU2.0 Outlet_Temp"
127.0.0.1:6379[6]>
```

#### Additional Information (Optional)
