### PR TITLE
[xcvrd] enable setting log level at real time

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1,4 +1,6 @@
 #from unittest.mock import DEFAULT
+import os
+os.environ["XCVRD_UNIT_TESTING"] = "1"
 from xcvrd.xcvrd_utilities.port_mapping import *
 from xcvrd.xcvrd_utilities.sfp_status_helper import *
 from xcvrd.xcvrd_utilities.media_settings_parser import *
@@ -33,8 +35,6 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "xcvrd")
 sys.path.insert(0, modules_path)
 DEFAULT_NAMESPACE = ['']
-
-os.environ["XCVRD_UNIT_TESTING"] = "1"
 
 with open(os.path.join(test_path, 'media_settings.json'), 'r') as f:
     media_settings_dict = json.load(f)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -29,6 +29,7 @@ try:
     from .xcvrd_utilities import port_mapping
     from .xcvrd_utilities import media_settings_parser
     from .xcvrd_utilities import optics_si_parser
+    from .xcvrd_utilities.logger import logger as helper_logger
     
     from sonic_platform_base.sonic_xcvr.api.public.c_cmis import CmisApi
 
@@ -97,11 +98,6 @@ g_dict = {}
 platform_sfputil = None
 # Global chassis object based on new platform api
 platform_chassis = None
-
-# Global logger instance for helper functions and classes
-# TODO: Refactor so that we only need the logger inherited
-# by DaemonXcvrd
-helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
 #
 # Helper functions =============================================================

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/logger.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/logger.py
@@ -1,0 +1,12 @@
+import os
+from sonic_py_common.logger import Logger
+
+# Global logger instance for xcvrd, the argument "enable_set_log_level_on_fly"
+# will start a thread to detect CONFIG DB LOGGER table change. The logger instance 
+# allow user to set log level via swssloglevel command at real time. This instance 
+# should be shared by all modules of xcvrd to avoid starting too many logger thread.
+if os.environ.get("XCVRD_UNIT_TESTING") != "1":
+    logger = Logger(log_identifier='xcvrd', enable_set_log_level_on_fly=True)
+else:
+    # for unit test, there is no redis, don't set enable_set_log_level_on_fly=True
+    logger = Logger(log_identifier='xcvrd')

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -6,9 +6,10 @@ import json
 import os
 import ast
 
-from sonic_py_common import device_info, logger
+from sonic_py_common import device_info
 from swsscommon import swsscommon
 from xcvrd import xcvrd
+from .logger import logger as helper_logger
 
 g_dict = {}
 
@@ -16,8 +17,6 @@ LANE_SPEED_KEY_PREFIX = "speed:"
 VENDOR_KEY = 'vendor_key'
 MEDIA_KEY = 'media_key'
 LANE_SPEED_KEY = 'lane_speed_key'
-SYSLOG_IDENTIFIER = "xcvrd"
-helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
 
 def load_media_settings():

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py
@@ -1,13 +1,12 @@
 import json
 import os
 
-from sonic_py_common import device_info, logger
+from sonic_py_common import device_info
 from xcvrd import xcvrd
+from .logger import logger as helper_logger
 
 g_optics_si_dict = {}
 
-SYSLOG_IDENTIFIER = "xcvrd"
-helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
 def get_optics_si_settings_value(physical_port, lane_speed, key, vendor_name_str):
     GLOBAL_MEDIA_SETTINGS_KEY = 'GLOBAL_MEDIA_SETTINGS'


### PR DESCRIPTION
Depends on https://github.com/sonic-net/sonic-buildimage/pull/17321

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Enable setting xcvrd log level on fly

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

Enable setting xcvrd log level on fly

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Manual test

#### Additional Information (Optional)
