### PR TITLE
[chassis][linecard] Fix Module LINECARD<> went off-line message for empty slot issue

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -199,7 +199,6 @@ class ModuleUpdater(logger.Logger):
 
         self.hostname_table = swsscommon.Table(self.chassis_state_db, CHASSIS_MODULE_HOSTNAME_TABLE)
         self.down_modules = {}
-        self.module_status = {}
         self.chassis_app_db_clean_sha = None
 
         self.midplane_initialized = try_get(chassis.init_midplane_switch, default=False)
@@ -238,6 +237,13 @@ class ModuleUpdater(logger.Logger):
         fvs = swsscommon.FieldValuePairs([(CHASSIS_INFO_CARD_NUM_FIELD, str(num_modules))])
         self.chassis_table.set(CHASSIS_INFO_KEY_TEMPLATE.format(1), fvs)
 
+    def get_module_current_status(self, key):
+        fvs = self.module_table.get(key)
+        if isinstance(fvs, list) and fvs[0] is True:
+            fvs = dict(fvs[-1])
+            return fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+        return ModuleBase.MODULE_STATUS_EMPTY        
+            
     def module_db_update(self):
         notOnlineModules = []
 
@@ -245,10 +251,7 @@ class ModuleUpdater(logger.Logger):
             module_info_dict = self._get_module_info(module_index)
             if module_info_dict is not None:
                 key = module_info_dict[CHASSIS_MODULE_INFO_NAME_FIELD]
-                # initialize for the first time
-                if key not in self.module_status:
-                    self.module_status[key] = "Init"
-                    
+
                 if not key.startswith(ModuleBase.MODULE_TYPE_SUPERVISOR) and \
                    not key.startswith(ModuleBase.MODULE_TYPE_LINE) and \
                    not key.startswith(ModuleBase.MODULE_TYPE_FABRIC):
@@ -264,6 +267,7 @@ class ModuleUpdater(logger.Logger):
                                                   (CHASSIS_MODULE_INFO_OPERSTATUS_FIELD, module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]),
                                                   (CHASSIS_MODULE_INFO_NUM_ASICS_FIELD, str(len(module_info_dict[CHASSIS_MODULE_INFO_ASICS]))),
                                                   (CHASSIS_MODULE_INFO_SERIAL_FIELD, module_info_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD])])
+                prev_status = self.get_module_current_status(key)
                 self.module_table.set(key, fvs)
 
                 # Construct key for down_modules dict. Example down_modules key format: LINE-CARD0|<hostname>
@@ -276,7 +280,7 @@ class ModuleUpdater(logger.Logger):
                     down_module_key = key+'|'
 
                 if module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD] != str(ModuleBase.MODULE_STATUS_ONLINE):
-                    if self.module_status[key] == ModuleBase.MODULE_STATUS_ONLINE:
+                    if prev_status == ModuleBase.MODULE_STATUS_ONLINE:
                         notOnlineModules.append(key)
                         # Record the time when the module down was detected to track the
                         # module down time. Used for chassis db cleanup for all asics of the module if the module is down for a 
@@ -289,16 +293,14 @@ class ModuleUpdater(logger.Logger):
                             self.down_modules[down_module_key] = {}
                             self.down_modules[down_module_key]['down_time'] = time.time()
                             self.down_modules[down_module_key]['cleaned'] = False
-                    self.module_status[key] = module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD] 
                     continue
                 else:
                     # Module is operational. Remove it from down time tracking.
                     if down_module_key in self.down_modules:
                         self.log_notice("Module {} recovered on-line!".format(key))
                         del self.down_modules[down_module_key]
-                    elif self.module_status[key] != ModuleBase.MODULE_STATUS_ONLINE:
+                    elif prev_status != ModuleBase.MODULE_STATUS_ONLINE:
                         self.log_notice("Module {} is on-line!".format(key))
-                    self.module_status[key] = module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD] 
 
                 for asic_id, asic in enumerate(module_info_dict[CHASSIS_MODULE_INFO_ASICS]):
                     asic_global_id, asic_pci_addr = asic

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -199,6 +199,7 @@ class ModuleUpdater(logger.Logger):
 
         self.hostname_table = swsscommon.Table(self.chassis_state_db, CHASSIS_MODULE_HOSTNAME_TABLE)
         self.down_modules = {}
+        self.module_status = {}
         self.chassis_app_db_clean_sha = None
 
         self.midplane_initialized = try_get(chassis.init_midplane_switch, default=False)
@@ -244,7 +245,10 @@ class ModuleUpdater(logger.Logger):
             module_info_dict = self._get_module_info(module_index)
             if module_info_dict is not None:
                 key = module_info_dict[CHASSIS_MODULE_INFO_NAME_FIELD]
-
+                # initialize for the first time
+                if key not in self.module_status:
+                    self.module_status[key] = "Init"
+                    
                 if not key.startswith(ModuleBase.MODULE_TYPE_SUPERVISOR) and \
                    not key.startswith(ModuleBase.MODULE_TYPE_LINE) and \
                    not key.startswith(ModuleBase.MODULE_TYPE_FABRIC):
@@ -272,23 +276,29 @@ class ModuleUpdater(logger.Logger):
                     down_module_key = key+'|'
 
                 if module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD] != str(ModuleBase.MODULE_STATUS_ONLINE):
-                    notOnlineModules.append(key)
-                    # Record the time when the module down was detected to track the
-                    # module down time. Used for chassis db cleanup for all asics of the module if the module is down for a 
-                    # long time like 30 mins.
-                    # All down modules including supervisor are added to the down modules dictionary. This is to help
-                    # identifying module operational status change. But the clean up will not be attempted for supervisor
-                    if down_module_key not in self.down_modules:
-                        self.log_warning("Module {} went off-line!".format(key))
-                        self.down_modules[down_module_key] = {}
-                        self.down_modules[down_module_key]['down_time'] = time.time()
-                        self.down_modules[down_module_key]['cleaned'] = False
+                    if self.module_status[key] == ModuleBase.MODULE_STATUS_ONLINE:
+                        notOnlineModules.append(key)
+                        # Record the time when the module down was detected to track the
+                        # module down time. Used for chassis db cleanup for all asics of the module if the module is down for a 
+                        # long time like 30 mins.
+                        # All down modules including supervisor are added to the down modules dictionary. This is to help
+                        # identifying module operational status change. But the clean up will not be attempted for supervisor
+
+                        if down_module_key not in self.down_modules:
+                            self.log_warning("Module {} went off-line!".format(key))
+                            self.down_modules[down_module_key] = {}
+                            self.down_modules[down_module_key]['down_time'] = time.time()
+                            self.down_modules[down_module_key]['cleaned'] = False
+                    self.module_status[key] = module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD] 
                     continue
                 else:
                     # Module is operational. Remove it from down time tracking.
                     if down_module_key in self.down_modules:
                         self.log_notice("Module {} recovered on-line!".format(key))
                         del self.down_modules[down_module_key]
+                    elif self.module_status[key] != ModuleBase.MODULE_STATUS_ONLINE:
+                        self.log_notice("Module {} is on-line!".format(key))
+                    self.module_status[key] = module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD] 
 
                 for asic_id, asic in enumerate(module_info_dict[CHASSIS_MODULE_INFO_ASICS]):
                     asic_global_id, asic_pci_addr = asic


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
The current implementation in chassisd has NO method to differentiates a module (Linecard & Farbic card) slot is empty during boot up or module is reseatted or removal.  Add get_module_current_status() to fetch the previous status from DB. And compare it to the new status to log a proper message.

After this change, the following is behaviours:
1) No longer log "Module LINE-CARD5 went off-line!" for empty slot upon Supervisor reboot 
2) There be any LINECARD Chassis db cleanup happened after the 30 minutes timeout
3) The following messages will be logged for a Linecard which is online upon Supervisor reboot 
```
Apr  9 19:05:43.028168 ixre-cpm-chassis15 NOTICE pmon#chassisd: Module SUPERVISOR0 is on-line!
Apr  9 19:05:43.233794 ixre-cpm-chassis15 NOTICE pmon#chassisd: Module LINE-CARD0 is on-line!
Apr  9 19:05:43.848048 ixre-cpm-chassis15 NOTICE pmon#chassisd: Module LINE-CARD3 is on-line!
Apr  9 19:05:45.686618 ixre-cpm-chassis15 NOTICE pmon#chassisd: Module FABRIC-CARD3 is on-line!
```

<!--
     Describe your changes in detail
-->

#### Motivation and Context
On a T2-VOQ chassis, where some linecard slots are empty. Upon supervisor reboot, following messages are seen for those empty linecard slots. 
```
pmon#chassisd: Module LINE-CARD5 went off-line!
pmon#chassisd: Host name is not available for Module LINE-CARD5. Chassis db clean up not done!
pmon#chassisd: Module LINE-CARD5| is down for long time. Initiating chassis app db clean up
```
This PR fixes https://github.com/sonic-net/sonic-buildimage/issues/18539

This change is required to 202205 branch

[x] 202205
[x] 202305

<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
This change has been tested on 202205 branch.
1) Reboot Supervisor, check the log message for the empty slot and non-empty slot
2) Reboot a linecard, check the proper log message
3)  Reboot a linecard and keep it down, to check the log messages and also the 30 minutes CHassis db cleanup happens for this slot

<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
