### PR TITLE
[ycabled] [active-standby] add changes for correcting telemetry values for 'active-standby' when the cable is present but vendor name and part number is not recognized

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -1136,6 +1136,8 @@ class TestYCableScript(object):
         static_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "STATIC_TABLE")
         static_tbl[asic_index].get.return_value = (status, fvs)
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "STATIC_TABLE")
 
         rc = create_tables_and_insert_mux_unknown_entries(
             state_db, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name)
@@ -1611,6 +1613,8 @@ class TestYCableScript(object):
             test_db[asic_index], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
         static_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], MUX_CABLE_STATIC_INFO_TABLE)
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "MUX_CABLE_INFO")
 
         port_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "PORT_INFO_TABLE")

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -1151,6 +1151,7 @@ def create_tables_and_insert_mux_unknown_entries(state_db, y_cable_tbl, static_t
     # fill the newly found entry
     read_y_cable_and_update_statedb_port_tbl(
         logical_port_name, y_cable_tbl[asic_index])
+    post_port_mux_info_to_db(logical_port_name,  mux_tbl, asic_index, y_cable_tbl, 'pseudo-cable')
     post_port_mux_static_info_to_db(
         logical_port_name, static_tbl[asic_index], y_cable_tbl)
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

#### Description

This change creates unknown, N/A values for active-standby cable type
Since streaming telemetry today looks for active-standby for posting values to State DB, this change introduces a one time posting of fields with 'pseudo-cable' type when cable port instances  are attempted to be created by ycabled.

For almost all cases this was covered except when vendor name and part number does not match to our mapping logic today 
```
mapping = {
    "credo": {
        "cacl05321p2pa1ms": "credo.y_cable_credo",
        "cacl1x321p2pa1ms": "credo.y_cable_credo",
        "cacl15321p2pa1ms": "credo.y_cable_credo",
        "cacl2x321p2pa1ms": "credo.y_cable_credo",

        "cac105321p2pa2ms": "credo.y_cable_credo",
        "cac11x321p2pa2ms": "credo.y_cable_credo",
        "cac115321p2pa2ms": "credo.y_cable_credo",
        "cac12x321p2pa2ms": "credo.y_cable_credo"
    },
    "molex": {
        "2164351001": "broadcom.y_cable_broadcom",
        "2164351002": "broadcom.y_cable_broadcom",
        "2164351003": "broadcom.y_cable_broadcom",
        "2164351004": "broadcom.y_cable_broadcom",
        "2164352001": "broadcom.y_cable_broadcom",
        "2164352002": "broadcom.y_cable_broadcom",
        "2164352003": "broadcom.y_cable_broadcom",
        "2164352004": "broadcom.y_cable_broadcom",
        "2164352501": "broadcom.y_cable_broadcom",
        "2164352502": "broadcom.y_cable_broadcom",
        "2164352503": "broadcom.y_cable_broadcom",
        "2164352504": "broadcom.y_cable_broadcom"
    },
    "microsoft": {
        "simulated": "microsoft.y_cable_simulated"
    }
}
```

This change should cover such an issue 

as their will be a one-time post of such values 
```
vdahiya@sonic:~$ redis-cli -n 6 hgetall "MUX_CABLE_INFO|Ethernet48"
 1) "tor_active"
 2) "unknown"
 3) "time_post"
 4) "2024-Apr-29 22:45:07.495362"
 5) "mux_direction"
 6) "unknown"
 7) "manual_switch_count"
 8) "N/A"
 9) "auto_switch_count"
10) "N/A"
11) "link_status_self"
12) "unknown"
13) "link_status_peer"
14) "unknown"
15) "link_status_nic"
16) "unknown"
17) "self_eye_height_lane1"
18) "N/A"
```
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?

UT and posting the changes on test device.
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
