### PR TITLE
400ZR not linking up with latest SONiC master image

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -205,6 +205,20 @@ class TestXcvrdThreadException(object):
 
 class TestXcvrdScript(object):
 
+    from sonic_platform_base.sonic_xcvr.api.public.c_cmis import CCmisApi
+    from sonic_platform_base.sonic_xcvr.api.public.sff8636 import Sff8636Api
+    from sonic_platform_base.sonic_xcvr.api.public.sff8436 import Sff8436Api
+    @pytest.mark.parametrize("mock_class, expected_return_value", [
+        (CmisApi, True),
+        (CCmisApi, True),
+        (Sff8636Api, False),
+        (Sff8436Api, False)
+    ])
+    def test_is_cmis_api(self, mock_class, expected_return_value):
+        mock_xcvr_api = MagicMock()
+        mock_xcvr_api.__class__ = mock_class
+        assert is_cmis_api(mock_xcvr_api) == expected_return_value
+
     @patch('xcvrd.xcvrd._wrapper_get_sfp_type')
     @patch('xcvrd.xcvrd_utilities.port_mapping.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -109,7 +109,7 @@ helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
 
 def is_cmis_api(api):
-   return type(api) == CmisApi
+   return isinstance(api, CmisApi)
 
 
 def get_cmis_application_desired(api, host_lane_count, speed):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
With the latest SONiC image, the link on 400ZR remains down.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The issue seems to have been introduced via https://github.com/sonic-net/sonic-platform-daemons/pull/400

The is_cmis_api API currently returns False for CCmis modules. Hence, the CMIS SM doesn't identify 400ZR and skips the port initialization as the desired application id is returned as None.

https://github.com/sonic-net/sonic-platform-daemons/blob/502c0b6622008363cb1ed6d1b7c85b4093997093/sonic-xcvrd/xcvrd/xcvrd.py#L134-L135

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Link up on 400ZR has been verified after switch boot-up.
```
root@sonic:/home/admin# show int status Ethernet144
  Interface                            Lanes    Speed    MTU    FEC         Alias    Vlan    Oper    Admin                                             Type    Asym PFC
-----------  -------------------------------  -------  -----  -----  ------------  ------  ------  -------  -----------------------------------------------  ----------
Ethernet144  145,146,147,148,149,150,151,152     400G   9100    N/A  Ethernet19/1  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
root@sonic:/home/admin# show int status Ethernet160
  Interface                            Lanes    Speed    MTU    FEC         Alias    Vlan    Oper    Admin                                             Type    Asym PFC
-----------  -------------------------------  -------  -----  -----  ------------  ------  ------  -------  -----------------------------------------------  ----------
Ethernet160  161,162,163,164,165,166,167,168     400G   9100    N/A  Ethernet21/1  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
root@sonic:/home/admin# show lldp table
Capability codes: (R) Router, (B) Bridge, (O) Other
LocalPort    RemoteDevice                  RemotePortID    Capability    RemotePortDescr
-----------  ----------------------------  --------------  ------------  ------------------------
Ethernet144  sonic                         Ethernet21/1    BR            Ethernet160
Ethernet160  sonic                         Ethernet19/1    BR            Ethernet144
--------------------------------------------------
Total entries displayed:  2
root@sonic:/home/admin# 
```

#### Additional Information (Optional)
