### PR TITLE
[pmon]chassisd crash fix

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -306,7 +306,7 @@ class ModuleUpdater(logger.Logger):
         if not self._is_supervisor():
            hostname_key = "{}{}".format(ModuleBase.MODULE_TYPE_LINE, int(self.my_slot) - 1)
            hostname = try_get(device_info.get_hostname, default="None")
-           hostname_fvs = swsscommon.FieldValuePairs([(CHASSIS_MODULE_INFO_SLOT_FIELD, self.my_slot), 
+           hostname_fvs = swsscommon.FieldValuePairs([(CHASSIS_MODULE_INFO_SLOT_FIELD, str(self.my_slot)), 
                                                         (CHASSIS_MODULE_INFO_HOSTNAME_FIELD, hostname),
                                                         (CHASSIS_MODULE_INFO_NUM_ASICS_FIELD, str(len(module_info_dict[CHASSIS_MODULE_INFO_ASICS])))])
            self.hostname_table.set(hostname_key, hostname_fvs)


### PR DESCRIPTION
#### Description
Fix for issue https://github.com/sonic-net/sonic-buildimage/issues/16465

MSFT ADO: 25174518

Root cause:
    - In the line card pmon, while pushing the hostname to CHASSIS_HOST_TABLE in chassis state db, the slot id is also pushed.     The slot id (self.my_slot) is not a string. Since the FieldValue construction function expects string values, the wrapper raises     value TypeError exception and hence chassisd exited.

Fix:
    - Fixed by hard converting self.my_slot to string while passing the value to the FieldValue data construction function.

#### Motivation and Context
The changes in this PR fixes the chassisd crash reported by https://github.com/sonic-net/sonic-buildimage/issues/16465

#### How Has This Been Tested?
- pmon with chassisd with the changes in the PR is loaded in a line card and the syslog was checked. 
- No chassisd crash was observed.
- Chassis state db CHASSIS_MODULE_TABLE entries' slot number was correctly updated as strings.

#### Additional Information (Optional)
