### PR TITLE
[202311][warm/fast-reboot] Retain TRANSCEIVER_INFO/STATUS tables on deinit

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2029,7 +2029,13 @@ class TestXcvrdScript(object):
         media_str = get_media_val_str(num_logical_ports, lane_dict, logical_idx)
         assert media_str == '3,4'
 
+    class MockPortMapping:
+        logical_port_list = [0, 1, 2]
+        logical_port_name_to_physical_port_list = MagicMock()
+        get_asic_id_for_logical_port = MagicMock()
+
     @patch('xcvrd.xcvrd.DaemonXcvrd.load_platform_util', MagicMock())
+    @patch('xcvrd.xcvrd_utilities.port_mapping.get_port_mapping', MagicMock(return_value=MockPortMapping))
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', None)))
     @patch('swsscommon.swsscommon.WarmStart', MagicMock())
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
@@ -2039,7 +2045,44 @@ class TestXcvrdScript(object):
             mock_run.return_value = "true"
 
             xcvrd.init()
+
+            status_tbl = MagicMock()
+            xcvrd.xcvr_table_helper.get_status_tbl = MagicMock(return_value=status_tbl)
+            xcvrd.xcvr_table_helper.get_dom_tbl = MagicMock(return_value=MagicMock)
+            xcvrd.xcvr_table_helper.get_dom_threshold_tbl = MagicMock(return_value=MagicMock)
+            xcvrd.xcvr_table_helper.get_pm_tbl = MagicMock(return_value=MagicMock)
+            xcvrd.xcvr_table_helper.get_firmware_info_tbl = MagicMock(return_value=MagicMock)
+
             xcvrd.deinit()
+
+            status_tbl.hdel.assert_not_called()
+
+    @patch('xcvrd.xcvrd.DaemonXcvrd.load_platform_util', MagicMock())
+    @patch('xcvrd.xcvrd_utilities.port_mapping.get_port_mapping', MagicMock(return_value=MockPortMapping))
+    @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', None)))
+    @patch('xcvrd.xcvrd.is_warm_reboot_enabled', MagicMock(return_value=False))
+    @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
+    @patch('subprocess.check_output', MagicMock(return_value='false'))
+    def test_DaemonXcvrd_init_deinit_cold(self):
+        xcvrd.platform_chassis = MagicMock()
+
+        xcvrdaemon = DaemonXcvrd(SYSLOG_IDENTIFIER)
+        with patch("subprocess.check_output") as mock_run:
+            mock_run.return_value = "false"
+
+            xcvrdaemon.init()
+
+            status_tbl = MagicMock()
+            xcvrdaemon.xcvr_table_helper.get_status_tbl = MagicMock(return_value=status_tbl)
+            xcvrdaemon.xcvr_table_helper.get_dom_tbl = MagicMock(return_value=MagicMock)
+            xcvrdaemon.xcvr_table_helper.get_dom_threshold_tbl = MagicMock(return_value=MagicMock)
+            xcvrdaemon.xcvr_table_helper.get_pm_tbl = MagicMock(return_value=MagicMock)
+            xcvrdaemon.xcvr_table_helper.get_firmware_info_tbl = MagicMock(return_value=MagicMock)
+            xcvrdaemon.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=MagicMock)
+
+            xcvrdaemon.deinit()
+
+            status_tbl.hdel.assert_called()
 
 
 def wait_until(total_wait_time, interval, call_back, *args, **kwargs):

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -30,7 +30,7 @@ try:
     from .xcvrd_utilities import port_mapping
     from .xcvrd_utilities import media_settings_parser
     from .xcvrd_utilities import optics_si_parser
-    
+
     from sonic_platform_base.sonic_xcvr.api.public.c_cmis import CmisApi
 
 except ImportError as e:
@@ -966,7 +966,7 @@ class CmisManagerTask(threading.Thread):
             self.log_error("Invalid input to get media lane mask - appl {} media_lane_count {} "
                             "lport {} subport {}!".format(appl, media_lane_count, lport, subport))
             return media_lanes_mask
-	
+
         media_lane_start_bit = (media_lane_count * (0 if subport == 0 else subport - 1))
         if media_lane_assignment_option & (1 << media_lane_start_bit):
             media_lanes_mask = ((1 << media_lane_count) - 1) << media_lane_start_bit
@@ -1392,7 +1392,7 @@ class CmisManagerTask(threading.Thread):
                             continue
                         host_lanes_mask = self.port_dict[lport]['host_lanes_mask']
                         self.log_notice("{}: Setting host_lanemask=0x{:x}".format(lport, host_lanes_mask))
-			
+
                         self.port_dict[lport]['media_lane_count'] = int(api.get_media_lane_count(appl))
                         self.port_dict[lport]['media_lane_assignment_options'] = int(api.get_media_lane_assignment_option(appl))
                         media_lane_count = self.port_dict[lport]['media_lane_count']
@@ -1462,8 +1462,8 @@ class CmisManagerTask(threading.Thread):
                         self.port_dict[lport]['cmis_expired'] = now + datetime.timedelta(seconds = max(modulePwrUpDuration, dpDeinitDuration))
 
                     elif state == CMIS_STATE_AP_CONF:
-                        # Explicit control bit to apply custom Host SI settings. 
-                        # It will be set to 1 and applied via set_application if 
+                        # Explicit control bit to apply custom Host SI settings.
+                        # It will be set to 1 and applied via set_application if
                         # custom SI settings is applicable
                         ec = 0
 
@@ -1495,13 +1495,13 @@ class CmisManagerTask(threading.Thread):
                             # Apply module SI settings if applicable
                             lane_speed = int(speed/1000)//host_lane_count
                             optics_si_dict = optics_si_parser.fetch_optics_si_setting(pport, lane_speed, sfp)
-                            
+
                             self.log_debug("Read SI parameters for port {} from optics_si_settings.json vendor file:".format(lport))
                             for key, sub_dict in optics_si_dict.items():
                                 self.log_debug("{}".format(key))
                                 for sub_key, value in sub_dict.items():
                                     self.log_debug("{}: {}".format(sub_key, str(value)))
-                            
+
                             if optics_si_dict:
                                 self.log_notice("{}: Apply Optics SI found for Vendor: {}  PN: {} lane speed: {}G".
                                                  format(lport, api.get_manufacturer(), api.get_model(), lane_speed))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -781,6 +781,14 @@ def is_fast_reboot_enabled():
     fastboot_enabled = subprocess.check_output('sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable', shell=True, universal_newlines=True)
     return "true" in fastboot_enabled
 
+
+def is_warm_reboot_enabled():
+    warmstart = swsscommon.WarmStart()
+    warmstart.initialize("xcvrd", "pmon")
+    warmstart.checkWarmStart("xcvrd", "pmon", False)
+    is_warm_start = warmstart.isWarmStart()
+    return is_warm_start
+
 #
 # Helper classes ===============================================================
 #
@@ -1842,11 +1850,7 @@ class SfpStateUpdateTask(threading.Thread):
         transceiver_dict = {}
         retry_eeprom_set = set()
 
-        warmstart = swsscommon.WarmStart()
-        warmstart.initialize("xcvrd", "pmon")
-        warmstart.checkWarmStart("xcvrd", "pmon", False)
-        is_warm_start = warmstart.isWarmStart()
-
+        is_warm_start = is_warm_reboot_enabled()
         # Post all the current interface sfp/dom threshold info to STATE_DB
         logical_port_list = port_mapping.logical_port_list
         for logical_port_name in logical_port_list:
@@ -2429,6 +2433,8 @@ class DaemonXcvrd(daemon_base.DaemonBase):
     def deinit(self):
         self.log_info("Start daemon deinit...")
 
+        is_warm_fast_reboot = is_warm_reboot_enabled() or is_fast_reboot_enabled()
+
         # Delete all the information from DB and then exit
         port_mapping_data = port_mapping.get_port_mapping(self.namespaces)
         logical_port_list = port_mapping_data.logical_port_list
@@ -2439,15 +2445,18 @@ class DaemonXcvrd(daemon_base.DaemonBase):
                 helper_logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
                 continue
 
+            intf_tbl = self.xcvr_table_helper.get_intf_tbl(asic_index) if not is_warm_fast_reboot else None
+
             del_port_sfp_dom_info_from_db(logical_port_name, port_mapping_data,
-                                          self.xcvr_table_helper.get_intf_tbl(asic_index),
+                                          intf_tbl,
                                           self.xcvr_table_helper.get_dom_tbl(asic_index),
                                           self.xcvr_table_helper.get_dom_threshold_tbl(asic_index),
                                           self.xcvr_table_helper.get_pm_tbl(asic_index),
                                           self.xcvr_table_helper.get_firmware_info_tbl(asic_index))
-            delete_port_from_status_table_sw(logical_port_name, self.xcvr_table_helper.get_status_tbl(asic_index))
-            delete_port_from_status_table_hw(logical_port_name, port_mapping_data, self.xcvr_table_helper.get_status_tbl(asic_index))
 
+            if not is_warm_fast_reboot:
+                delete_port_from_status_table_sw(logical_port_name, self.xcvr_table_helper.get_status_tbl(asic_index))
+                delete_port_from_status_table_hw(logical_port_name, port_mapping_data, self.xcvr_table_helper.get_status_tbl(asic_index))
 
         del globals()['platform_chassis']
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Save TRANSCEIVER_INFO/STATUS tables on warm/fast-reboot.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

The information in TRANSCEIVER_INFO/STATUS tables is required for orchagent to set SAI_PORT_ATTR_HOST_TX_SIGNAL_ENABLE=true on system startup.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Run fast/warm-reboot.

#### Additional Information (Optional)
