### PR TITLE
Signed-off-by: Jaganathan Anbalagan <jaganbal@cisco.com>

### DIFF
--- a/sonic-xcvrd/xcvrd/pm_mgr.py
+++ b/sonic-xcvrd/xcvrd/pm_mgr.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+
+"""
+    Performance Monitoring statistics manager 
+"""
+
+try:
+    import ast
+    import copy
+    import sys
+    import threading
+    import time
+    import traceback
+
+    from swsscommon import swsscommon
+    from .xcvrd_utilities import sfp_status_helper
+    from .xcvrd_utilities.xcvr_table_helper import XcvrTableHelper
+    from .xcvrd_utilities import port_mapping
+except ImportError as e:
+    raise ImportError(str(e) + " - required module not found")
+
+#
+# Constants ====================================================================
+#
+
+PM_INFO_UPDATE_PERIOD_SECS = 60
+
+MAX_NUM_60SEC_WINDOW = 15
+MAX_NUM_15MIN_WINDOW = 12
+MAX_NUM_24HRS_WINDOW = 2
+
+WINDOW_60SEC_START_NUM = 1
+WINDOW_15MIN_START_NUM = 16
+WINDOW_24HRS_START_NUM = 28
+
+WINDOW_60SEC_END_NUM = 15
+WINDOW_15MIN_END_NUM = 27
+WINDOW_24HRS_END_NUM = 29
+
+TIME_60SEC_IN_SECS = 60 
+TIME_15MIN_IN_SECS = 900
+TIME_24HRS_IN_SECS = 86400 
+
+class PmUpdateTask(threading.Thread):
+
+    # Subscribe to below table in Redis DB
+    PORT_TBL_MAP = [
+        {'STATE_DB': 'TRANSCEIVER_INFO', 'FILTER': ['media_interface_code']},
+    ]
+
+    def __init__(self, namespaces, port_mapping_data, main_thread_stop_event, platform_chassis, helper_logger, process_start_option, pm_interval):
+        threading.Thread.__init__(self)
+        self.name = "PmUpdateTask"
+        self.exc = None
+        self.task_stopping_event = threading.Event()
+        self.main_thread_stop_event = main_thread_stop_event
+        self.port_mapping_data = copy.deepcopy(port_mapping_data)
+        self.namespaces = namespaces
+        self.pm_interval = pm_interval 
+        self.helper_logger = helper_logger
+        self.platform_chassis = platform_chassis
+        self.process_start_option = process_start_option
+        self.xcvr_table_helper = XcvrTableHelper(namespaces)
+        #Port numbers that gets iterated for PM update.
+        self.pm_port_list = []
+    
+    def log_notice(self, message):
+        self.helper_logger.log_notice("PM: {}".format(message))
+
+    def log_warning(self, message):
+        self.helper_logger.log_warning("PM: {}".format(message))
+
+    def log_error(self, message):
+        self.helper_logger.log_error("PM: {}".format(message))
+
+    def get_transceiver_pm(self, physical_port):
+        if self.platform_chassis is not None:
+            try:
+                return self.platform_chassis.get_sfp(physical_port).get_transceiver_pm()
+            except NotImplementedError:
+                pass
+            return {}
+
+    def get_port_admin_status(self, lport):
+        admin_status = 'down'
+
+        asic_index = self.port_mapping_data.get_asic_id_for_logical_port(lport)
+        cfg_port_tbl = self.xcvr_table_helper.get_cfg_port_tbl(asic_index)
+
+        found, port_info = cfg_port_tbl.get(lport)
+        if found:
+            admin_status = dict(port_info).get('admin_status', 'down')
+        return admin_status
+
+    def on_port_update_event(self, port_change_event):
+        """Invoked when there is a change in TRANSCIEVER_INFO for the port.
+           Initialize the PM window slots to default when the TRANSCIEVER_INFO table is created.
+           Delete the PM window slots when the TRANSCIEVER_INFO table is deleted.
+
+        Args:
+            port_change_event (object): port change event
+        """
+        if (port_change_event.event_type
+                not in [port_change_event.PORT_SET, port_change_event.PORT_DEL]):
+            return
+
+        lport = port_change_event.port_name
+        pport = port_change_event.port_index
+        asic_id = port_change_event.asic_id
+
+        # Skip if it's not a physical port
+        if not lport.startswith('Ethernet'):
+            return
+
+        # Skip if the physical index is not available
+        if pport is None:
+            return
+
+        if port_change_event.port_dict is None:
+            return
+           
+        physical_port = self.port_mapping_data.get_logical_to_physical(lport)[0]
+        self.log_notice("PM port event type:{} for lport: {} table name: {}".format(port_change_event.event_type, lport, port_change_event.table_name))
+        if port_change_event.event_type == port_change_event.PORT_SET:
+            if (True if "ZR" not in str(port_change_event.port_dict.get('media_interface_code', None)) else False):
+                return
+            
+            if not self.platform_chassis.get_sfp(physical_port).get_presence():
+                self.log_error("Change in TRANSCIEVER_INFO table for the port {}, but transciever is not present".format(lport))
+                return
+            
+            #update the port list
+            if lport not in self.pm_port_list:
+                self.pm_port_list.append(lport)
+            else:
+                self.log_notice("Port number:{} already present in port list :: Spurious request\n".format(lport))
+                return
+            pm_win_dict = {}
+            # Set the TRANSCEIVER_PM_WINDOW_STATS keys for the port with default value
+            for key in ["window{}".format(win_num) for win_num in range(WINDOW_60SEC_START_NUM, WINDOW_24HRS_END_NUM + 1)]:
+                pm_win_dict[key] = "N/A" 
+        
+            #Update the table in DB    
+            state_pm_win_stats_tbl = self.xcvr_table_helper.get_pm_window_stats_tbl(asic_id)
+            fvs = swsscommon.FieldValuePairs([(k, v) for k, v in pm_win_dict.items()])
+            state_pm_win_stats_tbl.set(lport, fvs)
+            self.log_notice("Port add event:{} added to pm port list".format(port_change_event.port_name))
+        elif port_change_event.event_type == port_change_event.PORT_DEL and port_change_event.table_name == 'TRANSCEIVER_INFO':
+
+            if self.platform_chassis.get_sfp(physical_port).get_presence():
+                self.log_error("TRANSCIEVER_INFO table for the port {} is deleted but transciever is present".format(lport))
+                return
+            #Remove the port from port list and delete the TRANSCEIVER_PM_WINDOW_STATS table for the port 
+            self.pm_port_list.remove(lport)
+            state_pm_win_stats_tbl = self.xcvr_table_helper.get_pm_window_stats_tbl(asic_id)
+            if state_pm_win_stats_tbl:
+                state_pm_win_stats_tbl._del(lport)
+                self.log_notice("Port delete event:{} deleted from pm port list".format(port_change_event.port_name))
+
+    # Update the PM statistics in string format to respective window key to 
+    # TRANSCEIVER_PM_WINDOW_STATS_TABLE in state DB.
+    def set_pm_stats_in_pm_win_stats_tbl(self, asic, lport, window, pm_data_str):
+        state_pm_win_stats_tbl = self.xcvr_table_helper.get_pm_window_stats_tbl(asic)
+        fvs = swsscommon.FieldValuePairs([(window, str(pm_data_str))])
+        state_pm_win_stats_tbl.set(lport, fvs)
+
+    # Retrieve the PM statistics from respective window key from.
+    # TRANSCEIVER_PM_WINDOW_STATS_TABLE - state DB.
+    def get_pm_stats_in_pm_win_stats_tbl(self, asic, lport, window):
+        state_pm_win_stats_tbl = self.xcvr_table_helper.get_pm_window_stats_tbl(asic)
+        status, fvs = state_pm_win_stats_tbl.get(str(lport))
+        stats_tbl_tuple = dict((k, v) for k, v in fvs)
+        if stats_tbl_tuple != "":
+            return (stats_tbl_tuple.get(window, ""))
+        else:
+            return None
+
+    # 
+    # input args: asic index, logical port, start and end window number of a PM window granularity, 
+    # PM window granularity in secs, pm stats read from module.
+    #
+    # Algorithm to sample and update the PM stats to the appropriate PM window in TRANSCEIVER_PM_WINDOW_STATS_TABLE.
+    def pm_window_update_to_DB(self, asic, lport, start_window, end_window, pm_win_itrvl_in_secs, pm_hw_data):
+        window_num = start_window
+        while window_num < (end_window + 1):
+            #Retrieve PM data from DB
+            pm_data = {}
+            pm_data = self.get_pm_stats_in_pm_win_stats_tbl(lport, asic, "window"+str(window_num))
+            if pm_data == 'N/A' and window_num == start_window:
+                pm_data_dict = {} 
+                for key, value in pm_hw_data.items():
+                    pm_data_dict[key] = value
+                #First PM data read from the module 
+                pm_data_dict['pm_win_start_time'] = pm_hw_data.get('pm_win_end_time')
+                pm_data_dict['pm_win_end_time'] = pm_hw_data.get('pm_win_end_time')
+                pm_data_dict['pm_win_current'] = 'true'
+                pm_data_str = str(pm_data_dict) 
+                self.set_pm_stats_in_pm_win_stats_tbl(lport, asic, "window{}".format(window_num), pm_data_str)
+                break;
+            elif pm_data != 'N/A':
+                #retrieve pm_win_current index pm data from DB-the start of PM time window slot
+                pm_data_dic = ast.literal_eval(pm_data)
+                
+                if (float(pm_data_dic.get('pm_win_end_time')) == float(pm_data_dic.get('pm_win_start_time'))):
+                    #discard the 1st set of PM data retrieved from the module.
+                    pm_data_dic1 = {} 
+                    for key, value in pm_hw_data.items():
+                        pm_data_dic1[key] = value
+                    #First PM data read from the module 
+                    pm_data_dic1['pm_win_start_time'] = pm_data_dic.get('pm_win_start_time')
+                    pm_data_dic1['pm_win_end_time'] = pm_hw_data.get('pm_win_end_time')
+                    pm_data_dic1['pm_win_current'] = 'true'
+                    pm_data_str = str(pm_data_dic1) 
+                    self.set_pm_stats_in_pm_win_stats_tbl(lport, asic, "window{}".format(window_num), pm_data_str)
+                    break
+
+                if (float(pm_data_dic.get('pm_win_end_time')) - float(pm_data_dic.get('pm_win_start_time'))) < pm_win_itrvl_in_secs:
+                    sampled_pm_data = {}
+                    #Sample the data between pm_data and pm_hw_data.
+                    sampled_pm_data = self.pm_data_sampling(pm_data_dic, pm_hw_data)
+                    sampled_pm_data['pm_win_end_time'] = pm_hw_data.get('pm_win_end_time')
+                    sampled_pm_data['pm_win_start_time'] = pm_data_dic.get('pm_win_start_time')
+                    sampled_pm_data['pm_win_current'] = pm_data_dic.get('pm_win_current')
+                    #update the window with sampled data in DB.
+                    self.set_pm_stats_in_pm_win_stats_tbl(lport, asic, "window{}".format(window_num), sampled_pm_data)
+                    break
+
+                #set current to false in current pm window as this time window is completed.
+                pm_data_dic['pm_win_current'] = "false"
+                #update the current field in the current window_num key of pm_data
+                self.set_pm_stats_in_pm_win_stats_tbl(lport, asic, "window{}".format(window_num), pm_data_dic)
+
+                #retrieve next pm window number and its data
+                if window_num == end_window:
+                    next_window_num = start_window 
+                else:
+                    next_window_num = window_num + 1
+                next_pm_data = {}
+                next_pm_data_dic = {}
+                next_pm_data = self.get_pm_stats_in_pm_win_stats_tbl(lport, asic, "window"+str(next_window_num))
+                # If next window pm_data is empty, then fill the next window with pm_hw_data and 
+                # set the curremt, start and end time, 
+                # update the pm_win_current to false in current_pm_data and write to DB
+                if next_pm_data == 'N/A':
+                    # fill the hw data to the next window
+                    for key, value in pm_hw_data.items():
+                        next_pm_data_dic[key] = value
+                    
+                    next_pm_data_dic['pm_win_current'] = "true"
+                    next_pm_data_dic['pm_win_start_time'] = pm_data_dic.get('pm_win_end_time')
+                    next_pm_data_dic['pm_win_end_time'] = pm_hw_data.get('pm_win_end_time') 
+                    #convert to string and update current value of next pm data to DB
+                    self.set_pm_stats_in_pm_win_stats_tbl(lport, asic, "window{}".format(next_window_num), str(next_pm_data_dic))
+                    break;     
+                else:
+                    #next window pm data is not empty, check which window is current and udpate next window
+                    next_pm_data_dic = ast.literal_eval(next_pm_data)
+
+                    if (float(next_pm_data_dic.get('pm_win_end_time')) == float(next_pm_data_dic.get('pm_win_start_time'))):
+                         #discard the 1st set of PM data retrieved from the module.
+                         next_pm_data_dic1 = {}
+                         next_pm_data_dic1_str =""
+                         for key, value in pm_hw_data.items():
+                             next_pm_data_dic1[key] = value
+                         #First PM data read from the module 
+                         next_pm_data_dic1['pm_win_start_time'] = next_pm_data.get('pm_win_start_time')
+                         next_pm_data_dic1['pm_win_end_time'] = pm_hw_data.get('pm_win_end_time')
+                         next_pm_data_dic1['pm_win_current'] = 'true'
+                         next_pm_data_str = str(next_pm_data_dic1) 
+                         self.set_pm_stats_in_pm_win_stats_tbl(lport, asic, "window{}".format(next_window_num), next_pm_data_str)
+                         break
+
+
+                    if (float(next_pm_data_dic.get('pm_win_end_time')) - float(next_pm_data_dic.get('pm_win_start_time'))) < pm_win_itrvl_in_secs:
+                        #Sample the data between pm_data and pm_hw_data.
+                        sampled_pm_data = self.pm_data_sampling(next_pm_data_dic, pm_hw_data)
+                        sampled_pm_data['pm_win_end_time'] = pm_hw_data.get('pm_win_end_time')
+                        sampled_pm_data['pm_win_start_time'] = pm_data_dic.get('pm_win_end_time')
+                        sampled_pm_data['pm_win_current'] = next_pm_data_dic.get('pm_win_current')
+                        #update the window with sampled data in DB.
+                        self.set_pm_stats_in_pm_win_stats_tbl(lport, asic, "window{}".format(next_window_num), str(sampled_pm_data))
+                        break
+                    else: 
+                        if float(pm_data_dic.get('pm_win_start_time')) < float(next_pm_data_dic.get('pm_win_start_time')):
+                            window_num = window_num + 1
+                            continue
+                        else:
+                            #Fill the pm_hw_data into DB with key:window+1, with start and end time updated .
+                            next_pm_data_dic = {} 
+                            for key, value in pm_hw_data.items():
+                                next_pm_data_dic[key] = value
+                        
+                            next_pm_data_dic['pm_win_current'] = "true"
+                            next_pm_data_dic['pm_win_start_time'] = pm_data_dic.get('pm_win_end_time')
+                            next_pm_data_dic['pm_win_end_time'] = pm_hw_data.get('pm_win_end_time') 
+                            #convert to string and update current value of prev pm data to DB
+                            self.set_pm_stats_in_pm_win_stats_tbl(lport, asic, "window{}".format(next_window_num), next_pm_data_dic)
+                            #pm_win_stat_from_db["window{}".format(next_window_num)] = str(next_pm_data_dic)
+                        
+                            #update the current field in the current window_num key of pm_data
+                            pm_data_dic['pm_win_current'] = 'false'
+                            self.set_pm_stats_in_pm_win_stats_tbl(lport, asic, "window{}".format(window_num), str(pm_data_dic))
+                            break;     
+
+
+    def average_of_two_val(self, val1, val2):
+        return((val1+val2)/2)
+    
+    # perform min, max and average of relevant PM stats parameter between two dictionary
+    def pm_data_sampling(self, pm_data_dict1, pm_data_dict2):
+        sampled_pm_dict = {}
+        try:
+            sampled_pm_dict['prefec_ber_avg'] = self.average_of_two_val(float(pm_data_dict1['prefec_ber_avg']), float(pm_data_dict2['prefec_ber_avg']))
+            sampled_pm_dict['prefec_ber_min'] = min(float(pm_data_dict1['prefec_ber_min']), float(pm_data_dict2['prefec_ber_min']))
+            sampled_pm_dict['prefec_ber_max'] = max(float(pm_data_dict1['prefec_ber_max']), float(pm_data_dict2['prefec_ber_max']))
+         
+            sampled_pm_dict['uncorr_frames_avg'] = self.average_of_two_val(float(pm_data_dict1['uncorr_frames_avg']), float(pm_data_dict2['uncorr_frames_avg']))
+            sampled_pm_dict['uncorr_frames_min'] = min(float(pm_data_dict1['uncorr_frames_min']), float(pm_data_dict2['uncorr_frames_min']))
+            sampled_pm_dict['uncorr_frames_max'] = max(float(pm_data_dict1['uncorr_frames_max']), float(pm_data_dict2['uncorr_frames_max']))
+         
+            sampled_pm_dict['cd_avg'] = self.average_of_two_val(float(pm_data_dict1['cd_avg']), float(pm_data_dict2['cd_avg']))
+            sampled_pm_dict['cd_min'] = min(float(pm_data_dict1['cd_min']), float(pm_data_dict2['cd_min']))
+            sampled_pm_dict['cd_max'] = max(float(pm_data_dict1['cd_max']), float(pm_data_dict2['cd_max']))
+         
+            sampled_pm_dict['dgd_avg']   = self.average_of_two_val(float(pm_data_dict1['dgd_avg']), float(pm_data_dict2['dgd_avg']))
+            sampled_pm_dict['dgd_min']   = min(float(pm_data_dict1['dgd_min']), float(pm_data_dict2['dgd_min']))
+            sampled_pm_dict['dgd_max']   = max(float(pm_data_dict1['dgd_max']), float(pm_data_dict2['dgd_max']))
+         
+            sampled_pm_dict['sopmd_avg'] = self.average_of_two_val(float(pm_data_dict1['sopmd_avg']), float(pm_data_dict2['sopmd_avg']))
+            sampled_pm_dict['sopmd_min'] = min(float(pm_data_dict1['sopmd_min']), float(pm_data_dict2['sopmd_min']))
+            sampled_pm_dict['sopmd_max'] = max(float(pm_data_dict1['sopmd_max']), float(pm_data_dict2['sopmd_max']))
+         
+            sampled_pm_dict['pdl_avg']   = self.average_of_two_val(float(pm_data_dict1['pdl_avg']), float(pm_data_dict2['pdl_avg']))
+            sampled_pm_dict['pdl_min']   = min(float(pm_data_dict1['pdl_min']), float(pm_data_dict2['pdl_min']))
+            sampled_pm_dict['pdl_max']   = max(float(pm_data_dict1['pdl_max']), float(pm_data_dict2['pdl_max']))
+         
+            sampled_pm_dict['osnr_avg']  = self.average_of_two_val(float(pm_data_dict1['osnr_avg']), float(pm_data_dict2['osnr_avg']))
+            sampled_pm_dict['osnr_min']  = min(float(pm_data_dict1['osnr_min']), float(pm_data_dict2['osnr_min']))
+            sampled_pm_dict['osnr_max']  = max(float(pm_data_dict1['osnr_max']), float(pm_data_dict2['osnr_max']))
+         
+            sampled_pm_dict['esnr_avg']  = self.average_of_two_val(float(pm_data_dict1['esnr_avg']), float(pm_data_dict2['esnr_avg']))
+            sampled_pm_dict['esnr_min']  = min(float(pm_data_dict1['esnr_min']), float(pm_data_dict2['esnr_min']))
+            sampled_pm_dict['esnr_max']  = max(float(pm_data_dict1['esnr_max']), float(pm_data_dict2['esnr_max']))
+         
+            sampled_pm_dict['cfo_avg']   = self.average_of_two_val(float(pm_data_dict1['cfo_avg']), float(pm_data_dict2['cfo_avg']))
+            sampled_pm_dict['cfo_min']   = min(float(pm_data_dict1['cfo_min']), float(pm_data_dict2['cfo_min']))
+            sampled_pm_dict['cfo_max']   = max(float(pm_data_dict1['cfo_max']), float(pm_data_dict2['cfo_max']))
+         
+            sampled_pm_dict['evm_avg']   = self.average_of_two_val(float(pm_data_dict1['evm_avg']), float(pm_data_dict2['evm_avg']))
+            sampled_pm_dict['evm_min']   = min(float(pm_data_dict1['evm_min']), float(pm_data_dict2['evm_min']))
+            sampled_pm_dict['evm_max']   = max(float(pm_data_dict1['evm_max']), float(pm_data_dict2['evm_max']))
+         
+            sampled_pm_dict['soproc_avg'] = self.average_of_two_val(float(pm_data_dict1['soproc_avg']), float(pm_data_dict2['soproc_avg']))
+            sampled_pm_dict['soproc_min'] = min(float(pm_data_dict1['soproc_min']), float(pm_data_dict2['soproc_min']))
+            sampled_pm_dict['soproc_max'] = max(float(pm_data_dict1['soproc_max']), float(pm_data_dict2['soproc_max']))
+         
+            sampled_pm_dict['tx_power_avg']  = self.average_of_two_val(float(pm_data_dict1['tx_power_avg']), float(pm_data_dict2['tx_power_avg']))
+            sampled_pm_dict['tx_power_min']  = min(float(pm_data_dict1['tx_power_min']), float(pm_data_dict2['tx_power_min']))
+            sampled_pm_dict['tx_power_max']  = max(float(pm_data_dict1['tx_power_max']), float(pm_data_dict2['tx_power_max']))
+         
+            sampled_pm_dict['rx_tot_power_avg']  = self.average_of_two_val(float(pm_data_dict1['rx_tot_power_avg']), float(pm_data_dict2['rx_tot_power_avg']))
+            sampled_pm_dict['rx_tot_power_min']  = min(float(pm_data_dict1['rx_tot_power_min']), float(pm_data_dict2['rx_tot_power_min']))
+            sampled_pm_dict['rx_tot_power_max']  = max(float(pm_data_dict1['rx_tot_power_max']), float(pm_data_dict2['rx_tot_power_max']))
+         
+            sampled_pm_dict['rx_sig_power_avg'] = self.average_of_two_val(float(pm_data_dict1['rx_sig_power_avg']), float(pm_data_dict2['rx_sig_power_avg']))
+            sampled_pm_dict['rx_sig_power_min'] =  min(float(pm_data_dict1['rx_sig_power_min']), float(pm_data_dict2['rx_sig_power_min']))
+            sampled_pm_dict['rx_sig_power_max'] =  max(float(pm_data_dict1['rx_sig_power_max']), float(pm_data_dict2['rx_sig_power_max']))
+        except ValueError as e:
+            self.log_error("Value Error: {}".format(e))
+        return sampled_pm_dict
+
+    def is_current_window(self, pm_data_dict):
+        return (True if (pm_data_dic.get('pm_win_current', false) == 'true') else False)
+
+    def beautify_pm_info_dict(self, pm_info_dict, physical_port):
+        for k, v in pm_info_dict.items():
+            if type(v) is str:
+                continue
+            pm_info_dict[k] = str(v)
+
+    def task_worker(self):
+        self.log_notice("Start Performance monitoring for 400G ZR modules")
+        sel, asic_context = port_mapping.subscribe_port_update_event(self.namespaces, self, self.PORT_TBL_MAP)
+
+        # Start loop to update PM stats info to DB periodically for PM interval time, default is 60sec
+        while not self.task_stopping_event.wait(self.pm_interval):
+
+            # Handle port change event from main thread
+            port_mapping.handle_port_update_event(sel, asic_context, self.task_stopping_event, self, self.on_port_update_event)
+            for lport in self.pm_port_list:
+                asic_index = self.port_mapping_data.get_asic_id_for_logical_port(lport)
+                if asic_index is None:
+                    continue
+                
+                physical_port = self.port_mapping_data.get_logical_to_physical(lport)[0]
+                if not physical_port:
+                    continue
+
+                #skip if sfp obj or sfp is not present
+                sfp = self.platform_chassis.get_sfp(physical_port)
+                if sfp is not None:
+                    if not sfp.get_presence():
+                        continue
+                else:
+                    continue
+
+                if self.get_port_admin_status(lport) != 'up':
+                    continue
+
+                if not sfp_status_helper.detect_port_in_error_status(lport, self.xcvr_table_helper.get_status_tbl(asic_index)):
+                    try:
+                        pm_hw_data = self.get_transceiver_pm(physical_port)
+                    except (KeyError, TypeError) as e:
+                        #continue to process next port since execption could be raised due to port reset, transceiver removal
+                        self.log_warning("Got exception {} while reading pm stats for port {}, ignored".format(repr(e), lport))
+                        continue
+
+                if not pm_hw_data:
+                    continue
+
+                self.beautify_pm_info_dict(pm_hw_data, physical_port)
+
+                # Update 60Sec PM time window slots
+                start_window = WINDOW_60SEC_START_NUM
+                end_window = WINDOW_60SEC_END_NUM 
+                pm_win_itrvl_in_secs = TIME_60SEC_IN_SECS
+                self.pm_window_update_to_DB(lport, asic_index, start_window, end_window, pm_win_itrvl_in_secs, pm_hw_data)
+
+                # Update 15min PM time window slots
+                start_window = WINDOW_15MIN_START_NUM
+                end_window = WINDOW_15MIN_END_NUM 
+                pm_win_itrvl_in_secs = TIME_15MIN_IN_SECS
+                self.pm_window_update_to_DB(lport, asic_index, start_window, end_window, pm_win_itrvl_in_secs, pm_hw_data)
+  
+                # Update 24hrs PM time window slots
+                start_window = WINDOW_24HRS_START_NUM
+                end_window = WINDOW_24HRS_END_NUM 
+                pm_win_itrvl_in_secs = TIME_24HRS_IN_SECS
+                self.pm_window_update_to_DB(lport, asic_index, start_window, end_window, pm_win_itrvl_in_secs, pm_hw_data)
+
+        self.log_notice("Stop Performance Monitoring")
+
+    def run(self):
+        if self.task_stopping_event.is_set():
+            return
+
+        try:
+            self.task_worker()
+        except Exception as e:
+            self.log_error("Exception occured at {} thread due to {}".format(threading.current_thread().getName(), repr(e)))
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            msg = traceback.format_exception(exc_type, exc_value, exc_traceback)
+            for tb_line in msg:
+                for tb_line_split in tb_line.splitlines():
+                    self.log_error(tb_line_split)
+            self.exc = e
+            self.main_thread_stop_event.set()
+
+    def join(self):
+        self.task_stopping_event.set()
+        threading.Thread.join(self)
+        if self.exc:
+            raise self.exc
+
+

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/port_mapping.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/port_mapping.py
@@ -1,19 +1,33 @@
+import threading
 from sonic_py_common import daemon_base
 from sonic_py_common import multi_asic
 from sonic_py_common.interface import backplane_prefix, inband_prefix, recirc_prefix
 from swsscommon import swsscommon
 
 SELECT_TIMEOUT_MSECS = 1000
+DEFAULT_PORT_TBL_MAP = [
+    {'CONFIG_DB': swsscommon.CFG_PORT_TABLE_NAME},
+    {'STATE_DB': 'TRANSCEIVER_INFO'},
+    {'STATE_DB': 'PORT_TABLE', 'FILTER': ['host_tx_ready']},
+]
+
 
 
 class PortChangeEvent:
+    # thread_local_data will be used to hold class-scope thread-safe variables
+    # (i.e. global variable to the local thread), such as
+    # thread_local_data.PORT_EVENT. thread_local_data.PORT_EVENT dict will be
+    # initialized in subscribe_port_update_event, and used to store the latest
+    # port change event for each key, to avoid duplicate event processing.
+    thread_local_data = threading.local()
     PORT_ADD = 0
     PORT_REMOVE = 1
     PORT_SET = 2
     PORT_DEL = 3
     PORT_EVENT = {}
 
-    def __init__(self, port_name, port_index, asic_id, event_type, port_dict=None):
+    def __init__(self, port_name, port_index, asic_id, event_type, port_dict=None,
+                 db_name=None, table_name=None):
         # Logical port name, e.g. Ethernet0
         self.port_name = port_name
         # Physical port index, equals to "index" field of PORT table in CONFIG_DB
@@ -24,6 +38,8 @@ class PortChangeEvent:
         self.event_type = event_type
         # Port config dict
         self.port_dict = port_dict
+        self.db_name = db_name
+        self.table_name = table_name
 
     def __str__(self):
         return '{} - name={} index={} asic_id={}'.format('Add' if self.event_type == self.PORT_ADD else 'Remove',
@@ -107,18 +123,17 @@ def subscribe_port_config_change(namespaces):
         sel.addSelectable(port_tbl)
     return sel, asic_context
 
-def subscribe_port_update_event(namespaces, logger):
+def subscribe_port_update_event(namespaces, logger, port_tbl_map=DEFAULT_PORT_TBL_MAP):
     """
        Subscribe to a particular DB's table and listen to only interested fields
        Format :
           { <DB name> : <Table name> , <field1>, <field2>, .. } where only field<n> update will be received
     """
-    port_tbl_map = [
-        {'CONFIG_DB': swsscommon.CFG_PORT_TABLE_NAME},
-        {'STATE_DB': 'TRANSCEIVER_INFO'},
-        {'STATE_DB': 'PORT_TABLE', 'FILTER': ['host_tx_ready']},
-    ]
-
+    # PORT_EVENT dict stores the latest port change event for each key, to avoid
+    # duplicate event processing. key in PORT_EVENT dict would be a combination
+    # of (key of redis DB entry, port_tbl.db_name, port_tbl.table_name)
+    PortChangeEvent.thread_local_data.PORT_EVENT = {}
+ 
     sel = swsscommon.Select()
     asic_context = {}
     for d in port_tbl_map:
@@ -145,14 +160,18 @@ def handle_port_update_event(sel, asic_context, stop_event, logger, port_change_
     """
     Select PORT update events, notify the observers upon a port update in CONFIG_DB
     or a XCVR insertion/removal in STATE_DB
+
+    Returns:
+        bool: True if there's at least one update event; False if there's no update event.
     """
+    has_event = False
     if not stop_event.is_set():
         (state, _) = sel.select(SELECT_TIMEOUT_MSECS)
         if state == swsscommon.Select.TIMEOUT:
-            return
+            return has_event
         if state != swsscommon.Select.OBJECT:
             logger.log_warning('sel.select() did not return swsscommon.Select.OBJECT')
-            return
+            return has_event
 
         port_event_cache = {}
         for port_tbl in asic_context.keys():
@@ -173,10 +192,13 @@ def handle_port_update_event(sel, asic_context, stop_event, logger, port_change_
                 fvp['op'] = op
                 fvp['FILTER'] = port_tbl.filter
                 # Soak duplicate events and consider only the last event
-                port_event_cache[key+port_tbl.db_name+port_tbl.table_name] = fvp
+                port_event_cache[(key, port_tbl.db_name, port_tbl.table_name)] = fvp
 
         # Now apply filter over soaked events
         for key, fvp in port_event_cache.items():
+            port_name = key[0]
+            db_name = key[1]
+            table_name = key[2]
             port_index = int(fvp['index'])
             port_change_event = None
             diff = {}
@@ -184,32 +206,38 @@ def handle_port_update_event(sel, asic_context, stop_event, logger, port_change_
             del fvp['FILTER']
             apply_filter_to_fvp(filter, fvp)
 
-            if key in PortChangeEvent.PORT_EVENT:
-               diff = dict(set(fvp.items()) - set(PortChangeEvent.PORT_EVENT[key].items()))
+            if key in PortChangeEvent.thread_local_data.PORT_EVENT:
+               diff = dict(set(fvp.items()) - set(PortChangeEvent.thread_local_data.PORT_EVENT[key].items()))
                # Ignore duplicate events
                if not diff:
-                  PortChangeEvent.PORT_EVENT[key] = fvp
+                  PortChangeEvent.thread_local_data.PORT_EVENT[key] = fvp
                   continue
-            PortChangeEvent.PORT_EVENT[key] = fvp
+            PortChangeEvent.thread_local_data.PORT_EVENT[key] = fvp
 
             if fvp['op'] == swsscommon.SET_COMMAND:
                port_change_event = PortChangeEvent(fvp['key'],
                                                         port_index,
                                                         fvp['asic_id'],
                                                         PortChangeEvent.PORT_SET,
-                                                        fvp)
+                                                        fvp,
+                                                        db_name,
+                                                        table_name)
             elif fvp['op'] == swsscommon.DEL_COMMAND:
                port_change_event = PortChangeEvent(fvp['key'],
                                                         port_index,
                                                         fvp['asic_id'],
                                                         PortChangeEvent.PORT_DEL,
-                                                        fvp)
+                                                        fvp,
+                                                        db_name,
+                                                        table_name)
             # This is the final event considered for processing
             logger.log_warning("*** {} handle_port_update_event() fvp {}".format(
                 key, fvp))
             if port_change_event is not None:
-               port_change_event_handler(port_change_event)
+                has_event = True
+                port_change_event_handler(port_change_event)
 
+    return has_event
 
 def handle_port_config_change(sel, asic_context, stop_event, port_mapping, logger, port_change_event_handler):
     """Select CONFIG_DB PORT table changes, once there is a port configuration add/remove, notify observers

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvr_table_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvr_table_helper.py
@@ -1,0 +1,61 @@
+try:
+    from sonic_py_common import daemon_base
+    from sonic_py_common import multi_asic
+    from swsscommon import swsscommon
+except ImportError as e:
+    raise ImportError(str(e) + " - required module not found")
+
+TRANSCEIVER_INFO_TABLE = 'TRANSCEIVER_INFO'
+TRANSCEIVER_DOM_SENSOR_TABLE = 'TRANSCEIVER_DOM_SENSOR'
+TRANSCEIVER_DOM_THRESHOLD_TABLE = 'TRANSCEIVER_DOM_THRESHOLD'
+TRANSCEIVER_STATUS_TABLE = 'TRANSCEIVER_STATUS'
+TRANSCEIVER_PM_TABLE = 'TRANSCEIVER_PM'
+TRANSCEIVER_PM_WINDOW_STATS_TABLE = 'TRANSCEIVER_PM_WINDOW_STATS_TABLE'
+
+class XcvrTableHelper:
+    def __init__(self, namespaces):
+        self.int_tbl, self.dom_tbl, self.dom_threshold_tbl, self.status_tbl, self.app_port_tbl, \
+  self.cfg_port_tbl, self.state_port_tbl, self.pm_tbl,self.pm_window_stats_tbl = {}, {}, {}, {}, {}, {}, {}, {}, {}
+        self.state_db = {}
+        self.cfg_db = {}
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.int_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_INFO_TABLE)
+            self.dom_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_DOM_SENSOR_TABLE)
+            self.dom_threshold_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_DOM_THRESHOLD_TABLE)
+            self.status_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
+            self.pm_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_PM_TABLE)
+            self.pm_window_stats_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_PM_WINDOW_STATS_TABLE)
+            self.state_port_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], swsscommon.STATE_PORT_TABLE_NAME)
+            appl_db = daemon_base.db_connect("APPL_DB", namespace)
+            self.app_port_tbl[asic_id] = swsscommon.ProducerStateTable(appl_db, swsscommon.APP_PORT_TABLE_NAME)
+            self.cfg_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
+            self.cfg_port_tbl[asic_id] = swsscommon.Table(self.cfg_db[asic_id], swsscommon.CFG_PORT_TABLE_NAME)
+
+    def get_intf_tbl(self, asic_id):
+        return self.int_tbl[asic_id]
+
+    def get_dom_tbl(self, asic_id):
+        return self.dom_tbl[asic_id]
+
+    def get_dom_threshold_tbl(self, asic_id):
+        return self.dom_threshold_tbl[asic_id]
+
+    def get_status_tbl(self, asic_id):
+        return self.status_tbl[asic_id]
+
+    def get_app_port_tbl(self, asic_id):
+        return self.app_port_tbl[asic_id]
+
+    def get_state_db(self, asic_id):
+        return self.state_db[asic_id]
+
+    def get_cfg_port_tbl(self, asic_id):
+        return self.cfg_port_tbl[asic_id]
+
+    def get_state_port_tbl(self, asic_id):
+        return self.state_port_tbl[asic_id]
+    
+    def get_pm_window_stats_tbl(self, asic_id):
+        return self.pm_window_stats_tbl[asic_id]


### PR DESCRIPTION

#### Description
window based PM statistics collection.  Please refer to the HLD for more details https://github.com/sonic-net/SONiC/pull/1258

#### Motivation and Context
As per the above HLD, PM stats history is not present/maintained for 400G-ZR modules as of today. 
This PR has the changes to collect PM stats and store in time window of different granularity in state-DB as described in the HLD.  The stored PM stats for each window of a port then can be retrieved by CLI defined in the HLD.

#### How Has This Been Tested?
The changes are tested with inphi and acacia 400G-ZR modules on Cisco LC88-36FH-M-O pid.
