### PR TITLE
[PSUd]Update predefined position_in_parent and parent_name of PSU onl…

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -403,6 +403,9 @@ class DaemonPsud(daemon_base.DaemonBase):
         fvs = swsscommon.FieldValuePairs([(CHASSIS_INFO_PSU_NUM_FIELD, str(self.num_psus))])
         self.chassis_tbl.set(CHASSIS_INFO_KEY, fvs)
 
+        # Update predefined position_in_parent and parent_name for PSU
+        self._update_psu_entity_info()
+
     def __del__(self):
         # Delete all the information from DB and then exit
         for psu_index in range(1, self.num_psus + 1):
@@ -433,7 +436,6 @@ class DaemonPsud(daemon_base.DaemonBase):
             # We received a fatal signal
             return False
 
-        self._update_psu_entity_info()
         self.update_psu_data()
         self._update_led_color()
 


### PR DESCRIPTION
…y once

The values of position_in_parent and parent_name for PSU will remain unchanged. Consequently, update the predefined position_in_parent and parent_name of the PSU only once.

Resolve conflict in https://github.com/sonic-net/sonic-platform-daemons/pull/423.
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
The values of position_in_parent and parent_name for PSU will remain unchanged. Consequently, update the predefined position_in_parent and parent_name of the PSU only once.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Since the values of position_in_parent and parent_name of the PSU do not change, these fields only need to be updated once.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Booting on a SONiC switch, and check the STATE DB ""PHYSICAL_ENTITY_INFO|PSU *" table "position_in_parent" field and "parent_name" field.
#### Additional Information (Optional)
sonic-mgmt test result
============================= test session starts ==============================
platform linux2 -- Python 2.7.17, pytest-4.6.11, py-1.11.0, pluggy-0.13.1 -- /usr/bin/python2
cachedir: .pytest_cache
metadata: {'Python': '2.7.17', 'Platform': 'Linux-5.4.0-169-generic-x86_64-with-Ubuntu-18.04-bionic', 'Packages': {'py': '1.11.0', 'pytest': '4.6.11', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.9.1', u'ansible': u'2.2.2', u'xdist': u'1.28.0', u'allure-pytest': u'2.8.22', u'html': u'1.22.1', u'forked': u'1.3.0', u'metadata': u'1.11.0'}}
ansible: 2.8.12
rootdir: /var/ubuntu/sonic-mgmt/tests, inifile: pytest.ini
plugins: allure-pytest-2.8.22, forked-1.3.0, repeat-0.9.1, html-1.22.1, xdist-1.28.0, metadata-1.11.0, ansible-2.2.2
collecting ...
----------------------------- live log collection ------------------------------
04:10:34 init.load_dut_basic_facts L0095 INFO | Getting dut basic facts
04:11:07 init.pytest_collection_modifyitems L0299 INFO | Available basic facts that can be used in conditional skip:
{
"commit_id": "d1a8415c2",
"build_date": "Thu Jan 18 06:45:26 UTC 2024",
"topo_type": "ptf",
"asic_subtype": "broadcom",
"build_number": 140,
"asic_type": "broadcom",
"sonic_utilities": 1.2,
"kernel_version": "5.10.0-18-2-amd64",
"debian_version": "11.8",
"sonic_os_version": 11,
"built_by": "ubuntu@ip-10-5-1-100",
"num_asic": 1,
"is_multi_asic": false,
"platform": "x86_64-accton_as9817_64d-r0",
"hwsku": "Accton-AS9817-64D-100G",
"branch": "ec202211_ecsonic",
"libswsscommon": "1.0.0",
"build_version": "Edgecore-SONiC_20240118_051441_ec202211_ecsonic_140",
"release": "202211",
"topo_name": "ptf32"
}

-------------------------------- live log setup --------------------------------
04:11:07 init.set_default L0049 INFO | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
04:11:07 init.check_test_completeness L0140 INFO | Test has no defined levels. Continue without test completeness checks
04:11:11 conftest.generate_params_dut_hostname L0926 INFO | Using DUTs ['as9817-64d-1'] in testbed '8-41_ptf32'
04:11:11 conftest.rand_one_dut_hostname L0308 INFO | Randomly select dut as9817-64d-1 for testing
04:11:12 conftest.creds_on_dut L0562 INFO | dut as9817-64d-1 belongs to groups [u'lab', u'sonic', u'sonic_as9817-64d', 'fanout']
04:11:12 conftest.creds_on_dut L0574 INFO | skip empty var file ../ansible/group_vars/all/env.yml
04:11:12 conftest.creds_on_dut L0574 INFO | skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
04:11:17 init.cfg_sanity_check L0260 INFO | CFG sanity check Starts from Test Module::test_psud.py at 2024-0122-0411-17
04:11:17 init.do_cfg_DB_checks L0061 INFO | golden config_db.json md5sum=[u'1d8386ee5e51a3bc16c0f0b4aa5c768b']
04:11:17 init.do_cfg_DB_checks L0062 INFO | current config_db.json md5sum=[1d8386ee5e51a3bc16c0f0b4aa5c768b]
04:11:18 init.do_cfg_checks L0082 INFO | validate md5sums:[[u'd6f76db3f154bc123f1a78dd95be3a58']]
04:11:18 init.do_cfg_checks L0087 INFO | current md5sum=[d6f76db3f154bc123f1a78dd95be3a58]-OK!!
04:11:18 init.cfg_sanity_check L0298 INFO | Done CFG sanity checks@Pre-test in 1s.
04:11:18 conftest.nbrhosts L0413 INFO | No VMs exist for this topology: ptf32
04:11:18 init.sanity_check L0106 INFO | Prepare sanity check
04:11:18 init.sanity_check L0116 INFO | Found marker: m.name=topology, m.args=('any',), m.kwargs={}
04:11:18 init.sanity_check L0116 INFO | Found marker: m.name=sanity_check, m.args=(), m.kwargs={'skip_sanity': True}
04:11:18 init.sanity_check L0123 INFO | Process marker sanity_check in script. m.args=(), m.kwargs={'skip_sanity': True}
04:11:18 init.sanity_check L0142 INFO | Skip sanity check according to command line argument or configuration of test script.
04:11:18 init._fixture_func_decorator L0059 INFO | -------------------- fixture setup setup starts --------------------
04:11:20 sonic.get_pmon_daemon_states L0804 INFO | Pmon daemon state list for this platform is {u'containercfgd': u'RUNNING', u'pmon:xcvrd': u'RUNNING', u'syseepromd': u'RUNNING', u'pmon:psud': u'RUNNING', u'thermalctld': u'RUNNING', u'supervisor-proc-exit-listener': u'RUNNING', u'pcied': u'RUNNING'}
04:11:20 init._fixture_func_decorator L0066 INFO | -------------------- fixture setup setup ends --------------------
04:11:20 init._fixture_generator_decorator L0071 INFO | -------------------- fixture teardown_module setup starts --------------------
04:11:20 init._fixture_generator_decorator L0075 INFO | -------------------- fixture teardown_module setup ends --------------------
04:11:20 init._fixture_func_decorator L0059 INFO | -------------------- fixture data_before_restart setup starts --------------------
04:11:22 init._fixture_func_decorator L0066 INFO | -------------------- fixture data_before_restart setup ends --------------------
04:11:22 init.loganalyzer L0046 INFO | Log analyzer is disabled
-------------------------------- live log call ---------------------------------
04:11:23 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the RUNNING state with pid 34 uptime 7109
04:11:23 test_psud.test_pmon_psud_running_status L0127 INFO | pmon:psud daemon is RUNNING with pid 34
PASSED [ 25%]
platform_tests/daemon/test_psud.py::test_pmon_psud_stop_and_start_status
-------------------------------- live log setup --------------------------------
04:11:23 init.set_default L0049 INFO | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
04:11:23 init.check_test_completeness L0140 INFO | Test has no defined levels. Continue without test completeness checks
04:11:23 init.loganalyzer L0046 INFO | Log analyzer is disabled
04:11:23 init._fixture_func_decorator L0059 INFO | -------------------- fixture check_daemon_status setup starts --------------------
04:11:24 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the RUNNING state with pid 34 uptime 7110
04:11:35 init.fixture_func_decorator L0066 INFO | -------------------- fixture check_daemon_status setup ends --------------------
-------------------------------- live log call ---------------------------------
04:11:36 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the RUNNING state with pid 34 uptime 7122
04:11:36 test_psud.test_pmon_psud_stop_and_start L0143 INFO | pmon:psud daemon is RUNNING with pid 34
04:11:40 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the STOPPED state with pid -1 uptime None
04:11:53 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the RUNNING state with pid 935 uptime 11
04:11:54 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the RUNNING state with pid 935 uptime 12
04:11:56 test_psud._collect_data L0107 INFO | data_after_restart = {'keys': [u'PSU_INFO|PSU 2', u'PSU_INFO|PSU 1'], 'data': {u'PSU_INFO|PSU 1': {}, u'PSU_INFO|PSU 2': {}}}
04:11:56 test_psud._collect_data L0108 INFO | data_before_restart = {'keys': [u'PSU_INFO|PSU 2', u'PSU_INFO|PSU 1'], 'data': {u'PSU_INFO|PSU 1': {}, u'PSU_INFO|PSU 2': {}}}
PASSED [ 50%]
platform_tests/daemon/test_psud.py::test_pmon_psud_term_and_start_status
-------------------------------- live log setup --------------------------------
04:11:56 init.set_default L0049 INFO | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
04:11:56 init.check_test_completeness L0140 INFO | Test has no defined levels. Continue without test completeness checks
04:11:56 init.loganalyzer L0046 INFO | Log analyzer is disabled
04:11:56 init._fixture_func_decorator L0059 INFO | -------------------- fixture check_daemon_status setup starts --------------------
04:11:58 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the RUNNING state with pid 935 uptime 15
04:12:09 init.fixture_func_decorator L0066 INFO | -------------------- fixture check_daemon_status setup ends --------------------
-------------------------------- live log call ---------------------------------
04:12:10 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the RUNNING state with pid 935 uptime 27
04:12:10 test_psud.test_pmon_psud_term_and_start L0195 INFO | pmon:psud daemon is RUNNING with pid 935 uptime 27
04:12:11 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the STARTING state with pid -1 uptime None
04:12:11 test_psud.check_expected_daemon_uptime L0088 INFO | pre_uptime 27 uptime 27 condition False
04:12:23 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the RUNNING state with pid 979 uptime 11
04:12:23 test_psud.check_expected_daemon_uptime L0088 INFO | pre_uptime 27 uptime 11 condition True
04:12:24 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the RUNNING state with pid 979 uptime 13
04:12:26 test_psud._collect_data L0107 INFO | data_after_restart = {'keys': [u'PSU_INFO|PSU 2', u'PSU_INFO|PSU 1'], 'data': {u'PSU_INFO|PSU 1': {}, u'PSU_INFO|PSU 2': {}}}
04:12:26 test_psud._collect_data L0108 INFO | data_before_restart = {'keys': [u'PSU_INFO|PSU 2', u'PSU_INFO|PSU 1'], 'data': {u'PSU_INFO|PSU 1': {}, u'PSU_INFO|PSU 2': {}}}
PASSED [ 75%]
platform_tests/daemon/test_psud.py::test_pmon_psud_kill_and_start_status
-------------------------------- live log setup --------------------------------
04:12:26 init.set_default L0049 INFO | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
04:12:26 init.check_test_completeness L0140 INFO | Test has no defined levels. Continue without test completeness checks
04:12:26 init.loganalyzer L0046 INFO | Log analyzer is disabled
04:12:26 init._fixture_func_decorator L0059 INFO | -------------------- fixture check_daemon_status setup starts --------------------
04:12:27 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the RUNNING state with pid 979 uptime 16
04:12:38 init.fixture_func_decorator L0066 INFO | -------------------- fixture check_daemon_status setup ends --------------------
-------------------------------- live log call ---------------------------------
04:12:39 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the RUNNING state with pid 979 uptime 28
04:12:39 test_psud.test_pmon_psud_kill_and_start L0221 INFO | pmon:psud daemon is RUNNING with pid 979 uptime 28
04:12:46 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the STARTING state with pid -1 uptime None
04:12:46 test_psud.check_expected_daemon_uptime L0088 INFO | pre_uptime 28 uptime 28 condition False
04:12:58 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the RUNNING state with pid 1018 uptime 16
04:12:58 test_psud.check_expected_daemon_uptime L0088 INFO | pre_uptime 28 uptime 16 condition True
04:12:59 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the RUNNING state with pid 1018 uptime 17
04:13:01 test_psud._collect_data L0107 INFO | data_after_restart = {'keys': [u'PSU_INFO|PSU 2', u'PSU_INFO|PSU 1'], 'data': {u'PSU_INFO|PSU 1': {}, u'PSU_INFO|PSU 2': {}}}
04:13:01 test_psud._collect_data L0108 INFO | data_before_restart = {'keys': [u'PSU_INFO|PSU 2', u'PSU_INFO|PSU 1'], 'data': {u'PSU_INFO|PSU 1': {}, u'PSU_INFO|PSU 2': {}}}
PASSED [100%]
------------------------------ live log teardown -------------------------------
04:13:01 init._fixture_generator_decorator L0083 INFO | -------------------- fixture teardown_module teardown starts --------------------
04:13:02 sonic.get_pmon_daemon_status_and_uptime L0727 INFO | Daemon pmon:psud in the RUNNING state with pid 1018 uptime 21
04:13:13 test_psud.teardown_module L0063 INFO | Tearing down: to make sure all the critical services, interfaces and transceivers are good
04:13:13 processes_utils.check_critical_processes L0037 INFO | Check all critical processes are healthy for 10 seconds
04:13:42 init._fixture_generator_decorator L0092 INFO | -------------------- fixture teardown_module teardown ends --------------------
04:13:43 init.do_cfg_DB_checks L0061 INFO | golden config_db.json md5sum=[u'1d8386ee5e51a3bc16c0f0b4aa5c768b']
04:13:43 init.do_cfg_DB_checks L0062 INFO | current config_db.json md5sum=[1d8386ee5e51a3bc16c0f0b4aa5c768b]
04:13:43 init.do_cfg_checks L0082 INFO | validate md5sums:[[u'd6f76db3f154bc123f1a78dd95be3a58']]
04:13:43 init.do_cfg_checks L0087 INFO | current md5sum=[d6f76db3f154bc123f1a78dd95be3a58]-OK!!
04:13:43 init.cfg_sanity_check L0317 INFO | Done CFG sanity checks@Post-test in 1s.

=============================== warnings summary ===============================
/var/ubuntu/.local/lib/python2.7/site-packages/_pytest/config/init.py:545
/var/ubuntu/.local/lib/python2.7/site-packages/_pytest/config/init.py:545: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
---------------------------- live log sessionfinish ----------------------------
04:13:44 init.pytest_terminal_summary L0064 INFO | Can not get Allure report URL. Please check logs
==================== 4 passed, 1 warnings in 190.07 seconds ====================
