### PR TITLE
Mark sub-port interfaces as invalid ports in xcvrd

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/port_mapping.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/port_mapping.py
@@ -92,7 +92,7 @@ class PortMapping:
                 return None
 
 def validate_port(port):
-    if port.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
+    if port.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())) or '.' in port:
         return False
     return True
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Currently, the CmisManagerTask thread crashes with the below traceback when subport interfaces are created.
```
E               Dec  4 06:47:53.773502 dut-sonic ERR pmon#xcvrd[197]: Exception occured at CmisManagerTask thread due to KeyError(None)
E               
E               Dec  4 06:47:53.777609 dut-sonic ERR pmon#xcvrd[197]: Traceback (most recent call last):
E               
E               Dec  4 06:47:53.777609 dut-sonic ERR pmon#xcvrd[197]:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1717, in run
E               
E               Dec  4 06:47:53.777724 dut-sonic ERR pmon#xcvrd[197]:     self.task_worker()
E               
E               Dec  4 06:47:53.777724 dut-sonic ERR pmon#xcvrd[197]:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1427, in task_worker
E               
E               Dec  4 06:47:53.778242 dut-sonic ERR pmon#xcvrd[197]:     self.port_dict[lport]['host_tx_ready'] = self.get_host_tx_status(lport)
E               
E               Dec  4 06:47:53.778647 dut-sonic ERR pmon#xcvrd[197]:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1299, in get_host_tx_status
E               
E               Dec  4 06:47:53.778942 dut-sonic ERR pmon#xcvrd[197]:     state_port_tbl = self.xcvr_table_helper.get_state_port_tbl(asic_index)
E               
E               Dec  4 06:47:53.778942 dut-sonic ERR pmon#xcvrd[197]:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 2631, in get_state_port_tbl
E               
E               Dec  4 06:47:53.779013 dut-sonic ERR pmon#xcvrd[197]:     return self.state_port_tbl[asic_id]
E               
E               Dec  4 06:47:53.779370 dut-sonic ERR pmon#xcvrd[197]: KeyError: None
E               
E               Dec  4 06:47:53.779580 dut-sonic ERR pmon#xcvrd[197]: Xcvrd: exception found at child thread CmisManagerTask due to KeyError(None)
E               
E               Dec  4 06:47:53.779580 dut-sonic ERR pmon#xcvrd[197]: Exiting main loop as child thread raised exception!
E               
```
The above traceback is also seen while executing the sonic-mgmt sub_port_interfaces/test_show_subinterface.py::test_subinterface_status[port] testcase.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
As part of dynamic sub-port interfaces creation (sub-port interfaces such as Ethernet1.X, Ethernet2.X are created), the STATE_DB gets a SET event and hence, CmisManagerTask handles the event.
However, since the get_port_mapping function (responsible for updating port relevant data such as asic_id, logical_to_asic etc) is only called during xcvrd boot-up, asic_id remains undefined for the sub-port interfaces ports as they are dynamically created.
Due to this, CmisManagerTask thread crashes since the asic_index is None for the sub-port interfaces ports.

https://github.com/sonic-net/sonic-platform-daemons/blob/1c9b01d12393f25db7b258f58d10ea77c3f5b682/sonic-xcvrd/xcvrd/xcvrd.py#L1098

In order to fix this issue, I am planning to mark the sub-port interfaces (port name contains '.') as invalid in port_mapping.py file since xcvrd does not need to handle such ports.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Verified that xcvrd remains stable after sub-port interfaces are created dynamically.
Also ensure that the sonic-mgmt sub_port_interfaces/test_show_subinterface.py::test_subinterface_status[port] testcase is passing now.

```
sub_port_interfaces/test_show_subinterface.py::test_subinterface_status[port] PASSED                                                         [100%]

================================================================= warnings summary =================================================================
../../../../usr/local/lib/python3.8/dist-packages/_yaml/__init__.py:18
  /usr/local/lib/python3.8/dist-packages/_yaml/__init__.py:18: DeprecationWarning: The _yaml extension module is now located at yaml._yaml and its location is subject to change.  To use the LibYAML-based parser and emitter, import from `yaml`: `from yaml import CLoader as Loader, CDumper as Dumper`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--------------------------------------------- generated xml file: /var/src/workspace/tests/logs/tr.xml ---------------------------------------------
===================================================== 1 passed, 1 warning in 373.01s (0:06:13) =====================================================
INFO:root:Can not get Allure report URL. Please check logs
```

#### Additional Information (Optional)
MSFT ADO - 25745106