### PR TITLE
Fix the exception when configure unsupported frequency

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -876,6 +876,7 @@ class TestXcvrdScript(object):
         task.get_configured_tx_power_from_db = MagicMock(return_value=-13)
         task.get_configured_laser_freq_from_db = MagicMock(return_value=193100)
         task.configure_tx_output_power = MagicMock(return_value=1)
+        task.verify_config_laser_frequency = MagicMock(return_value=1)
         task.configure_laser_frequency = MagicMock(return_value=1)
 
         # Case 1: Module Inserted --> DP_DEINIT


### PR DESCRIPTION
#### Description
Fix the issue #322 

#### Motivation and Context
1. Add verify_config_laser_frequency to check frequency eariler
=> It doesn't need to re-init CMIS when configure unsupported frequency.
2. Catch the exception for set_laser_freq

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>