### PR TITLE
[warm/fast-reboot] Retain TRANSCEIVER_INFO/STATUS tables on deinit

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2375,7 +2375,26 @@ class TestXcvrdScript(object):
             mock_run.return_value = "true"
 
             xcvrd.init()
+
+            status_tbl = MagicMock()
+            xcvrd.xcvr_table_helper.get_status_tbl = MagicMock(return_value=status_tbl)
+
             xcvrd.deinit()
+
+            status_tbl.hdel.assert_not_called()
+
+    @patch('xcvrd.xcvrd.DaemonXcvrd.load_platform_util', MagicMock())
+    @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', None)))
+    @patch('swsscommon.swsscommon.WarmStart', MagicMock())
+    @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
+    @patch('subprocess.check_output', MagicMock(return_value='false'))
+    def test_DaemonXcvrd_init_deinit_cold(self):
+        xcvrd.platform_chassis = MagicMock()
+
+        xcvrdaemon = DaemonXcvrd(SYSLOG_IDENTIFIER)
+        xcvrdaemon.init()
+        xcvrdaemon.deinit()
+
 
 def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
     wait_time = 0

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2365,7 +2365,13 @@ class TestXcvrdScript(object):
         media_str = get_media_val_str(num_logical_ports, lane_dict, logical_idx)
         assert media_str == '3,4'
 
+    class MockPortMapping:
+        logical_port_list = [0, 1, 2]
+        logical_port_name_to_physical_port_list = MagicMock()
+        get_asic_id_for_logical_port = MagicMock()
+
     @patch('xcvrd.xcvrd.DaemonXcvrd.load_platform_util', MagicMock())
+    @patch('xcvrd.xcvrd_utilities.port_event_helper.get_port_mapping', MagicMock(return_value=MockPortMapping))
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', None)))
     @patch('swsscommon.swsscommon.WarmStart', MagicMock())
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
@@ -2378,22 +2384,41 @@ class TestXcvrdScript(object):
 
             status_tbl = MagicMock()
             xcvrd.xcvr_table_helper.get_status_tbl = MagicMock(return_value=status_tbl)
+            xcvrd.xcvr_table_helper.get_dom_tbl = MagicMock(return_value=MagicMock)
+            xcvrd.xcvr_table_helper.get_dom_threshold_tbl = MagicMock(return_value=MagicMock)
+            xcvrd.xcvr_table_helper.get_pm_tbl = MagicMock(return_value=MagicMock)
+            xcvrd.xcvr_table_helper.get_firmware_info_tbl = MagicMock(return_value=MagicMock)
 
             xcvrd.deinit()
 
             status_tbl.hdel.assert_not_called()
 
     @patch('xcvrd.xcvrd.DaemonXcvrd.load_platform_util', MagicMock())
+    @patch('xcvrd.xcvrd_utilities.port_event_helper.get_port_mapping', MagicMock(return_value=MockPortMapping))
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', None)))
-    @patch('swsscommon.swsscommon.WarmStart', MagicMock())
+    @patch('xcvrd.xcvrd.is_warm_reboot_enabled', MagicMock(return_value=False))
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
     @patch('subprocess.check_output', MagicMock(return_value='false'))
     def test_DaemonXcvrd_init_deinit_cold(self):
         xcvrd.platform_chassis = MagicMock()
 
         xcvrdaemon = DaemonXcvrd(SYSLOG_IDENTIFIER)
-        xcvrdaemon.init()
-        xcvrdaemon.deinit()
+        with patch("subprocess.check_output") as mock_run:
+            mock_run.return_value = "false"
+
+            xcvrdaemon.init()
+
+            status_tbl = MagicMock()
+            xcvrdaemon.xcvr_table_helper.get_status_tbl = MagicMock(return_value=status_tbl)
+            xcvrdaemon.xcvr_table_helper.get_dom_tbl = MagicMock(return_value=MagicMock)
+            xcvrdaemon.xcvr_table_helper.get_dom_threshold_tbl = MagicMock(return_value=MagicMock)
+            xcvrdaemon.xcvr_table_helper.get_pm_tbl = MagicMock(return_value=MagicMock)
+            xcvrdaemon.xcvr_table_helper.get_firmware_info_tbl = MagicMock(return_value=MagicMock)
+            xcvrdaemon.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=MagicMock)
+
+            xcvrdaemon.deinit()
+
+            status_tbl.hdel.assert_called()
 
 
 def wait_until(total_wait_time, interval, call_back, *args, **kwargs):

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -752,6 +752,14 @@ def is_fast_reboot_enabled():
     fastboot_enabled = subprocess.check_output('sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable', shell=True, universal_newlines=True)
     return "true" in fastboot_enabled
 
+
+def is_warm_reboot_enabled():
+    warmstart = swsscommon.WarmStart()
+    warmstart.initialize("xcvrd", "pmon")
+    warmstart.checkWarmStart("xcvrd", "pmon", False)
+    is_warm_start = warmstart.isWarmStart()
+    return is_warm_start
+
 #
 # Helper classes ===============================================================
 #
@@ -1784,11 +1792,7 @@ class SfpStateUpdateTask(threading.Thread):
         transceiver_dict = {}
         retry_eeprom_set = set()
 
-        warmstart = swsscommon.WarmStart()
-        warmstart.initialize("xcvrd", "pmon")
-        warmstart.checkWarmStart("xcvrd", "pmon", False)
-        is_warm_start = warmstart.isWarmStart()
-
+        is_warm_start = is_warm_reboot_enabled()
         # Post all the current interface sfp/dom threshold info to STATE_DB
         logical_port_list = port_mapping.logical_port_list
         for logical_port_name in logical_port_list:
@@ -2372,6 +2376,8 @@ class DaemonXcvrd(daemon_base.DaemonBase):
     def deinit(self):
         self.log_info("Start daemon deinit...")
 
+        is_warm_fast_reboot = is_warm_reboot_enabled() or is_fast_reboot_enabled()
+
         # Delete all the information from DB and then exit
         port_mapping_data = port_event_helper.get_port_mapping(self.namespaces)
         logical_port_list = port_mapping_data.logical_port_list
@@ -2382,15 +2388,18 @@ class DaemonXcvrd(daemon_base.DaemonBase):
                 helper_logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
                 continue
 
+            intf_tbl = self.xcvr_table_helper.get_intf_tbl(asic_index) if not is_warm_fast_reboot else None
+
             del_port_sfp_dom_info_from_db(logical_port_name, port_mapping_data,
-                                          self.xcvr_table_helper.get_intf_tbl(asic_index),
+                                          intf_tbl,
                                           self.xcvr_table_helper.get_dom_tbl(asic_index),
                                           self.xcvr_table_helper.get_dom_threshold_tbl(asic_index),
                                           self.xcvr_table_helper.get_pm_tbl(asic_index),
                                           self.xcvr_table_helper.get_firmware_info_tbl(asic_index))
-            delete_port_from_status_table_sw(logical_port_name, self.xcvr_table_helper.get_status_tbl(asic_index))
-            delete_port_from_status_table_hw(logical_port_name, port_mapping_data, self.xcvr_table_helper.get_status_tbl(asic_index))
 
+            if not is_warm_fast_reboot:
+                delete_port_from_status_table_sw(logical_port_name, self.xcvr_table_helper.get_status_tbl(asic_index))
+                delete_port_from_status_table_hw(logical_port_name, port_mapping_data, self.xcvr_table_helper.get_status_tbl(asic_index))
 
         del globals()['platform_chassis']
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Save TRANSCEIVER_INFO/STATUS tables on warm/fast-reboot.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

The information in TRANSCEIVER_INFO tables is required for orchagent to set SAI_PORT_ATTR_HOST_TX_SIGNAL_ENABLE=true on system startup, otherwise after APPLY_VIEW port becomes down until pmon populates TRANSCEIEVER_INFO table.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Run fast/warm-reboot.

#### Additional Information (Optional)
