### PR TITLE
CMIS 'ConfigSuccess" failure while changing default ApSel code for 800G DR8/FR8 modules

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1771,7 +1771,7 @@ class TestXcvrdScript(object):
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_DP_DEINIT
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
-        assert mock_xcvr_api.set_datapath_deinit.call_count == 1
+        assert mock_xcvr_api.set_datapath_deinit.call_count == 2
         assert mock_xcvr_api.tx_disable_channel.call_count == 1
         assert mock_xcvr_api.set_lpmode.call_count == 1
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_AP_CONF
@@ -1779,7 +1779,7 @@ class TestXcvrdScript(object):
         # Case 2: DP_DEINIT --> AP Configured
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
-        assert mock_xcvr_api.set_application.call_count == 1
+        assert mock_xcvr_api.set_application.call_count == 2
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_DP_INIT
 
         # Case 3: AP Configured --> DP_INIT

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1888,7 +1888,7 @@ class TestXcvrdScript(object):
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_DP_DEINIT
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
-        assert mock_xcvr_api.set_datapath_deinit.call_count == 2
+        assert mock_xcvr_api.set_datapath_deinit.call_count == 1
         assert mock_xcvr_api.tx_disable_channel.call_count == 1
         assert mock_xcvr_api.set_lpmode.call_count == 1
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_AP_CONF
@@ -1896,7 +1896,7 @@ class TestXcvrdScript(object):
         # Case 2: DP_DEINIT --> AP Configured
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
-        assert mock_xcvr_api.set_application.call_count == 2
+        assert mock_xcvr_api.set_application.call_count == 1
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_DP_INIT
 
         # Case 3: AP Configured --> DP_INIT

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1400,6 +1400,31 @@ class TestXcvrdScript(object):
         cmis_manager.join()
         assert not cmis_manager.is_alive()
 
+    def test_CmisManagerTask_reset_app_code_and_reinit_all_lanes(self):
+        mock_xcvr_api = MagicMock()
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
+        task.reset_app_code_and_reinit_all_lanes(mock_xcvr_api)
+
+        assert mock_xcvr_api.set_application.call_count == 1
+        assert mock_xcvr_api.set_datapath_deinit.call_count == 1
+        assert mock_xcvr_api.scs_apply_datapath_init.call_count == 1
+
+    @pytest.mark.parametrize("app_new, lane_appl_code", [
+        (2, {0 : 1, 1 : 1, 2 : 1, 3 : 1, 4 : 2, 5 : 2, 6 : 2, 7 : 2}),
+        (0, {0 : 1, 1 : 1, 2 : 1, 3 : 1},)
+     ])
+    def test_CmisManagerTask_is_cmis_app_code_reset_required(self, app_new, lane_appl_code):
+        mock_xcvr_api = MagicMock()
+        def get_application(lane):
+            return lane_appl_code.get(lane, 0)
+        mock_xcvr_api.get_application = MagicMock(side_effect=get_application)
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
+        task.is_cmis_app_code_reset_required(mock_xcvr_api, app_new)
+
     DEFAULT_DP_STATE = {
         'DP1State': 'DataPathActivated',
         'DP2State': 'DataPathActivated',

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1523,17 +1523,6 @@ class TestXcvrdScript(object):
         cmis_manager.join()
         assert not cmis_manager.is_alive()
 
-    def test_CmisManagerTask_decommission_all_datapaths(self):
-        mock_xcvr_api = MagicMock()
-        port_mapping = PortMapping()
-        stop_event = threading.Event()
-        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
-        assert task.decommission_all_datapaths(mock_xcvr_api) == True
-
-        assert mock_xcvr_api.set_application.call_count == 1
-        assert mock_xcvr_api.set_datapath_deinit.call_count == 1
-        assert mock_xcvr_api.scs_apply_datapath_init.call_count == 1
-
     @pytest.mark.parametrize("app_new, lane_appl_code", [
         (2, {0 : 1, 1 : 1, 2 : 1, 3 : 1, 4 : 2, 5 : 2, 6 : 2, 7 : 2}),
         (0, {0 : 1, 1 : 1, 2 : 1, 3 : 1},)
@@ -1548,6 +1537,9 @@ class TestXcvrdScript(object):
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
         mock_xcvr_api.decommission_all_datapaths = MagicMock(return_value=True)
         assert task.is_appl_reconfigure_required(mock_xcvr_api, app_new) == True
+
+        mock_xcvr_api.decommission_all_datapaths = MagicMock(return_value=False)
+        assert task.is_appl_reconfigure_required(mock_xcvr_api, app_new) == False
 
     DEFAULT_DP_STATE = {
         'DP1State': 'DataPathActivated',

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1879,14 +1879,14 @@ class TestXcvrdScript(object):
         task.configure_tx_output_power = MagicMock(return_value=1)
         task.configure_laser_frequency = MagicMock(return_value=1)
 
-        task.is_appl_reconfigure_required = MagicMock(return_value=False)
         # Fail test coverage - Module Inserted state failing to reach DP_DEINIT
+        task.is_appl_reconfigure_required = MagicMock(return_value=False)
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_INSERTED
 
-        task.is_appl_reconfigure_required = MagicMock(return_value=True)
         # Case 1: Module Inserted --> DP_DEINIT
+        task.is_appl_reconfigure_required = MagicMock(return_value=True)
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_DP_DEINIT

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1400,12 +1400,12 @@ class TestXcvrdScript(object):
         cmis_manager.join()
         assert not cmis_manager.is_alive()
 
-    def test_CmisManagerTask_reset_app_code_and_reinit_all_lanes(self):
+    def test_CmisManagerTask_decommission_all_datapaths(self):
         mock_xcvr_api = MagicMock()
         port_mapping = PortMapping()
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
-        task.reset_app_code_and_reinit_all_lanes(mock_xcvr_api)
+        assert task.decommission_all_datapaths(mock_xcvr_api) == True
 
         assert mock_xcvr_api.set_application.call_count == 1
         assert mock_xcvr_api.set_datapath_deinit.call_count == 1
@@ -1415,7 +1415,7 @@ class TestXcvrdScript(object):
         (2, {0 : 1, 1 : 1, 2 : 1, 3 : 1, 4 : 2, 5 : 2, 6 : 2, 7 : 2}),
         (0, {0 : 1, 1 : 1, 2 : 1, 3 : 1},)
      ])
-    def test_CmisManagerTask_is_cmis_app_code_reset_required(self, app_new, lane_appl_code):
+    def test_CmisManagerTask_is_appl_reconfigure_required(self, app_new, lane_appl_code):
         mock_xcvr_api = MagicMock()
         def get_application(lane):
             return lane_appl_code.get(lane, 0)
@@ -1423,7 +1423,8 @@ class TestXcvrdScript(object):
         port_mapping = PortMapping()
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
-        task.is_cmis_app_code_reset_required(mock_xcvr_api, app_new)
+        mock_xcvr_api.decommission_all_datapaths = MagicMock(return_value=True)
+        assert task.is_appl_reconfigure_required(mock_xcvr_api, app_new) == True
 
     DEFAULT_DP_STATE = {
         'DP1State': 'DataPathActivated',

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1523,11 +1523,12 @@ class TestXcvrdScript(object):
         cmis_manager.join()
         assert not cmis_manager.is_alive()
 
-    @pytest.mark.parametrize("app_new, lane_appl_code", [
-        (2, {0 : 1, 1 : 1, 2 : 1, 3 : 1, 4 : 2, 5 : 2, 6 : 2, 7 : 2}),
-        (0, {0 : 1, 1 : 1, 2 : 1, 3 : 1},)
+    @pytest.mark.parametrize("app_new, lane_appl_code, expected", [
+        (2, {0 : 1, 1 : 1, 2 : 1, 3 : 1, 4 : 2, 5 : 2, 6 : 2, 7 : 2}, True),
+        (0, {0 : 1, 1 : 1, 2 : 1, 3 : 1}, True),
+        (1, {0 : 0, 1 : 0, 2 : 0, 3 : 0, 4 : 0, 5 : 0, 6 : 0, 7 : 0}, False)
      ])
-    def test_CmisManagerTask_is_appl_reconfigure_required(self, app_new, lane_appl_code):
+    def test_CmisManagerTask_is_appl_reconfigure_required(self, app_new, lane_appl_code, expected):
         mock_xcvr_api = MagicMock()
         def get_application(lane):
             return lane_appl_code.get(lane, 0)
@@ -1535,8 +1536,7 @@ class TestXcvrdScript(object):
         port_mapping = PortMapping()
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
-        mock_xcvr_api.decommission_all_datapaths = MagicMock(return_value=True)
-        assert task.is_appl_reconfigure_required(mock_xcvr_api, app_new) == True
+        assert task.is_appl_reconfigure_required(mock_xcvr_api, app_new) == expected
 
     DEFAULT_DP_STATE = {
         'DP1State': 'DataPathActivated',
@@ -1879,14 +1879,9 @@ class TestXcvrdScript(object):
         task.configure_tx_output_power = MagicMock(return_value=1)
         task.configure_laser_frequency = MagicMock(return_value=1)
 
-        # Fail test coverage - Module Inserted state failing to reach DP_DEINIT
-        task.is_appl_reconfigure_required = MagicMock(return_value=False)
-        task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
-        task.task_worker()
-        assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_INSERTED
-
         # Case 1: Module Inserted --> DP_DEINIT
         task.is_appl_reconfigure_required = MagicMock(return_value=True)
+        mock_xcvr_api.decommission_all_datapaths = MagicMock(return_value=True)
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_DP_DEINIT
@@ -1921,6 +1916,40 @@ class TestXcvrdScript(object):
         task.task_worker()
         assert task.post_port_active_apsel_to_db.call_count == 1
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_READY
+
+        # Fail test coverage - Module Inserted state failing to reach DP_DEINIT
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
+        task.port_mapping.logical_port_list = ['Ethernet1']
+        task.xcvr_table_helper.get_status_tbl.return_value = mock_get_status_tbl
+        task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
+        task.task_worker()
+        assert get_cmis_state_from_state_db('Ethernei1', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet1'))) == CMIS_STATE_UNKNOWN
+
+        task.port_mapping.logical_port_list = MagicMock()
+        port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
+        task.on_port_update_event(port_change_event)
+        assert task.isPortConfigDone
+
+        port_change_event = PortChangeEvent('Ethernet1', 1, 0, PortChangeEvent.PORT_SET,
+                                            {'speed':'400000', 'lanes':'1,2,3,4,5,6,7,8'})
+        task.on_port_update_event(port_change_event)
+        assert len(task.port_dict) == 1
+        assert get_cmis_state_from_state_db('Ethernet1', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet1'))) == CMIS_STATE_INSERTED
+
+        task.get_host_tx_status = MagicMock(return_value='true')
+        task.get_port_admin_status = MagicMock(return_value='up')
+        task.get_configured_tx_power_from_db = MagicMock(return_value=-13)
+        task.get_configured_laser_freq_from_db = MagicMock(return_value=193100)
+        task.configure_tx_output_power = MagicMock(return_value=1)
+        task.configure_laser_frequency = MagicMock(return_value=1)
+
+        task.is_appl_reconfigure_required = MagicMock(return_value=True)
+        mock_xcvr_api.decommission_all_datapaths = MagicMock(return_value=False)
+        task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
+        task.task_worker()
+        assert get_cmis_state_from_state_db('Ethernet1', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet1'))) == CMIS_STATE_FAILED
 
     @pytest.mark.parametrize("lport, expected_dom_polling", [
         ('Ethernet0', 'disabled'),

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -995,20 +995,7 @@ class CmisManagerTask(threading.Thread):
                             media_lane_assignment_option, media_lane_start_bit, media_lane_count,
                             lport, subport, appl))
 
-        return media_lanes_mask
-
-    def decommission_all_datapaths(self, api):
-        """
-	   Reset and DP init all the lanes
-        """
-        self.log_notice("Changing from default AppSel to non default AppSel code. Decommission all datapaths")
-        lanes = (1 << self.CMIS_MAX_HOST_LANES) - 1
-        api.set_datapath_deinit(lanes)
-        api.set_application(lanes, 0, 0)
-        if not api.scs_apply_datapath_init(lanes):
-            return False
-        return True
-        
+        return media_lanes_mask        
 
     def is_appl_reconfigure_required(self, api, app_new):
         """
@@ -1017,7 +1004,7 @@ class CmisManagerTask(threading.Thread):
         for lane in range(self.CMIS_MAX_HOST_LANES):
             app_cur = api.get_application(lane)
             if app_cur != 0 and app_cur != app_new:
-                return self.decommission_all_datapaths(api)
+                return api.decommission_all_datapaths(api)
         return True
 
     def is_cmis_application_update_required(self, api, app_new, host_lanes_mask):

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -995,7 +995,7 @@ class CmisManagerTask(threading.Thread):
                             media_lane_assignment_option, media_lane_start_bit, media_lane_count,
                             lport, subport, appl))
 
-        return media_lanes_mask        
+        return media_lanes_mask
 
     def is_appl_reconfigure_required(self, api, app_new):
         """


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
CMIS 'ConfigSuccess" failure while changing default ApSel code for 800G DR8/FR8 modules
Issue seen with vendors:
Eoptolink
Finisar
Source-Photonics

Ex: If module supports 800G, 400G and 100G app code and has default app mode as 800G, an issue has arisen with the 2x400G target mode which is hitting ConfigRejectedPartailDataPath error and failing. (same as 8x100 App mode)

#### Motivation and Context
Extract from CMIS spec: - 6.2.4.3 Host Rules and Recommendations
 ```The host can change the width of a Data Path only while in the DPDeactivated state, i.e. the host must always transition an existing Data Path to DPDeactivated before selecting an Application with a different lane count. Any lane that becomes unused must be marked as such (AppSel = 0000b) or it must be assigned to a new valid Data Path (remaining in DPDeactivated state until eventually used) ```

Reset AppSel value for all lanes when setting non default app value

#### How Has This Been Tested?
Tested with different vendors changing different modes:

```
root@sonic:/home/cisco# show logging xcvrd | grep Ethernet160
Apr  5 17:11:02.534867 sonic WARNING pmon#xcvrd[29]: $$$ Ethernet160 handle_port_update_event() : op=SET DB:CONFIG_DB Table:PORT fvp {'admin_status': 'up', 'alias': 'etp20a', 'index': '20', 'lanes': '8,9,10,11', 'mtu': '9100', 'speed': '400000', 'subport': '1'}
Apr  5 17:11:02.537697 sonic WARNING pmon#xcvrd[29]: $$$ Ethernet160 handle_port_update_event() : op=SET DB:STATE_DB Table:PORT_TABLE fvp {'state': 'ok', 'netdev_oper_status': 'down', 'admin_status': 'up', 'mtu': '9100', 'supported_speeds': '40000,100000,200000,400000', 'supported_fecs': 'rs', 'host_tx_ready': 'true'}
Apr  5 17:11:02.538174 sonic WARNING pmon#xcvrd[29]: *** Ethernet160CONFIG_DBPORT handle_port_update_event() fvp {'admin_status': 'up', 'alias': 'etp20a', 'index': '20', 'lanes': '8,9,10,11', 'mtu': '9100', 'speed': '400000', 'subport': '1', 'key': 'Ethernet160', 'asic_id': 0, 'op': 'SET'}
Apr  5 17:11:02.550360 sonic WARNING pmon#xcvrd[29]: *** Ethernet160STATE_DBPORT_TABLE handle_port_update_event() fvp {'host_tx_ready': 'true', 'index': '-1', 'key': 'Ethernet160', 'asic_id': 0, 'op': 'SET'}
Apr  5 17:11:03.280329 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: 400G, lanemask=0x0, state=INSERTED, appl 0 host_lane_count 4 retries=0
Apr  5 17:11:03.341874 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: Setting appl=3
Apr  5 17:11:03.403239 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: Setting host_lanemask=0xf
Apr  5 17:11:03.524128 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: Setting media_lanemask=0xf
Apr  5 17:11:03.531581 sonic NOTICE pmon#xcvrd[29]: CMIS: Changing from default AppSel 1 to non default AppSel code 3. Reset AppSel code for all lanes
Apr  5 17:11:03.556579 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: force Datapath reinit

Apr  5 17:11:10.936253 sonic WARNING pmon#xcvrd[29]: $$$ Ethernet160 handle_port_update_event() : op=SET DB:STATE_DB Table:TRANSCEIVER_INFO fvp {'host_electrical_interface': '800G L C2M (placeholder)', 'active_apsel_hostlane1': '0', 'model': 'EOLD-138HG-02-41', 'hardware_rev': '1.0', 'vendor_rev': '01', 'active_apsel_hostlane5': '0', 'active_apsel_hostlane3': '0', 'host_lane_assignment_option': '1', 'active_apsel_hostlane2': '0', 'ext_identifier': 'Power Class 8 (17.0W Max)', 'media_interface_code': 'Undefined', 'specification_compliance': 'sm_media_interface', 'application_advertisement': "{1: {'host_electrical_interface_id': '800G L C2M (placeholder)', 'module_media_interface_id': 'Undefined', 'media_lane_count': 8, 'host_lane_count': 8, 'host_lane_assignment_options': 1, 'media_lane_assignment_options': 1}, 2: {'host_electrical_interface_id': '800G S C2M (placeholder)', 'module_media_interface_id': 'Undefined', 'media_lane_count': 8, 'host_lane_count': 8, 'host_lane_assignment_options': 1, 'media_lane_assignment_options': 1}, 3: {'host_electrical_interface_id': '400GAUI-4-L C2M (Annex 120G)', 'module_media_interface_id': '400GBASE-DR4 (Cl 124)', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 17, 'media_lane_assignment_options': 17}, 4: {'host_electrical_interface_id': '400GAUI-4-S C2M (Annex 120G)', 'module_media_interface_id': '400GBASE-DR4 (Cl 124)', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 17, 'media_lane_assignment_options': 17}, 5: {'host_electrical_interface_id': '100GAUI-1-L C2M (Annex 120G)', 'module_media_interface_id': '100G-FR/100GBASE-FR1 (Cl 140)', 'media_lane_count': 1, 'host_lane_count': 1, 'host_lane_assignment_options': 255, 'media_lane_assignment_options': 255}, 6: {'host_electrical_interface_id': '100GAUI-1-S C2M (Annex 120G)', 'module_media_interface_id': '100G-FR/100GBASE-FR1 (Cl 140)', 'media_lane_count': 1, 'host_lane_count': 1, 'host_lane_assignment_options': 255, 'media_lane_assignment_options': 255}}", 'vendor_oui': '70-ee-a3', 'active_apsel_hostlane6': '0', 'media_lane_count': '8', 'is_replaceable': 'True', 'cable_type': 'Length Cable Assembly(m)', 'connector': 'MPO 1x12', 'ext_rateselect_compliance': 'N/A', 'active_apsel_hostlane4': '0', 'vendor_date': '2023-02-24   ', 'host_lane_count': '8', 'encoding': 'N/A', 'nominal_bit_rate': '0', 'supported_max_tx_power': 'N/A', 'supported_min_laser_freq': 'N/A', 'active_apsel_hostlane8': '0', 'dom_capability': 'N/A', 'supported_max_laser_freq': 'N/A', 'type': 'QSFP-DD Double Density 8X Pluggable Transceiver', 'manufacturer': 'CISCO-EOPTOLINK ', 'media_interface_technology': '1310 nm EML', 'supported_min_tx_power': 'N/A', 'cmis_rev': '5.0', 'media_lane_assignment_option': '1', 'cable_length': '0.0', 'serial': 'EOP27080006     ', 'active_apsel_hostlane7': '0'}
Apr  5 17:11:10.936760 sonic WARNING pmon#xcvrd[29]: *** Ethernet160STATE_DBTRANSCEIVER_INFO handle_port_update_event() 
Apr  5 17:11:11.212687 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: 400G, lanemask=0xf, state=INSERTED, appl 3 host_lane_count 4 retries=0
Apr  5 17:11:11.274449 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: Setting appl=3
Apr  5 17:11:11.336291 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: Setting host_lanemask=0xf
Apr  5 17:11:11.459386 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: Setting media_lanemask=0xf
Apr  5 17:11:11.473669 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: force Datapath reinit
Apr  5 17:11:33.323121 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: 400G, lanemask=0xf, state=DP_DEINIT, appl 3 host_lane_count 4 retries=0
Apr  5 17:11:34.359393 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: DpDeinit duration 1.0 secs, modulePwrUp duration 10.0 secs
Apr  5 17:11:39.597517 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: 400G, lanemask=0xf, state=AP_CONFIGURED, appl 3 host_lane_count 4 retries=0
Apr  5 17:11:39.635618 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: Apply Optics SI found for Vendor: CISCO-EOPTOLINK   PN: EOLD-138HG-02-41 lane speed: 100G
Apr  5 17:11:50.731261 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: 400G, lanemask=0xf, state=DP_INIT, appl 3 host_lane_count 4 retries=0
Apr  5 17:11:50.746872 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: DpInit duration 10.0 secs
Apr  5 17:11:57.587755 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: 400G, lanemask=0xf, state=DP_TXON, appl 3 host_lane_count 4 retries=0
Apr  5 17:11:57.598835 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: Turning ON tx power
Apr  5 17:12:03.315972 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: 400G, lanemask=0xf, state=DP_ACTIVATION, appl 3 host_lane_count 4 retries=0
Apr  5 17:12:03.319969 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: READY
Apr  5 17:12:03.390218 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: updated TRANSCEIVER_INFO_TABLE [('active_apsel_hostlane1', '3'), ('active_apsel_hostlane2', '3'), ('active_apsel_hostlane3', '3'), ('active_apsel_hostlane4', '3'), ('host_lane_count', '4'), ('media_lane_count', '4')]
Apr  5 17:12:06.651543 sonic WARNING pmon#xcvrd[29]: $$$ Ethernet160 handle_port_update_event() :
Apr  5 17:12:06.651646 sonic WARNING pmon#xcvrd[29]: *** Ethernet160STATE_DBTRANSCEIVER_INFO handle_port_update_event() fvp 
Apr  5 17:12:06.655136 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: 400G, lanemask=0xf, state=INSERTED, appl 3 host_lane_count 4 retries=0
Apr  5 17:12:06.714680 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: Setting appl=3
Apr  5 17:12:06.774654 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: Setting host_lanemask=0xf
Apr  5 17:12:06.895745 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: Setting media_lanemask=0xf
Apr  5 17:12:06.917114 sonic NOTICE pmon#xcvrd[29]: CMIS: Ethernet160: no CMIS application update required...READY
Apr  5 17:12:14.943653 sonic WARNING pmon#xcvrd[29]: $$$ Ethernet160 handle_port_update_event() : op=SET DB:STATE_DB Table:PORT_TABLE fvp {'state': 'ok', 'netdev_oper_status': 'up', 'admin_status': 'up', 'mtu': '9100', 'supported_speeds': '40000,100000,200000,400000', 'supported_fecs': 'rs', 'host_tx_ready': 'true', 'speed': '400000'}
Apr  5 17:12:14.943750 sonic WARNING pmon#xcvrd[29]: $$$ Ethernet160 handle_port_update_event() : op=SET DB:STATE_DB Table:PORT_TABLE fvp {'state': 'ok', 'netdev_oper_status': 'up', 'admin_status': 'up', 'mtu': '9100', 'supported_speeds': '40000,100000,200000,400000', 'supported_fecs': 'rs', 'host_tx_ready': 'true', 'speed': '400000'}
root@sonic:/home/cisco# 
```
[subport_shutdown_ut.txt](https://github.com/sonic-net/sonic-platform-daemons/files/15303756/subport_shutdown_ut.txt)

#### Additional Information (Optional)
