### PR TITLE
Support 800G ifname in xcvrd

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -987,6 +987,7 @@ class TestXcvrdScript(object):
         assert task.is_cmis_application_update_required(mock_xcvr_api, app_new, host_lanes_mask) == expected
 
     @pytest.mark.parametrize("ifname, expected", [
+        ('800G L C2M', 800000),
         ('400G CR8', 400000),
         ('200GBASE-CR4 (Clause 136)', 200000),
         ('100GBASE-CR2 (Clause 136)', 100000),

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -155,7 +155,9 @@ def get_interface_speed(ifname):
     """
     # see HOST_ELECTRICAL_INTERFACE of sff8024.py
     speed = 0
-    if '400G' in ifname:
+    if '800G' in ifname:
+        speed = 800000
+    elif '400G' in ifname:
         speed = 400000
     elif '200G' in ifname:
         speed = 200000


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Add 800G ifname in xcvrd get_interface_speed() which gets the port speed from the host interface name. 

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Verified with enabling 800G module app code 

#### Additional Information (Optional)
