### PR TITLE
[Xcvrd] Skip to get dom/threshold/pm for flat memory

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2475,6 +2475,20 @@ class TestXcvrdScript(object):
         mock_chassis.get_sfp = MagicMock(side_effect=NotImplementedError)
         assert not _wrapper_get_sfp_error_description(1)
 
+    @patch('xcvrd.xcvrd.platform_chassis')
+    def test_wrapper_is_flat_memory(self, mock_chassis):
+        mock_api = MagicMock()
+        mock_api.is_flat_memory = MagicMock(return_value=True)
+        mock_object = MagicMock()
+        mock_object.get_xcvr_api = MagicMock(return_value=mock_api)
+        mock_chassis.get_sfp = MagicMock(return_value=mock_object)
+
+        from xcvrd.xcvrd import _wrapper_is_flat_memory
+        assert _wrapper_is_flat_memory(1) == True
+
+        mock_chassis.get_sfp = MagicMock(side_effect=NotImplementedError)
+        assert not _wrapper_is_flat_memory(1)
+
     def test_check_port_in_range(self):
         range_str = '1 - 32'
         physical_port = 1

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -308,6 +308,15 @@ def _wrapper_get_transceiver_pm(physical_port):
             pass
     return {}
 
+def _wrapper_is_flat_memory(physical_port):
+    if platform_chassis is not None:
+        try:
+            sfp = platform_chassis.get_sfp(physical_port)
+            api = sfp.get_xcvr_api()
+            return api.is_flat_memory()
+        except NotImplementedError:
+            pass
+    return None
 
 # Soak SFP insert event until management init completes
 def _wrapper_soak_sfp_insert_event(sfp_insert_events, port_dict):
@@ -584,6 +593,9 @@ def post_port_dom_threshold_info_to_db(logical_port_name, port_mapping, table,
         if not _wrapper_get_presence(physical_port):
             continue
 
+        if _wrapper_is_flat_memory(physical_port) == True:
+            continue
+
         port_name = get_physical_port_name(logical_port_name,
                                            ganged_member_num, ganged_port)
         ganged_member_num += 1
@@ -619,6 +631,9 @@ def post_port_dom_info_to_db(logical_port_name, port_mapping, table, stop_event=
         if not _wrapper_get_presence(physical_port):
             continue
 
+        if _wrapper_is_flat_memory(physical_port) == True:
+            continue
+
         try:
             if dom_info_cache is not None and physical_port in dom_info_cache:
                 # If cache is enabled and dom information is in cache, just read from cache, no need read from EEPROM
@@ -648,6 +663,9 @@ def post_port_pm_info_to_db(logical_port_name, port_mapping, table, stop_event=t
             break
 
         if not _wrapper_get_presence(physical_port):
+            continue
+
+        if _wrapper_is_flat_memory(physical_port) == True:
             continue
 
         if pm_info_cache is not None and physical_port in pm_info_cache:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Fix https://github.com/sonic-net/sonic-buildimage/issues/18468
xcvrd crashes due to PR https://github.com/sonic-net/sonic-platform-common/pull/397.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Insert CMIS DAC cable 

```
root@sonic:/tmp# show interfaces transceiver eeprom Ethernet256 -d
Ethernet256: SFP EEPROM detected
        Active Firmware: N/A
        Active application selected code assigned to host lane 1: N/A
        Active application selected code assigned to host lane 2: N/A
        Active application selected code assigned to host lane 3: N/A
        Active application selected code assigned to host lane 4: N/A
        Active application selected code assigned to host lane 5: N/A
        Active application selected code assigned to host lane 6: N/A
        Active application selected code assigned to host lane 7: N/A
        Active application selected code assigned to host lane 8: N/A
        Application Advertisement: 1 - 400G CR8 - Host Assign (0x1) - Copper cable - Media Assign (Unknown)
                                   2 - 200GBASE-CR4 (Clause 136) - Host Assign (0x11) - Copper cable - Media Assign (Unknown)
                                   3 - 100GBASE-CR2 (Clause 136) - Host Assign (0x55) - Copper cable - Media Assign (Unknown)
                                   4 - 50GBASE-CR (Clause 126) - Host Assign (0xff) - Copper cable - Media Assign (Unknown)
                                   5 - 25GBASE-CR CA-L (Clause 110) - Host Assign (0xff) - Copper cable - Media Assign (Unknown)
                                   6 - 100GBASE-CR4 (Clause 92) - Host Assign (Unknown) - Undefined - Media Assign (Unknown)
                                   7 - Undefined - Host Assign (0x11) - Copper cable - Media Assign (Unknown)
        CMIS Rev: 3.0
        Connector: No separable connector
        Encoding: N/A
        Extended Identifier: Power Class 1 (0.25W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: 8
        Identifier: *QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware: N/A
        Length Cable Assembly(m): 1.0
        Media Interface Technology: Copper cable unequalized
        Media Lane Count: 0
        Module Hardware Rev: 0.0
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: passive_copper_media_interface
        Supported Max Laser Frequency: N/A
        Supported Max TX Power: N/A
        Supported Min Laser Frequency: N/A
        Supported Min TX Power: N/A
        Vendor Date Code(YYYY-MM-DD Lot): 2023-02-08
        Vendor Name: Edgecore
        Vendor OUI: 3c-2c-99
        Vendor PN: ET7502-DAC-1M
        Vendor Rev: X1
        Vendor SN: M52306100015
        ChannelMonitorValues:
        ChannelThresholdValues:
        ModuleMonitorValues:
        ModuleThresholdValues:
root@sonic:/tmp# sfputil show eeprom -d -p Ethernet256
Ethernet256: SFP EEPROM detected
        Active App Selection Host Lane 1: N/A
        Active App Selection Host Lane 2: N/A
        Active App Selection Host Lane 3: N/A
        Active App Selection Host Lane 4: N/A
        Active App Selection Host Lane 5: N/A
        Active App Selection Host Lane 6: N/A
        Active App Selection Host Lane 7: N/A
        Active App Selection Host Lane 8: N/A
        Active Firmware Version: N/A
        Application Advertisement: 1 - 400G CR8 - Host Assign (0x1) - Copper cable - Media Assign (Unknown)
                                   2 - 200GBASE-CR4 (Clause 136) - Host Assign (0x11) - Copper cable - Media Assign (Unknown)
                                   3 - 100GBASE-CR2 (Clause 136) - Host Assign (0x55) - Copper cable - Media Assign (Unknown)
                                   4 - 50GBASE-CR (Clause 126) - Host Assign (0xff) - Copper cable - Media Assign (Unknown)
                                   5 - 25GBASE-CR CA-L (Clause 110) - Host Assign (0xff) - Copper cable - Media Assign (Unknown)
                                   6 - 100GBASE-CR4 (Clause 92) - Host Assign (Unknown) - Undefined - Media Assign (Unknown)
                                   7 - Undefined - Host Assign (0x11) - Copper cable - Media Assign (Unknown)
        CMIS Revision: 3.0
        Connector: No separable connector
        Encoding: N/A
        Extended Identifier: Power Class 1 (0.25W Max)
        Extended RateSelect Compliance: N/A
        Hardware Revision: 0.0
        Host Electrical Interface: N/A
        Host Lane Assignment Options: 1
        Host Lane Count: 8
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware Version: N/A
        Length Cable Assembly(m): 1.0
        Media Interface Code: Copper cable
        Media Interface Technology: Copper cable unequalized
        Media Lane Assignment Options: N/A
        Media Lane Count: 0
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: passive_copper_media_interface
        Vendor Date Code(YYYY-MM-DD Lot): 2023-02-08
        Vendor Name: Edgecore
        Vendor OUI: 3c-2c-99
        Vendor PN: ET7502-DAC-1M
        Vendor Rev: X1
        Vendor SN: M52306100015
        ChannelMonitorValues:
        ChannelThresholdValues:
        ModuleMonitorValues:
        ModuleThresholdValues:
```

QSFP DAC cable
```
root@sonic:/tmp# show interfaces transceiver eeprom -d Ethernet304
Ethernet304: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Power Class 1 Module (1.5W max.), No CLEI code present in Page 02h, No CDR in TX, No CDR in RX
        Extended RateSelect Compliance: Unknown: 0
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 1.0
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-CR4
                Extended Specification Compliance: 100GBASE-CR4, 25GBASE-CR CA-25G-L or 50GBASE-CR2 with RS
                Fibre Channel Link Length: Unknown: 0
                Fibre Channel Speed: Unknown: 0
                Fibre Channel Transmission Media: Twin Axial Pair (TW)
                Fibre Channel Transmitter Technology: Unknown: 0
                Gigabit Ethernet Compliant Codes: Unknown: 0
                SAS/SATA Compliance Codes: Unknown: 0
                SONET Compliance Codes: Unknown: 0
        Vendor Date Code(YYYY-MM-DD Lot): 2021-06-30
        Vendor Name: Edgecore
        Vendor OUI: 00-00-00
        Vendor PN: ET7402-DAC-0.5M
        Vendor Rev: X1
        Vendor SN: M52127100004
        ChannelMonitorValues:
        ChannelThresholdValues:
        ModuleMonitorValues:
        ModuleThresholdValues:
root@sonic:/tmp# sfputil show eeprom -d -p Ethernet304
Ethernet304: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Power Class 1 Module (1.5W max.), No CLEI code present in Page 02h, No CDR in TX, No CDR in RX
        Extended RateSelect Compliance: Unknown: 0
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 1.0
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-CR4
                Extended Specification Compliance: 100GBASE-CR4, 25GBASE-CR CA-25G-L or 50GBASE-CR2 with RS
                Fibre Channel Link Length: Unknown: 0
                Fibre Channel Speed: Unknown: 0
                Fibre Channel Transmission Media: Twin Axial Pair (TW)
                Fibre Channel Transmitter Technology: Unknown: 0
                Gigabit Ethernet Compliant Codes: Unknown: 0
                SAS/SATA Compliance Codes: Unknown: 0
                SONET Compliance Codes: Unknown: 0
        Vendor Date Code(YYYY-MM-DD Lot): 2021-06-30
        Vendor Name: Edgecore
        Vendor OUI: 00-00-00
        Vendor PN: ET7402-DAC-0.5M
        Vendor Rev: X1
        Vendor SN: M52127100004
        ChannelMonitorValues:
                TX1Bias: 0.0mA
                TX2Bias: 0.0mA
                TX3Bias: 0.0mA
                TX4Bias: 0.0mA
        ChannelThresholdValues:
        ModuleMonitorValues:
        ModuleThresholdValues:
```
QSFP AOC
```
root@sonic:/tmp# show interfaces transceiver eeprom Ethernet0 -d
Ethernet0: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: 256B/257B (transcoded FEC-enabled data)
        Extended Identifier: Power Class 3 Module (2.5W max.), No CLEI code present in Page 02h, CDR present in TX, CDR present in RX
        Extended RateSelect Compliance: Unknown: 0
        Identifier: *QSFP28 or later
        Length Cable Assembly(m): 1.0
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
                10/40G Ethernet Compliance Code: Extended
                Extended Specification Compliance: 100G AOC (Active Optical Cable) or 25GAUI C2M AOC
                Fibre Channel Link Length: Unknown: 0
                Fibre Channel Speed: Unknown: 0
                Fibre Channel Transmission Media: Unknown: 0
                Fibre Channel Transmitter Technology: Unknown: 0
                Gigabit Ethernet Compliant Codes: Unknown: 0
                SAS/SATA Compliance Codes: Unknown: 0
                SONET Compliance Codes: Unknown: 0
        Vendor Date Code(YYYY-MM-DD Lot): 2023-02-20
        Vendor Name: Edgecore
        Vendor OUI: 3c-2c-99
        Vendor PN: ET7402-AOC-1M
        Vendor Rev: 10
        Vendor SN: L12307000146
        ChannelMonitorValues:
                RX1Power: -0.8407278830288423dBm
                RX2Power: -0.41914151478914874dBm
                RX3Power: -0.6499684854634524dBm
                RX4Power: -0.6248210798265337dBm
                TX1Bias: 7.1mA
                TX1Power: -0.7211658966929311dBm
                TX2Bias: 7.1mA
                TX2Power: -0.4383156952463668dBm
                TX3Bias: 7.1mA
                TX3Power: -0.4383156952463668dBm
                TX4Bias: 7.1mA
                TX4Power: -0.2502800570193105dBm
        ChannelThresholdValues:
                RxPowerHighAlarm  : 3.4dBm
                RxPowerHighWarning: 2.4dBm
                RxPowerLowAlarm   : -11.002dBm
                RxPowerLowWarning : -10.6dBm
                TxBiasHighAlarm   : 14.0mA
                TxBiasHighWarning : 13.0mA
                TxBiasLowAlarm    : 2.0mA
                TxBiasLowWarning  : 3.0mA
                TxPowerHighAlarm  : 3.4dBm
                TxPowerHighWarning: 2.4dBm
                TxPowerLowAlarm   : -9.401dBm
                TxPowerLowWarning : -8.401dBm
        ModuleMonitorValues:
                Temperature: 30.801C
                Vcc: 3.298Volts
        ModuleThresholdValues:
                TempHighAlarm  : 80.0C
                TempHighWarning: 75.0C
                TempLowAlarm   : -10.0C
                TempLowWarning : 0.0C
                VccHighAlarm   : 3.6Volts
                VccHighWarning : 3.5Volts
                VccLowAlarm    : 2.9Volts
                VccLowWarning  : 3.0Volts
root@sonic:/tmp# sfputil show eeprom -d -p Ethernet0
Ethernet0: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: 256B/257B (transcoded FEC-enabled data)
        Extended Identifier: Power Class 3 Module (2.5W max.), No CLEI code present in Page 02h, CDR present in TX, CDR present in RX
        Extended RateSelect Compliance: Unknown: 0
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 1.0
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
                10/40G Ethernet Compliance Code: Extended
                Extended Specification Compliance: 100G AOC (Active Optical Cable) or 25GAUI C2M AOC
                Fibre Channel Link Length: Unknown: 0
                Fibre Channel Speed: Unknown: 0
                Fibre Channel Transmission Media: Unknown: 0
                Fibre Channel Transmitter Technology: Unknown: 0
                Gigabit Ethernet Compliant Codes: Unknown: 0
                SAS/SATA Compliance Codes: Unknown: 0
                SONET Compliance Codes: Unknown: 0
        Vendor Date Code(YYYY-MM-DD Lot): 2023-02-20
        Vendor Name: Edgecore
        Vendor OUI: 3c-2c-99
        Vendor PN: ET7402-AOC-1M
        Vendor Rev: 10
        Vendor SN: L12307000146
        ChannelMonitorValues:
                RX1Power: -0.8512818245994963dBm
                RX2Power: -0.41914151478914874dBm
                RX3Power: -0.644927341752872dBm
                RX4Power: -0.6348625752110671dBm
                TX1Bias: 7.1mA
                TX1Power: -0.400051616715838dBm
                TX2Bias: 7.1mA
                TX2Power: -0.4383156952463668dBm
                TX3Bias: 7.1mA
                TX3Power: -0.4383156952463668dBm
                TX4Bias: 7.1mA
                TX4Power: -0.2502800570193105dBm
        ChannelThresholdValues:
                RxPowerHighAlarm  : 3.4dBm
                RxPowerHighWarning: 2.4dBm
                RxPowerLowAlarm   : -11.002dBm
                RxPowerLowWarning : -10.6dBm
                TxBiasHighAlarm   : 14.0mA
                TxBiasHighWarning : 13.0mA
                TxBiasLowAlarm    : 2.0mA
                TxBiasLowWarning  : 3.0mA
                TxPowerHighAlarm  : 3.4dBm
                TxPowerHighWarning: 2.4dBm
                TxPowerLowAlarm   : -9.401dBm
                TxPowerLowWarning : -8.401dBm
        ModuleMonitorValues:
                Temperature: 30.938C
                Vcc: 3.296Volts
        ModuleThresholdValues:
                TempHighAlarm  : 80.0C
                TempHighWarning: 75.0C
                TempLowAlarm   : -10.0C
                TempLowWarning : 0.0C
                VccHighAlarm   : 3.6Volts
                VccHighWarning : 3.5Volts
                VccLowAlarm    : 2.9Volts
                VccLowWarning  : 3.0Volts
```
CMIS ZR
```
root@sonic:/tmp# show interfaces transceiver eeprom -d Ethernet368
Ethernet368: SFP EEPROM detected
        Active Firmware: 61.23.32
        Active application selected code assigned to host lane 1: 1
        Active application selected code assigned to host lane 2: 1
        Active application selected code assigned to host lane 3: 1
        Active application selected code assigned to host lane 4: 1
        Active application selected code assigned to host lane 5: 1
        Active application selected code assigned to host lane 6: 1
        Active application selected code assigned to host lane 7: 1
        Active application selected code assigned to host lane 8: 1
        Application Advertisement: 1 - 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, DWDM, amplified - Media Assign (0x1)
                                   2 - 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, Single Wavelength, Unamplified - Media Assign (0x1)
                                   3 - 100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - Media Assign (0x1)
                                   4 - 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - Vendor specific: 197 - Media Assign (0x1)
                                   5 - 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - Vendor specific: 192 - Media Assign (0x1)
                                   6 - 100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - Vendor specific: 192 - Media Assign (0x1)
                                   7 - 100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - Vendor specific: 193 - Media Assign (0x1)
                                   8 - 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - Vendor specific: 206 - Media Assign (0x1)
                                   9 - 100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - Vendor specific: 206 - Media Assign (0x1)
                                   10 - 100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - Vendor specific: 207 - Media Assign (0x1)
                                   11 - 100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - Vendor specific: 194 - Media Assign (0x1)
                                   12 - CAUI-4 C2M (Annex 83E) without FEC - Host Assign (0x11) - Vendor specific: 194 - Media Assign (0x1)
                                   13 - 100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - Vendor specific: 196 - Media Assign (0x1)
                                   14 - CAUI-4 C2M (Annex 83E) without FEC - Host Assign (0x11) - Vendor specific: 196 - Media Assign (0x1)
        CMIS Rev: 4.1
        Connector: LC
        Encoding: N/A
        Extended Identifier: Power Class 8 (23.75W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: 8
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware: 61.23.32
        Length Cable Assembly(m): 0.0
        Media Interface Technology: 850 nm VCSEL
        Media Lane Count: 1
        Module Hardware Rev: 49.50
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: sm_media_interface
        Supported Max Laser Frequency: 196100
        Supported Max TX Power: 4.0
        Supported Min Laser Frequency: 191300
        Supported Min TX Power: -22.9
        Vendor Date Code(YYYY-MM-DD Lot): 2022-09-23
        Vendor Name: Acacia Comm Inc.
        Vendor OUI: 7c-b2-5c
        Vendor PN: DP04QSDD-E30-001
        Vendor Rev: A
        Vendor SN: ACA263900SW
        ChannelMonitorValues:
                RX1Power: -40.0dBm
                RX2Power: -infdBm
                RX3Power: -infdBm
                RX4Power: -infdBm
                RX5Power: -infdBm
                RX6Power: -infdBm
                RX7Power: -infdBm
                RX8Power: -infdBm
                TX1Bias: 239.696mA
                TX1Power: -40.0dBm
                TX2Bias: 0.0mA
                TX2Power: -infdBm
                TX3Bias: 0.0mA
                TX3Power: -infdBm
                TX4Bias: 0.0mA
                TX4Power: -infdBm
                TX5Bias: 0.0mA
                TX5Power: -infdBm
                TX6Bias: 0.0mA
                TX6Power: -infdBm
                TX7Bias: 0.0mA
                TX7Power: -infdBm
                TX8Bias: 0.0mA
                TX8Power: -infdBm
        ChannelThresholdValues:
                RxPowerHighAlarm  : 2.0dBm
                RxPowerHighWarning: 0.0dBm
                RxPowerLowAlarm   : -28.239dBm
                RxPowerLowWarning : -23.01dBm
                TxBiasHighAlarm   : 0.0mA
                TxBiasHighWarning : 0.0mA
                TxBiasLowAlarm    : 0.0mA
                TxBiasLowWarning  : 0.0mA
                TxPowerHighAlarm  : 0.0dBm
                TxPowerHighWarning: -2.0dBm
                TxPowerLowAlarm   : -18.013dBm
                TxPowerLowWarning : -16.003dBm
        ModuleMonitorValues:
                Temperature: 42.0C
                Vcc: 3.289Volts
        ModuleThresholdValues:
                TempHighAlarm  : 80.0C
                TempHighWarning: 75.0C
                TempLowAlarm   : -5.0C
                TempLowWarning : 15.0C
                VccHighAlarm   : 3.465Volts
                VccHighWarning : 3.432Volts
                VccLowAlarm    : 3.135Volts
                VccLowWarning  : 3.168Volts
root@sonic:/tmp# sfputil show eeprom -d -p Ethernet368
Ethernet368: SFP EEPROM detected
        Active App Selection Host Lane 1: 1
        Active App Selection Host Lane 2: 1
        Active App Selection Host Lane 3: 1
        Active App Selection Host Lane 4: 1
        Active App Selection Host Lane 5: 1
        Active App Selection Host Lane 6: 1
        Active App Selection Host Lane 7: 1
        Active App Selection Host Lane 8: 1
        Active Firmware Version: 61.23.32
        Application Advertisement: 1 - 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, DWDM, amplified - Media Assign (0x1)
                                   2 - 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, Single Wavelength, Unamplified - Media Assign (0x1)
                                   3 - 100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - Media Assign (0x1)
                                   4 - 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - Vendor specific: 197 - Media Assign (0x1)
                                   5 - 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - Vendor specific: 192 - Media Assign (0x1)
                                   6 - 100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - Vendor specific: 192 - Media Assign (0x1)
                                   7 - 100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - Vendor specific: 193 - Media Assign (0x1)
                                   8 - 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - Vendor specific: 206 - Media Assign (0x1)
                                   9 - 100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - Vendor specific: 206 - Media Assign (0x1)
                                   10 - 100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - Vendor specific: 207 - Media Assign (0x1)
                                   11 - 100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - Vendor specific: 194 - Media Assign (0x1)
                                   12 - CAUI-4 C2M (Annex 83E) without FEC - Host Assign (0x11) - Vendor specific: 194 - Media Assign (0x1)
                                   13 - 100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - Vendor specific: 196 - Media Assign (0x1)
                                   14 - CAUI-4 C2M (Annex 83E) without FEC - Host Assign (0x11) - Vendor specific: 196 - Media Assign (0x1)
        CMIS Revision: 4.1
        Connector: LC
        Encoding: N/A
        Extended Identifier: Power Class 8 (23.75W Max)
        Extended RateSelect Compliance: N/A
        Hardware Revision: 49.50
        Host Electrical Interface: 400GAUI-8 C2M (Annex 120E)
        Host Lane Assignment Options: 1
        Host Lane Count: 8
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware Version: 61.23.32
        Length Cable Assembly(m): 0.0
        Media Interface Code: 400ZR, DWDM, amplified
        Media Interface Technology: 850 nm VCSEL
        Media Lane Assignment Options: 1
        Media Lane Count: 1
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: sm_media_interface
        Supported Max Laser Frequency: 196100GHz
        Supported Max TX Power: 4.0dBm
        Supported Min Laser Frequency: 191300GHz
        Supported Min TX Power: -22.9dBm
        Vendor Date Code(YYYY-MM-DD Lot): 2022-09-23
        Vendor Name: Acacia Comm Inc.
        Vendor OUI: 7c-b2-5c
        Vendor PN: DP04QSDD-E30-001
        Vendor Rev: A
        Vendor SN: ACA263900SW
        ChannelMonitorValues:
                RX1Power: -40.0dBm
                RX2Power: -infdBm
                RX3Power: -infdBm
                RX4Power: -infdBm
                RX5Power: -infdBm
                RX6Power: -infdBm
                RX7Power: -infdBm
                RX8Power: -infdBm
                TX1Bias: 0.0mA
                TX1Power: -40.0dBm
                TX2Bias: 0.0mA
                TX2Power: -infdBm
                TX3Bias: 0.0mA
                TX3Power: -infdBm
                TX4Bias: 0.0mA
                TX4Power: -infdBm
                TX5Bias: 0.0mA
                TX5Power: -infdBm
                TX6Bias: 0.0mA
                TX6Power: -infdBm
                TX7Bias: 0.0mA
                TX7Power: -infdBm
                TX8Bias: 0.0mA
                TX8Power: -infdBm
        ChannelThresholdValues:
                RxPowerHighAlarm  : 2.0dBm
                RxPowerHighWarning: 0.0dBm
                RxPowerLowAlarm   : -28.239dBm
                RxPowerLowWarning : -23.01dBm
                TxBiasHighAlarm   : 0.0mA
                TxBiasHighWarning : 0.0mA
                TxBiasLowAlarm    : 0.0mA
                TxBiasLowWarning  : 0.0mA
                TxPowerHighAlarm  : 0.0dBm
                TxPowerHighWarning: -2.0dBm
                TxPowerLowAlarm   : -18.013dBm
                TxPowerLowWarning : -16.003dBm
        ModuleMonitorValues:
                Temperature: 41.0C
                Vcc: 3.314Volts
        ModuleThresholdValues:
                TempHighAlarm  : 80.0C
                TempHighWarning: 75.0C
                TempLowAlarm   : -5.0C
                TempLowWarning : 15.0C
                VccHighAlarm   : 3.465Volts
                VccHighWarning : 3.432Volts
                VccLowAlarm    : 3.135Volts
                VccLowWarning  : 3.168Volts
```

#### Additional Information (Optional)
