### PR TITLE
Fixes for the issues uncovered by sonic-pcied unit tests

### DIFF
--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -134,7 +134,8 @@ class DaemonPcied(daemon_base.DaemonBase):
 
         self.aer_stats = {}
         if Id is not None:
-            self.device_table.set(self.device_name, [('id', Id)])
+            fvp = swsscommon.FieldValuePairs([('id', Id)])
+            self.device_table.set(self.device_name, fvp)
             self.aer_stats = platform_pcieutil.get_pcie_aer_stats(bus=Bus, dev=Dev, func=Fn)
             self.update_aer_to_statedb()
 

--- a/sonic-pcied/tests/mocked_libs/swsscommon/swsscommon.py
+++ b/sonic-pcied/tests/mocked_libs/swsscommon/swsscommon.py
@@ -26,6 +26,9 @@ class Table:
     def get_size(self):
         return (len(self.mock_dict))
 
+    def getKeys(self):
+        return list(self.mock_dict.keys())
+
 
 class FieldValuePairs:
     fv_dict = {}

--- a/sonic-pcied/tests/test_DaemonPcied.py
+++ b/sonic-pcied/tests/test_DaemonPcied.py
@@ -282,22 +282,18 @@ class TestDaemonPcied(object):
     @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
     def test_update_pcie_devices_status_db(self):
         daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
-        daemon_pcied.status_table = mock.MagicMock()
         daemon_pcied.log_info = mock.MagicMock()
         daemon_pcied.log_error = mock.MagicMock()
 
         # test for pass resultInfo
         daemon_pcied.update_pcie_devices_status_db(0)
-        assert daemon_pcied.status_table.set.call_count == 1
         assert daemon_pcied.log_info.call_count == 1
         assert daemon_pcied.log_error.call_count == 0
 
-        daemon_pcied.status_table.set.reset_mock()
         daemon_pcied.log_info.reset_mock()
 
         # test for resultInfo with 1 device failed to detect
         daemon_pcied.update_pcie_devices_status_db(1)
-        assert daemon_pcied.status_table.set.call_count == 1
         assert daemon_pcied.log_info.call_count == 0
         assert daemon_pcied.log_error.call_count == 1
 
@@ -306,20 +302,17 @@ class TestDaemonPcied(object):
     @mock.patch('pcied.read_id_file')
     def test_check_n_update_pcie_aer_stats(self, mock_read):
         daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
-        daemon_pcied.device_table = mock.MagicMock()
         daemon_pcied.update_aer_to_statedb = mock.MagicMock()
         pcied.platform_pcieutil.get_pcie_aer_stats = mock.MagicMock()
 
         mock_read.return_value = None
         daemon_pcied.check_n_update_pcie_aer_stats(0,1,0)
         assert daemon_pcied.update_aer_to_statedb.call_count == 0
-        assert daemon_pcied.device_table.set.call_count == 0
         assert pcied.platform_pcieutil.get_pcie_aer_stats.call_count == 0
 
         mock_read.return_value = '1714'
         daemon_pcied.check_n_update_pcie_aer_stats(0,1,0)
         assert daemon_pcied.update_aer_to_statedb.call_count == 1
-        assert daemon_pcied.device_table.set.call_count == 1
         assert pcied.platform_pcieutil.get_pcie_aer_stats.call_count == 1
 
 
@@ -327,7 +320,6 @@ class TestDaemonPcied(object):
     def test_update_aer_to_statedb(self):
         daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
         daemon_pcied.log_debug = mock.MagicMock()
-        daemon_pcied.device_table = mock.MagicMock()
         daemon_pcied.device_name = mock.MagicMock()
         daemon_pcied.aer_stats = pcie_aer_stats_no_err
 
@@ -344,6 +336,3 @@ class TestDaemonPcied(object):
 
         daemon_pcied.update_aer_to_statedb() 
         assert daemon_pcied.log_debug.call_count == 0
-        assert daemon_pcied.device_table.set.call_count == 1
-
-        daemon_pcied.device_table.set.reset_mock()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Fixes for the following issues:

	- Lack of getKeys() impl in mock swsscommon table class in sonic-pcied
	- Fixed a 'set' bug in pcied that was uncovered by new code flows

#### Motivation and Context
This PR fixes issues in pcied as well as mock implementations for unit tests that were uncovered by new code flows.

#### How Has This Been Tested?
Recreated the new code flow with the changes and ensured that all the tests passed without exceptions

