### PR TITLE
Fix intermittent build failure for test_SfpStateUpdateTask_task_run_stop

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1958,15 +1958,14 @@ class TestXcvrdScript(object):
         assert mock_update_status_hw.call_count == 1
 
     def test_SfpStateUpdateTask_task_run_stop(self):
-        def poll_for_5s(*args, **kwargs):
-            for i in range(5):
+        def poll_forever(*args, **kwargs):
+            while True:
                 time.sleep(1)
-            return None
-        # Redefine the XcvrTableHelper function to poll for 5 seconds so that the task can be stopped by
+        # Redefine the XcvrTableHelper function to poll forever so that the task can be stopped by
         # raising an exception in between. Also, XcvrTableHelper is the first function to be called after
         # starting the task, so having the patch here will avoid the task crashing unexpectedly
         # at a different location.
-        with patch('xcvrd.xcvrd.XcvrTableHelper', new=poll_for_5s):
+        with patch('xcvrd.xcvrd.XcvrTableHelper', new=poll_forever):
             port_mapping = PortMapping()
             stop_event = threading.Event()
             sfp_error_event = threading.Event()

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1957,17 +1957,25 @@ class TestXcvrdScript(object):
         assert not task.port_mapping.logical_to_asic
         assert mock_update_status_hw.call_count == 1
 
-    @patch('xcvrd.xcvrd_utilities.port_event_helper.subscribe_port_config_change', MagicMock(return_value=(None, None)))
     def test_SfpStateUpdateTask_task_run_stop(self):
-        port_mapping = PortMapping()
-        stop_event = threading.Event()
-        sfp_error_event = threading.Event()
-        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
-        task.start()
-        assert wait_until(5, 1, task.is_alive)
-        task.raise_exception()
-        task.join()
-        assert wait_until(5, 1, lambda: task.is_alive() is False)
+        def poll_for_5s(*args, **kwargs):
+            for i in range(5):
+                time.sleep(1)
+            return None
+        # Redefine the XcvrTableHelper function to poll for 5 seconds so that the task can be stopped by
+        # raising an exception in between. Also, XcvrTableHelper is the first function to be called after
+        # starting the task, so having the patch here will avoid the task crashing unexpectedly
+        # at a different location.
+        with patch('xcvrd.xcvrd.XcvrTableHelper', new=poll_for_5s):
+            port_mapping = PortMapping()
+            stop_event = threading.Event()
+            sfp_error_event = threading.Event()
+            task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
+            task.start()
+            assert wait_until(5, 1, task.is_alive)
+            task.raise_exception()
+            task.join()
+            assert wait_until(5, 1, lambda: task.is_alive() is False)
 
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
An intermittent build failure is seen for the test_SfpStateUpdateTask_task_run_stop unit-test with the below backtrace. We have observed more than one type of backtrace so far (details are mentioned in the issues mentioned below).
```
[2023-06-21T12:27:31.213Z] =================================== FAILURES ===================================
[2023-06-21T12:27:31.213Z] ____________ TestXcvrdScript.test_SfpStateUpdateTask_task_run_stop _____________
[2023-06-21T12:27:31.213Z]
[2023-06-21T12:27:31.213Z] self = <tests.test_xcvrd.TestXcvrdScript object at 0x7ff1f404b610>
[2023-06-21T12:27:31.213Z]
[2023-06-21T12:27:31.213Z] @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_config_change', MagicMock(return_value=(None, None)))
[2023-06-21T12:27:31.213Z] def test_SfpStateUpdateTask_task_run_stop(self):
[2023-06-21T12:27:31.213Z] port_mapping = PortMapping()
[2023-06-21T12:27:31.213Z] stop_event = threading.Event()
[2023-06-21T12:27:31.213Z] sfp_error_event = threading.Event()
[2023-06-21T12:27:31.213Z] task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
[2023-06-21T12:27:31.213Z] task.start()
[2023-06-21T12:27:31.213Z] assert wait_until(5, 1, task.is_alive)
[2023-06-21T12:27:31.213Z] task.raise_exception()
[2023-06-21T12:27:31.213Z] > task.join()
[2023-06-21T12:27:31.213Z]
[2023-06-21T12:27:31.213Z] tests/test_xcvrd.py:1041:
[2023-06-21T12:27:31.214Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
[2023-06-21T12:27:31.214Z] xcvrd/xcvrd.py:2200: in join
[2023-06-21T12:27:31.214Z] raise self.exc
[2023-06-21T12:27:31.214Z] xcvrd/xcvrd.py:2175: in run
[2023-06-21T12:27:31.214Z] self.task_worker(self.task_stopping_event, self.sfp_error_event)
[2023-06-21T12:27:31.214Z] xcvrd/xcvrd.py:1987: in task_worker
[2023-06-21T12:27:31.214Z] self.init()
[2023-06-21T12:27:31.214Z] xcvrd/xcvrd.py:1905: in init
[2023-06-21T12:27:31.214Z] self.retry_eeprom_set = self._post_port_sfp_info_and_dom_thr_to_db_once(port_mapping_data, self.xcvr_table_helper, self.main_thread_stop_event)
[2023-06-21T12:27:31.214Z] xcvrd/xcvrd.py:1845: in _post_port_sfp_info_and_dom_thr_to_db_once
[2023-06-21T12:27:31.214Z] warmstart.initialize("xcvrd", "pmon")
[2023-06-21T12:27:31.214Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
[2023-06-21T12:27:31.214Z]
[2023-06-21T12:27:31.214Z] app_name = 'xcvrd', docker_name = 'pmon', db_timeout = 0, isTcpConn = False
[2023-06-21T12:27:31.214Z]
[2023-06-21T12:27:31.214Z] @staticmethod
[2023-06-21T12:27:31.214Z] def initialize(app_name, docker_name, db_timeout=0, isTcpConn=False):
[2023-06-21T12:27:31.214Z] > return _swsscommon.WarmStart_initialize(app_name, docker_name, db_timeout, isTcpConn)
[2023-06-21T12:27:31.214Z] E RuntimeError: Unable to connect to redis (unix-socket): Cannot assign requested address
[2023-06-21T12:27:31.214Z]
[2023-06-21T12:27:31.214Z] /usr/lib/python3/dist-packages/swsscommon/swsscommon.py:3369: RuntimeError
[2023-06-21T12:27:31.214Z] =============================== warnings summary ===============================
```

Consistent way to fail the test
Add at least 1s sleep in between the below lines
https://github.com/sonic-net/sonic-platform-daemons/blob/d0fd1e1c6113d4a0e2e7bff1559d89e6105269c9/sonic-xcvrd/tests/test_xcvrd.py#L1966-L1967

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
fixes #369, fixes #370, fixes #382 

Intention of the testcase
The test case tests a scenario wherein while SfpStateUpdateTask thread is busy polling for few seconds, its parent process (xcvrd in an ideal case) generates an exception to stop the SfpStateUpdateTask thread in the middle of polling.

RCA for current failure
Since `test_SfpStateUpdateTask_task_run_stop` does not have all the underlying functions of SfpStateUpdateTask.task_worker mocked, there is a probability of SfpStateUpdateTask thread exiting early which will thereby cause `assert wait_until(5, 1, task.is_alive)` to fail based on the place at which SfpStateUpdateTask thread crashes.

Fix details
Modified the implementation of `XcvrTableHelper` function to have a busy polling to ensure that SfpStateUpdateTask thread does not quit before the `test_SfpStateUpdateTask_task_run_stop` testcase raises an exception.
Also, this approach will ensure that if any new function calls are being added in SfpStateUpdateTask.task_worker, they will not needed to be mocked in SfpStateUpdateTask.task_worker since `XcvrTableHelper` is the first function called in SfpStateUpdateTask.task_worker.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Ran the test multiple times to ensure that the testcases passes.
Also, added a 3s sleep in between the below lines and ensured that the testcases was passing consistently.
https://github.com/sonic-net/sonic-platform-daemons/blob/d0fd1e1c6113d4a0e2e7bff1559d89e6105269c9/sonic-xcvrd/tests/test_xcvrd.py#L1966-L1967

#### Additional Information (Optional)
MSFT ADO - 24271303