### PR TITLE
[xcvrd] Introduce regex style keys in media_settings  for setting up port configuration in xcvrd

### DIFF
--- a/sonic-xcvrd/tests/media_settings.json
+++ b/sonic-xcvrd/tests/media_settings.json
@@ -436,6 +436,39 @@
                     "lane3":"0x144808"
                 }
             }
+        },
+        "33": {
+            "Default": {
+                "preemphasis": {
+                    "lane0":"0x144808",
+                    "lane1":"0x144808",
+                    "lane2":"0x144808",
+                    "lane3":"0x144808"
+                }
+            }
+        }
+    },
+    "GLOBAL_MEDIA_PATTERN_SETTINGS": {
+        "1-33": {
+            "^QSFP\\+.*10G.*SR.*": {
+                   "interface_type": "sr4"
+
+            },
+            "^QSFP\\+.*40G.*": {
+                   "interface_type": "sr4"
+
+            },
+            "QSFP\\+.*100GBASE-LR4.*": {
+                   "interface_type": "sr4"
+
+            }
+
+        },
+        "34,35,36": {
+            "^QSFP\\+.*10G.*SR.*": {
+                   "interface_type": "sr4"
+
+            }
         }
     }
 }

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -454,7 +454,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.g_dict', media_settings_dict)
     @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))
     def test_notify_media_setting(self):
-        rv = self._check_notify_media_setting(1)
+        self._check_notify_media_setting(1)
 
     @patch('xcvrd.xcvrd.g_dict', media_settings_with_comma_dict)
     @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -634,6 +634,7 @@ def get_media_settings_value(physical_port, key):
 
     media_dict = {}
 
+
     if PORT_MEDIA_SETTINGS_KEY in g_dict:
         for keys in g_dict[PORT_MEDIA_SETTINGS_KEY]:
             if int(keys) == physical_port:
@@ -647,6 +648,7 @@ def get_media_settings_value(physical_port, key):
                 helper_logger.log_error("Error: No values for physical port '{}'".format(physical_port))
             return {}
 
+
         if key[0] in media_dict:
             return media_dict[key[0]]
         elif key[0].split('-')[0] in media_dict:
@@ -654,8 +656,7 @@ def get_media_settings_value(physical_port, key):
         elif key[1] in media_dict:
             return media_dict[key[1]]
         elif DEFAULT_KEY in media_dict:
-            return media_dict[DEFAULT_KEY]
-
+            default_dict = media_dict[DEFAULT_KEY]
 
     if GLOBAL_MEDIA_PATTERN_SETTINGS_KEY in g_dict:
         for keys in g_dict[GLOBAL_MEDIA_PATTERN_SETTINGS_KEY]:

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -663,7 +663,7 @@ def get_media_settings_value(physical_port, key):
 
             for dkey, val in media_dict.items():
                 if re.match(dkey, key[1]):
-                    return media_dict[key[1]]
+                    return media_dict[dkey]
 
     else:
         if len(default_dict) != 0:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description

This PR introduces a new way of specifying keys in media_settings file in a regex format.  This way port settings will be applied to ports specified in `GLOBAL_MEDIA_PATTERN_SETTINGS` key in the media_settings.json key and whichever port vendor key matches the regex format key, they will be configured with params specified for that key. 
If None of the keys match, default settings if any will be applied as in `GLOBAL_MEDIA_SETTINGS` or `PORT_MEDIA_SETTINGS`. 


```
{
    "GLOBAL_MEDIA_PATTERN_SETTINGS": {
        "1-32": {
            "^QSFP28+\\.*10G.*SR.*": {
                   "interface_type": "sr4"

            },
            "^QSFP\\+.*40G.*": {
                   "interface_type": "sr4"

            },
            "QSFP\\+.*100GBASE-LR4.*": {
                   "interface_type": "sr4"

            }

        }
    }
}

```
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
UT and testing on a sonic-mgmt Testbed
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
