### PR TITLE
Support 800G ifname in xcvrd

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -972,7 +972,7 @@ class CmisManagerTask(threading.Thread):
         speed = 0
         if '800G' in ifname:
             speed = 800000
-	elif '400G' in ifname:
+        elif '400G' in ifname:
             speed = 400000
         elif '200G' in ifname:
             speed = 200000

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -970,7 +970,9 @@ class CmisManagerTask(threading.Thread):
         """
         # see HOST_ELECTRICAL_INTERFACE of sff8024.py
         speed = 0
-        if '400G' in ifname:
+        if '800G' in ifname:
+            speed = 800000
+	elif '400G' in ifname:
             speed = 400000
         elif '200G' in ifname:
             speed = 200000


### PR DESCRIPTION
Support 800G ifname

<!-- Provide a general summary of your changes in the Title above -->

#### Description
Add 800G ifname in xcvrd get_interface_speed() which gets the port speed from the host interface name.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Verified with enabling 800G module app code

Master commit: https://github.com/sonic-net/sonic-platform-daemons/pull/416

#### Additional Information (Optional)
