### PR TITLE
[ycabled][tests] Fix UT for Bookworm

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -20,6 +20,7 @@ swsscommon.Table = MagicMock()
 
 sys.modules['sonic_y_cable'] = MagicMock()
 sys.modules['sonic_y_cable.y_cable'] = MagicMock()
+sys.modules['sonic_y_cable.y_cable_vendor_mapping'] = MagicMock()
 
 os.environ["Y_CABLE_HELPER_UNIT_TESTING"] = "1"
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Directly assign MagicMock for module 'sonic_y_cable.y_cable_vendor_mapping'

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

Fix UT cases failing due to 'sonic_y_cable.y_cable_vendor_mapping' not being mocked in Python 3.11 (Bookworm).
The UT failure blocks PMON container from being built with Debian Bookworm.
(Python mock import target change ref: https://github.com/python/cpython/commit/ab7fcc8fbdc11091370deeb000a787fb02f9b13d )

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Run sonic_y_cabled UT in Python3.11 and verify that it does not report any failure.

Without fix:
```
abalac@95bc81120a7d:/sonic/src/sonic-platform-daemons/sonic-ycabled$ python3 --version
Python 3.11.2
abalac@95bc81120a7d:/sonic/src/sonic-platform-daemons/sonic-ycabled$
abalac@95bc81120a7d:/sonic/src/sonic-platform-daemons/sonic-ycabled$ python3 setup.py test
running pytest
running egg_info
writing sonic_ycabled.egg-info/PKG-INFO
writing dependency_links to sonic_ycabled.egg-info/dependency_links.txt
writing entry points to sonic_ycabled.egg-info/entry_points.txt
writing requirements to sonic_ycabled.egg-info/requires.txt
writing top-level names to sonic_ycabled.egg-info/top_level.txt
reading manifest file 'sonic_ycabled.egg-info/SOURCES.txt'
writing manifest file 'sonic_ycabled.egg-info/SOURCES.txt'
running build_ext
running GrpcTool
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0+repack -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /sonic/src/sonic-platform-daemons/sonic-ycabled, configfile: pytest.ini
plugins: pyfakefs-5.3.4, cov-4.0.0
collected 270 items
...
...
...
---------- coverage: platform linux, python 3.11.2-final-0 -----------
Name                                              Stmts   Miss  Cover
---------------------------------------------------------------------
ycable/__init__.py                                    0      0   100%
ycable/ycable.py                                    267    113    58%
ycable/ycable_utilities/__init__.py                   0      0   100%
ycable/ycable_utilities/y_cable_helper.py          2612    556    79%
ycable/ycable_utilities/y_cable_table_helper.py     350     33    91%
---------------------------------------------------------------------
TOTAL                                              3229    702    78%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

================================================================================= short test summary info ==================================================================================
FAILED tests/test_y_cable_helper.py::TestYCableScript::test_check_identifier_presence_and_update_mux_table_entry_module_none - AttributeError: 'dict' object attribute 'get' is read-only
FAILED tests/test_y_cable_helper.py::TestYCableScript::test_check_identifier_presence_and_update_mux_table_entry_module_microsoft - AttributeError: 'dict' object attribute 'get' is read-only
FAILED tests/test_y_cable_helper.py::TestYCableScript::test_check_identifier_presence_and_update_mux_table_entry_module_microsoft_y_cable_presence_false - AttributeError: 'dict' object attribute 'get' is read-only
======================================================================= 3 failed, 267 passed, 68 warnings in 13.91s ========================================================================
abalac@95bc81120a7d:/sonic/src/sonic-platform-daemons/sonic-ycabled$
```

With fix:
```
abalac@95bc81120a7d:/sonic/src/sonic-platform-daemons/sonic-ycabled$ python3 --version
Python 3.11.2
abalac@95bc81120a7d:/sonic/src/sonic-platform-daemons/sonic-ycabled$
abalac@95bc81120a7d:/sonic/src/sonic-platform-daemons/sonic-ycabled$ python3 setup.py test
running pytest
running egg_info
writing sonic_ycabled.egg-info/PKG-INFO
writing dependency_links to sonic_ycabled.egg-info/dependency_links.txt
writing entry points to sonic_ycabled.egg-info/entry_points.txt
writing requirements to sonic_ycabled.egg-info/requires.txt
writing top-level names to sonic_ycabled.egg-info/top_level.txt
reading manifest file 'sonic_ycabled.egg-info/SOURCES.txt'
writing manifest file 'sonic_ycabled.egg-info/SOURCES.txt'
running build_ext
running GrpcTool
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0+repack -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /sonic/src/sonic-platform-daemons/sonic-ycabled, configfile: pytest.ini
plugins: pyfakefs-5.3.4, cov-4.0.0
collected 270 items
...
...
...
---------- coverage: platform linux, python 3.11.2-final-0 -----------
Name                                              Stmts   Miss  Cover
---------------------------------------------------------------------
ycable/__init__.py                                    0      0   100%
ycable/ycable.py                                    267    113    58%
ycable/ycable_utilities/__init__.py                   0      0   100%
ycable/ycable_utilities/y_cable_helper.py          2612    549    79%
ycable/ycable_utilities/y_cable_table_helper.py     350     33    91%
---------------------------------------------------------------------
TOTAL                                              3229    695    78%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

============================================================================ 270 passed, 68 warnings in 11.83s =============================================================================
abalac@95bc81120a7d:/sonic/src/sonic-platform-daemons/sonic-ycabled$
```
With 
#### Additional Information (Optional)
