### PR TITLE
Update sonic-ycabled Python package build for Bookworm

### DIFF
--- a/sonic-ycabled/MANIFEST.in
+++ b/sonic-ycabled/MANIFEST.in
@@ -1,0 +1,1 @@
+graft proto

--- a/sonic-ycabled/setup.py
+++ b/sonic-ycabled/setup.py
@@ -1,7 +1,10 @@
 from setuptools import setup, find_packages
 from setuptools.command.build_py import build_py as _build_py
-from setuptools.errors import CompileError
 import setuptools.command
+try:
+    from setuptools.errors import CompileError
+except:
+    from distutils.errors import CompileError
 
 class GrpcTool(setuptools.Command):
     def initialize_options(self):


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

The build infra for Python packages in Bookworm has changed. Specifically, by default, a sdist (source) tarball is built first, and then the wheel is built. Because of this, the proto file needs to be included in the sdist tarball, and the Python bindings need to be generated at a different stage.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

This is to make sonic-ycabled buildable on Bookworm and Python 3.11.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
