### PR TITLE
Adding frequency grid validation for ZR optics 

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2500,7 +2500,9 @@ class TestXcvrdScript(object):
          (1, 193100, 75, True),
          (1, 193100, 100, False),
          (1, 193125, 75, False),
-         (1, 193100, 25, True)
+         (1, 193100, 25, False),
+         (1, 191295, 75, False),
+         (1, 196105, 75, False)
     ])
     def test_CmisManagerTask_config_laser_frequency_validate(self, lport, freq, grid, expected):
         mock_xcvr_api = MagicMock()

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2599,14 +2599,14 @@ class TestXcvrdScript(object):
          (1, 191295, 75, False),
          (1, 196105, 75, False)
     ])
-    def test_CmisManagerTask_config_laser_frequency_validate(self, lport, freq, grid, expected):
+    def test_CmisManagerTask_validate_frequency_and_grid(self, lport, freq, grid, expected):
         mock_xcvr_api = MagicMock()
         mock_xcvr_api.get_supported_freq_config = MagicMock()
         mock_xcvr_api.get_supported_freq_config.return_value = (0x80, 0, 0, 191300, 196100)
         port_mapping = PortMapping()
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
-        result = task.config_laser_frequency_validate(mock_xcvr_api, lport, freq, grid)
+        result = task.validate_frequency_and_grid(mock_xcvr_api, lport, freq, grid)
         assert result == expected
 
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1217,10 +1217,7 @@ class CmisManagerTask(threading.Thread):
     def configure_laser_frequency(self, api, lport, freq, grid=75):
         if api.get_tuning_in_progress():
             self.log_error("{} Tuning in progress, subport selection may fail!".format(lport))
-        try:
-            return api.set_laser_freq(freq, grid)
-        except:
-            return False
+        return api.set_laser_freq(freq, grid)
 
     def post_port_active_apsel_to_db(self, api, lport, host_lanes_mask):
         try:

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1189,18 +1189,31 @@ class CmisManagerTask(threading.Thread):
            self.log_error("{} configured tx power {} > maximum power {} supported".format(lport, tx_power, max_p))
         return api.set_tx_power(tx_power)
 
-    def configure_laser_frequency(self, api, lport, freq, grid=75):
-        _, _,  _, lowf, highf = api.get_supported_freq_config()
+    def config_laser_frequency_validate(self, api, lport, freq, grid=75):
+        supported_grid, _,  _, lowf, highf = api.get_supported_freq_config()
         if freq < lowf:
             self.log_error("{} configured freq:{} GHz is lower than the supported freq:{} GHz".format(lport, freq, lowf))
+            return false
         if freq > highf:
             self.log_error("{} configured freq:{} GHz is higher than the supported freq:{} GHz".format(lport, freq, highf))
-        chan = int(round((freq - 193100)/25))
-        if chan % 3 != 0:
-            self.log_error("{} configured freq:{} GHz is NOT in 75GHz grid".format(lport, freq))
+            return false
+        if grid == 75:
+            if (supported_grid >> 7) & 0x1 != 1:
+                self.log_error("{} 75GHz is not supported".format(lport))
+                return False
+            chan = int(round((freq - 193100)/25))
+            if chan % 3 != 0:
+                self.log_error("{} configured freq:{} GHz is NOT in 75GHz grid".format(lport, freq))
+                return False
+        return True
+
+    def configure_laser_frequency(self, api, lport, freq, grid=75):
         if api.get_tuning_in_progress():
             self.log_error("{} Tuning in progress, subport selection may fail!".format(lport))
-        return api.set_laser_freq(freq, grid)
+        try:
+            return api.set_laser_freq(freq, grid)
+        except:
+            return False
 
     def post_port_active_apsel_to_db(self, api, lport, host_lanes_mask):
         try:
@@ -1424,11 +1437,15 @@ class CmisManagerTask(threading.Thread):
 
                         # For ZR module, Datapath needes to be re-initlialized on new channel selection
                         if api.is_coherent_module():
-                           freq = self.port_dict[lport]['laser_freq']
-                           # If user requested frequency is NOT the same as configured on the module
-                           # force datapath re-initialization
-                           if 0 != freq and freq != api.get_laser_config_freq():
-                              need_update = True
+                            freq = self.port_dict[lport]['laser_freq']
+                            # If user requested frequency is NOT the same as configured on the module
+                            # force datapath re-initialization
+                            if 0 != freq and freq != api.get_laser_config_freq():
+                                if self.config_laser_frequency_validate(api, lport, freq) == True:
+                                    need_update = True
+                                else:
+                                    # clear setting of invalid frequency config
+                                    self.port_dict[lport]['laser_freq'] = 0
 
                         if not need_update:
                             # No application updates

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1193,10 +1193,10 @@ class CmisManagerTask(threading.Thread):
         supported_grid, _,  _, lowf, highf = api.get_supported_freq_config()
         if freq < lowf:
             self.log_error("{} configured freq:{} GHz is lower than the supported freq:{} GHz".format(lport, freq, lowf))
-            return false
+            return False
         if freq > highf:
             self.log_error("{} configured freq:{} GHz is higher than the supported freq:{} GHz".format(lport, freq, highf))
-            return false
+            return False
         if grid == 75:
             if (supported_grid >> 7) & 0x1 != 1:
                 self.log_error("{} 75GHz is not supported".format(lport))
@@ -1209,9 +1209,9 @@ class CmisManagerTask(threading.Thread):
             if (supported_grid >> 5) & 0x1 != 1:
                 self.log_error("{} 100GHz is not supported".format(lport))
                 return False
-            else:
-                self.log_error("{} {}GHz is not supported".format(lport, grid))
-                return False
+        else:
+            self.log_error("{} {}GHz is not supported".format(lport, grid))
+            return False
         return True
 
     def configure_laser_frequency(self, api, lport, freq, grid=75):

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1205,7 +1205,7 @@ class CmisManagerTask(threading.Thread):
             if chan % 3 != 0:
                 self.log_error("{} configured freq:{} GHz is NOT in 75GHz grid".format(lport, freq))
                 return False
-	elif grid == 100:
+        elif grid == 100:
             if (supported_grid >> 5) & 0x1 != 1:
                 self.log_error("{} 100GHz is not supported".format(lport))
                 return False

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1205,6 +1205,13 @@ class CmisManagerTask(threading.Thread):
             if chan % 3 != 0:
                 self.log_error("{} configured freq:{} GHz is NOT in 75GHz grid".format(lport, freq))
                 return False
+	elif grid == 100:
+            if (supported_grid >> 5) & 0x1 != 1:
+                self.log_error("{} 100GHz is not supported".format(lport))
+                return False
+            else:
+                self.log_error("{} {}GHz is not supported".format(lport, grid))
+                return False
         return True
 
     def configure_laser_frequency(self, api, lport, freq, grid=75):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Configuring frequency for ZR optics , which is not a multiple of 75Ghz was throwing exception causing xcvrd to crash.
Added validation check for 75GHz Grid without throwing exception and returning false/true value based on the input.
This change currently supports only 75GHz grid value and not any other frequency.

root@sonic:/home/cisco# sudo config interface -n asic2 transceiver frequency Ethernet200 196000
Setting laser frequency to 196000 GHz on port Ethernet200
root@sonic:/home/cisco#
Cause xcvrd to crash

#### Motivation and Context

#### How Has This Been Tested?
Configured frequency which was within the min and max supported limits with 2 sample size
1. Multiple of Grid frequency (75Ghz). Expectation is laser frequency configuration should be successful.
2. Not a multiple of Grid Frequency. Xcvrd should not crash

CONFIGURED 191450 WHICH IS 75GHZ GRID
=====================================
Apr 12 09:37:09.140467 sonic WARNING kernel: [ 1165.878981] imc_smbus 0000:ff:13.0: CLTT with interval of 0 looks suspicious
Apr 12 09:37:09.152458 sonic WARNING kernel: [ 1165.891307] imc_smbus 0000:ff:13.0: CLTT with interval of 0 looks suspicious
Apr 12 09:37:09.164457 sonic WARNING kernel: [ 1165.903618] imc_smbus 0000:ff:13.0: CLTT with interval of 0 looks suspicious
Apr 12 09:37:09.176454 sonic WARNING kernel: [ 1165.916303] imc_smbus 0000:ff:13.0: CLTT with interval of 0 looks suspicious
Apr 12 09:37:09.188453 sonic WARNING kernel: [ 1165.928616] imc_smbus 0000:ff:13.0: CLTT with interval of 0 looks suspicious
Apr 12 09:37:09.200450 sonic WARNING kernel: [ 1165.939432] imc_smbus 0000:ff:13.0: CLTT with interval of 0 looks suspicious
Apr 12 09:37:09.389668 sonic NOTICE pmon#xcvrd[28]: CMIS: Ethernet248: 400G, lanemask=0xff, state=AP_CONFIGURED, appl 1 host_lane_count 8 retries=0
Apr 12 09:37:15.478194 sonic NOTICE pmon#xcvrd[28]: message repeated 6 times: [ CMIS: Ethernet248: 400G, lanemask=0xff, state=AP_CONFIGURED, appl 1 host_lane_count 8 retries=0]
Apr 12 09:37:15.478194 sonic NOTICE pmon#xcvrd[28]: CMIS: Ethernet248 configured laser frequency 191450 GHz
Apr 12 09:37:16.506193 sonic NOTICE pmon#xcvrd[28]: CMIS: Ethernet248: 400G, lanemask=0xff, state=DP_INIT, appl 1 host_lane_count 8 retries=0
Apr 12 09:37:16.519890 sonic NOTICE pmon#xcvrd[28]: CMIS: Ethernet248: DpInit duration 60.0 secs
Apr 12 09:37:17.527446 sonic NOTICE pmon#xcvrd[28]: CMIS: Ethernet248: 400G, lanemask=0xff, state=DP_TXON, appl 1 host_lane_count 8 retries=0
Apr 12 09:37:21.204489 sonic WARNING kernel: [ 1177.944702] imc_smbus 0000:ff:13.0: CLTT with interval of 0 looks suspicious
Apr 12 09:37:21.216482 sonic WARNING kernel: [ 1177.955787] imc_smbus 0000:ff:13.0: CLTT with interval of 0 looks suspicious

Apr 12 09:37:21.508478 sonic WARNING kernel: [ 1178.247422] imc_smbus 0000:ff:13.0: CLTT with interval of 0 looks suspicious
Apr 12 09:37:21.520471 sonic WARNING kernel: [ 1178.259330] imc_smbus 0000:ff:13.0: CLTT with interval of 0 looks suspicious



CONFIGURED 191500 WHICH IS NOT IN 75GHZ GRID
===========================================
Apr 12 09:37:35.906393 sonic NOTICE pmon#xcvrd[28]: message repeated 18 times: [ CMIS: Ethernet248: 400G, lanemask=0xff, state=DP_TXON, appl 1 host_lane_count 8 retries=0]
Apr 12 09:37:35.906393 sonic WARNING pmon#xcvrd[28]: $$$ Ethernet248 handle_port_update_event() : op=SET DB:CONFIG_DB Table:PORT fvp {'admin_status': 'up', 'alias': 'Eth0/0/0/31', 'asic_port_name': 'Eth56-ASIC2', 'index': '31', 'lanes': '512,513,514,515,516,517,518,519', 'mtu': '9100', 'role': 'Ext', 'speed': '400000', 'laser_freq': '191500'}
Apr 12 09:37:35.906393 sonic WARNING pmon#xcvrd[28]: *** Ethernet248CONFIG_DBPORT handle_port_update_event() fvp {'admin_status': 'up', 'alias': 'Eth0/0/0/31', 'asic_port_name': 'Eth56-ASIC2', 'index': '31', 'lanes': '512,513,514,515,516,517,518,519', 'mtu': '9100', 'role': 'Ext', 'speed': '400000', 'laser_freq': '191500', 'key': 'Ethernet248', 'asic_id': 2, 'op': 'SET'}
Apr 12 09:37:35.906969 sonic WARNING swss2#orchagent: :- parsePortConfig: Unknown field(laser_freq): skipping ...
Apr 12 09:37:35.906969 sonic WARNING swss2#orchagent: :- parsePortConfig: Unknown field(asic_port_name): skipping ...
Apr 12 09:37:35.907197 sonic NOTICE swss2#orchagent: :- setGearboxPortAttr: BOX: Set Ethernet248 lane system_speed 400000
Apr 12 09:37:35.907756 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:350: GBCRUD-REQ:SET-PORT: port_oid=100000000003e request: #0 PORT:SPEED=400000 #012 
Apr 12 09:37:35.907929 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:465: GBCRUD-RES:SET-PORT:port_oid:100000000003e, pd_port=31, is_lineside=0 speed(400000) is the same#012 
Apr 12 09:37:35.907945 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:516: GBCRUD-RES:SET-PORT:port_oid=100000000003e, pd_port=31, is_lineside=0, status:0 #012 
Apr 12 09:37:35.908533 sonic NOTICE swss2#orchagent: :- setGearboxPortAttr: BOX: Updated APPL_DB key:phy:15:ports:31 system_speed 400000
Apr 12 09:37:35.908533 sonic NOTICE swss2#orchagent: :- setGearboxPortAttr: BOX: Set Ethernet248 lane line_speed 400000
Apr 12 09:37:35.909037 sonic NOTICE swss2#portmgrd: :- doTask: Configure Ethernet248 MTU to 9100
Apr 12 09:37:35.909087 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:350: GBCRUD-REQ:SET-PORT: port_oid=100000000003f request: #0 PORT:SPEED=400000 #012 
Apr 12 09:37:35.909087 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:465: GBCRUD-RES:SET-PORT:port_oid:100000000003f, pd_port=31, is_lineside=1 speed(400000) is the same#012 
Apr 12 09:37:35.909097 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:516: GBCRUD-RES:SET-PORT:port_oid=100000000003f, pd_port=31, is_lineside=1, status:0 #012 
Apr 12 09:37:35.909683 sonic NOTICE swss2#orchagent: :- setGearboxPortAttr: BOX: Updated APPL_DB key:phy:15:ports:31 line_speed 400000
Apr 12 09:37:35.910288 sonic WARNING swss2#orchagent: :- parsePortConfig: Unknown field(laser_freq): skipping ...
Apr 12 09:37:35.910288 sonic WARNING swss2#orchagent: :- parsePortConfig: Unknown field(asic_port_name): skipping ...
Apr 12 09:37:35.910507 sonic NOTICE swss2#orchagent: :- setGearboxPortAttr: BOX: Set Ethernet248 lane system_speed 400000
Apr 12 09:37:35.911316 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:350: GBCRUD-REQ:SET-PORT: port_oid=100000000003e request: #0 PORT:SPEED=400000 #012 
Apr 12 09:37:35.911481 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:465: GBCRUD-RES:SET-PORT:port_oid:100000000003e, pd_port=31, is_lineside=0 speed(400000) is the same#012 
Apr 12 09:37:35.911481 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:516: GBCRUD-RES:SET-PORT:port_oid=100000000003e, pd_port=31, is_lineside=0, status:0 #012 
Apr 12 09:37:35.911765 sonic NOTICE swss2#portmgrd: :- doTask: Configure Ethernet248 admin status to up
Apr 12 09:37:35.912125 sonic NOTICE swss2#orchagent: :- setGearboxPortAttr: BOX: Updated APPL_DB key:phy:15:ports:31 system_speed 400000
Apr 12 09:37:35.912125 sonic NOTICE swss2#orchagent: :- setGearboxPortAttr: BOX: Set Ethernet248 lane line_speed 400000
Apr 12 09:37:35.912527 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:350: GBCRUD-REQ:SET-PORT: port_oid=100000000003f request: #0 PORT:SPEED=400000 #012 
Apr 12 09:37:35.912736 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:465: GBCRUD-RES:SET-PORT:port_oid:100000000003f, pd_port=31, is_lineside=1 speed(400000) is the same#012 
Apr 12 09:37:35.912756 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:516: GBCRUD-RES:SET-PORT:port_oid=100000000003f, pd_port=31, is_lineside=1, status:0 #012 
Apr 12 09:37:35.913168 sonic NOTICE swss2#orchagent: :- setGearboxPortAttr: BOX: Updated APPL_DB key:phy:15:ports:31 line_speed 400000
Apr 12 09:37:35.913594 sonic WARNING swss2#orchagent: :- parsePortConfig: Unknown field(laser_freq): skipping ...
Apr 12 09:37:35.913594 sonic WARNING swss2#orchagent: :- parsePortConfig: Unknown field(asic_port_name): skipping ...
Apr 12 09:37:35.913724 sonic NOTICE swss2#orchagent: :- setGearboxPortAttr: BOX: Set Ethernet248 lane system_speed 400000
Apr 12 09:37:35.914097 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:350: GBCRUD-REQ:SET-PORT: port_oid=100000000003e request: #0 PORT:SPEED=400000 #012 
Apr 12 09:37:35.914265 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:465: GBCRUD-RES:SET-PORT:port_oid:100000000003e, pd_port=31, is_lineside=0 speed(400000) is the same#012 
Apr 12 09:37:35.914283 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:516: GBCRUD-RES:SET-PORT:port_oid=100000000003e, pd_port=31, is_lineside=0, status:0 #012 
Apr 12 09:37:35.914760 sonic NOTICE swss2#orchagent: :- setGearboxPortAttr: BOX: Updated APPL_DB key:phy:15:ports:31 system_speed 400000
Apr 12 09:37:35.914760 sonic NOTICE swss2#orchagent: :- setGearboxPortAttr: BOX: Set Ethernet248 lane line_speed 400000
Apr 12 09:37:35.915055 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:350: GBCRUD-REQ:SET-PORT: port_oid=100000000003f request: #0 PORT:SPEED=400000 #012 
Apr 12 09:37:35.915262 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:465: GBCRUD-RES:SET-PORT:port_oid:100000000003f, pd_port=31, is_lineside=1 speed(400000) is the same#012 
Apr 12 09:37:35.915278 sonic NOTICE gbsyncd2#GBSAI[18]: GBSAI: phy_set_port_attribute:516: GBCRUD-RES:SET-PORT:port_oid=100000000003f, pd_port=31, is_lineside=1, status:0 #012 
Apr 12 09:37:35.915788 sonic NOTICE swss2#orchagent: :- setGearboxPortAttr: BOX: Updated APPL_DB key:phy:15:ports:31 line_speed 400000
Apr 12 09:37:35.922339 sonic NOTICE pmon#xcvrd[28]: CMIS: Ethernet248: 400G, lanemask=0xff, state=INSERTED, appl 1 host_lane_count 8 retries=0
Apr 12 09:37:36.004299 sonic NOTICE pmon#xcvrd[28]: CMIS: Ethernet248: Setting appl=1
Apr 12 09:37:36.086602 sonic NOTICE pmon#xcvrd[28]: CMIS: Ethernet248: Setting host_lanemask=0xff
Apr 12 09:37:36.208476 sonic WARNING kernel: [ 1192.945057] imc_smbus 0000:ff:13.0: CLTT with interval of 0 looks suspicious
Apr 12 09:37:36.220468 sonic WARNING kernel: [ 1192.957295] imc_smbus 0000:ff:13.0: CLTT with interval of 0 looks suspicious
Apr 12 09:37:36.257574 sonic NOTICE pmon#xcvrd[28]: CMIS: Ethernet248: Setting media_lanemask=0x1
Apr 12 09:37:36.425168 sonic ERR pmon#xcvrd[28]: CMIS: Ethernet248 configured freq:191500 GHz is NOT in 75GHz grid
Apr 12 09:37:36.425168 sonic NOTICE pmon#xcvrd[28]: CMIS: Ethernet248: force Datapath reinit
Apr 12 09:37:36.524475 sonic WARNING kernel: [ 1193.263374] imc_smbus 0000:ff:13.0: CLTT with interval of 0 looks suspicious
Apr 12 09:37:36.536467 sonic WARNING kernel: [ 1193.275654] imc_smbus 0000:ff:13.0: CLTT with interval of 0 looks suspicious
Apr 12 09:37:37.439684 sonic NOTICE pmon#xcvrd[28]: CMIS: Ethernet248: 400G, lanemask=0xff, state=DP_DEINIT, appl 1 host_lane_count 8 retries=0
Apr 12 09:37:38.503378 sonic NOTICE pmon#xcvrd[28]: CMIS: Ethernet248: DpDeinit duration 5.0 secs, modulePwrUp duration 60.0 secs
Apr 12 09:37:39.521233 sonic NOTICE pmon#xcvrd[28]: CMIS: Ethernet248: 400G, lanemask=0xff, state=AP_CONFIGURED, appl 1 host_lane_count 8 retries=0
Apr 12 09:37:46.717133 sonic NOTICE pmon#xcvrd[28]: message repeated 6 times: [ CMIS: Ethernet248: 400G, lanemask=0xff, state=AP_CONFIGURED, appl 1 host_lane_count 8 retries=0]
LISHED: {"sonic-host:device-test-event":{"batch-id":"555a75aa-f8b0-11ee-846c-bc4a56c228ff","index":"3","reason":"monit periodic test","sender":"events_monit_test.py","timestamp":"2024-04-12T09:37:53.110130Z"}}
Apr 12 09:37:53.110295 sonic NOTICE python3: :- publish: EVENT_PUBLISHED: {"sonic-host:device-test-event":{"batch-id":"555a75aa-f8b0-11ee-846c-bc4a56c228ff","index":"4","reason":"monit periodic test","sender":"events_monit_test.py","timestamp":"2024-04-12T09:37:53.110212Z"}}
^C
root@sonic:/home/cisco# 
#### Additional Information (Optional)
