### PR TITLE
Add dynamic sensor logic for fixed and psu presence/state checking in thermalctld

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -520,10 +520,10 @@ class TemperatureUpdater(logger.Logger):
         self.table = swsscommon.Table(state_db, TemperatureUpdater.TEMPER_INFO_TABLE_NAME)
         self.phy_entity_table = swsscommon.Table(state_db, PHYSICAL_ENTITY_INFO_TABLE)
         self.chassis_table = None
+        self.all_thermals = set()
 
         self.is_chassis_system = chassis.is_modular_chassis()
         if self.is_chassis_system:
-            self.module_thermals = set()
             my_slot = try_get(chassis.get_my_slot, INVALID_SLOT)
             if my_slot != INVALID_SLOT:
                 try:
@@ -572,13 +572,23 @@ class TemperatureUpdater(logger.Logger):
 
             self._refresh_temperature_status(CHASSIS_INFO_KEY, thermal, index)
 
+        available_thermals = set()
+        for index, thermal in enumerate(self.chassis.get_all_thermals()):
+            if self.task_stopping_event.is_set():
+                return
+
+            available_thermals.add((thermal, CHASSIS_INFO_KEY, index))
+            self._refresh_temperature_status(CHASSIS_INFO_KEY, thermal, index)
+
         for psu_index, psu in enumerate(self.chassis.get_all_psus()):
             parent_name = 'PSU {}'.format(psu_index + 1)
-            for thermal_index, thermal in enumerate(psu.get_all_thermals()):
-                if self.task_stopping_event.is_set():
-                    return
+            if psu.get_presence() and psu.get_powergood_status():
+                for thermal_index, thermal in enumerate(psu.get_all_thermals()):
+                    if self.task_stopping_event.is_set():
+                        return
 
-                self._refresh_temperature_status(parent_name, thermal, thermal_index)
+                    available_thermals.add((thermal, parent_name, thermal_index))
+                    self._refresh_temperature_status(parent_name, thermal, thermal_index)
 
         for sfp_index, sfp in enumerate(self.chassis.get_all_sfps()):
             parent_name = 'SFP {}'.format(sfp_index + 1)
@@ -586,10 +596,9 @@ class TemperatureUpdater(logger.Logger):
                 if self.task_stopping_event.is_set():
                     return
 
+                available_thermals.add((thermal, parent_name, thermal_index))
                 self._refresh_temperature_status(parent_name, thermal, thermal_index)
-
         if self.is_chassis_system:
-            available_thermals = set()
             for module_index, module in enumerate(self.chassis.get_all_modules()):
                 module_name = try_get(module.get_name, 'Module {}'.format(module_index + 1))
 
@@ -608,21 +617,19 @@ class TemperatureUpdater(logger.Logger):
 
                         available_thermals.add((thermal, sfp_name, thermal_index))
                         self._refresh_temperature_status(sfp_name, thermal, thermal_index)
-
+                        
                 for psu_index, psu in enumerate(module.get_all_psus()):
-                    psu_name = '{} PSU {}'.format(module_name, psu_index + 1)
-                    for thermal_index, thermal in enumerate(psu.get_all_thermals()):
-                        if self.task_stopping_event.is_set():
-                            return
+                    if psu.get_presence() and psu.get_powergood_status():
+                        for thermal_index, thermal in enumerate(psu.get_all_thermals()):
+                            if self.task_stopping_event.is_set():
+                                return
+                            available_thermals.add((thermal, psu_name, thermal_index))
+                            self._refresh_temperature_status(psu_name, thermal, thermal_index)
 
-                        available_thermals.add((thermal, psu_name, thermal_index))
-                        self._refresh_temperature_status(psu_name, thermal, thermal_index)
-
-
-            thermals_to_remove = self.module_thermals - available_thermals
-            self.module_thermals = available_thermals
-            for thermal, parent_name, thermal_index in thermals_to_remove:
-                self._remove_thermal_from_db(thermal, parent_name, thermal_index)
+        thermals_to_remove = self.all_thermals - available_thermals
+        self.all_thermals = available_thermals
+        for thermal, parent_name, thermal_index in thermals_to_remove:
+            self._remove_thermal_from_db(thermal, parent_name, thermal_index)
 
         self.log_debug("End temperature updating")
 


### PR DESCRIPTION
…hecking for PSUs

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Extends the existing dynamic sensor logic of modular chassis to fixed and adds a check for PSU presence/status in thermalctld
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
In current form, if a PSU or other device with sensors is removed from the device or disabled during runtime on a fixed chassis, they will remain in the temperature sensor DB which should not be correct. This change brings the existing logic checks that modular chassis' have to fixed platform as well as checks for PSU presence/status to account for scenario where PSU may be disabled during runtime.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
On both fixed and modular platforms (Cisco 8800RP and Cisco 8101_32FH), I confirmed presence of all thermal sensors. Then disable the PSU and confirmed its associated sensors were removed from the DB while it was either inactive and present or not present. Reenabled PSU and confirmed its associated sensors were updated back into the DB.

#### Additional Information (Optional)
