### PR TITLE
[chassis][midplane] Modify the chassisd to log expected/unexpected midplane connectivity messages

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -71,6 +71,7 @@ CHASSIS_MODULE_INFO_HOSTNAME_FIELD = 'hostname'
 
 CHASSIS_MODULE_REBOOT_INFO_TABLE = 'CHASSIS_MODULE_REBOOT_INFO_TABLE'
 CHASSIS_MODULE_REBOOT_TIMESTAMP_FIELD = 'timestamp'
+CHASSIS_MODULE_REBOOT_REBOOT_FIELD = 'reboot'
 REBOOT_SYSTEM_UP_WARNING_TIMEOUT = 180 
 
 CHASSIS_INFO_UPDATE_PERIOD_SECS = 10
@@ -370,7 +371,9 @@ class ModuleUpdater(logger.Logger):
     def is_module_reboot_expected(self, key):
         fvs = self.module_reboot_table.get(key)
         if isinstance(fvs, list) and fvs[0] is True:
-            return True
+            fvs = dict(fvs[-1])
+            if fvs[CHASSIS_MODULE_REBOOT_REBOOT_FIELD] == "expected":
+                return True
         return False
     
     def module_reboot_set_time(self, key):
@@ -435,7 +438,7 @@ class ModuleUpdater(logger.Logger):
                     self.module_reboot_table._del(module_key)
             elif midplane_access is False and current_midplane_state == 'False':
                 if self.is_module_reboot_system_up_expired(module_key):
-                    self.log_warning("Unexpected: Module {} lost midplane connectivity for more than 3 minutes".format(module_key))
+                    self.log_warning("Unexpected: Module {} midplane connectivity is not restored in 3 minutes".format(module_key))
                     
             # Update db with midplane information
             fvs = swsscommon.FieldValuePairs([(CHASSIS_MIDPLANE_INFO_IP_FIELD, midplane_ip),

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -72,7 +72,8 @@ CHASSIS_MODULE_INFO_HOSTNAME_FIELD = 'hostname'
 CHASSIS_MODULE_REBOOT_INFO_TABLE = 'CHASSIS_MODULE_REBOOT_INFO_TABLE'
 CHASSIS_MODULE_REBOOT_TIMESTAMP_FIELD = 'timestamp'
 CHASSIS_MODULE_REBOOT_REBOOT_FIELD = 'reboot'
-REBOOT_SYSTEM_UP_WARNING_TIMEOUT = 180 
+DEFAULT_LINECARD_REBOOT_TIMEOUT = 180
+PLATFORM_ENV_CONF_FILE = "/usr/share/sonic/platform/platform_env.conf"
 
 CHASSIS_INFO_UPDATE_PERIOD_SECS = 10
 CHASSIS_DB_CLEANUP_MODULE_DOWN_PERIOD = 30 # Minutes
@@ -207,6 +208,14 @@ class ModuleUpdater(logger.Logger):
         self.down_modules = {}
         self.chassis_app_db_clean_sha = None
 
+        self.linecard_reboot_timeout = DEFAULT_LINECARD_REBOOT_TIMEOUT
+        if os.path.isfile(PLATFORM_ENV_CONF_FILE):
+            with open(PLATFORM_ENV_CONF_FILE, 'r') as file:
+                for line in file:
+                    field = line.split('=')[0].strip()
+                    if field == "linecard_reboot_timeout":
+                        self.linecard_reboot_timeout = int(line.split('=')[1].strip())
+                        
         self.midplane_initialized = try_get(chassis.init_midplane_switch, default=False)
         if not self.midplane_initialized:
             self.log_error("Chassisd midplane intialization failed")
@@ -388,7 +397,7 @@ class ModuleUpdater(logger.Logger):
             if CHASSIS_MODULE_REBOOT_TIMESTAMP_FIELD in fvs.keys():
                 timestamp= float(fvs[CHASSIS_MODULE_REBOOT_TIMESTAMP_FIELD])
                 time_now = time.time()
-                if time_now - timestamp >= REBOOT_SYSTEM_UP_WARNING_TIMEOUT:
+                if time_now - timestamp >= self.linecard_reboot_timeout:
                     self.module_reboot_table._del(key)
                     return True
         return False
@@ -438,7 +447,7 @@ class ModuleUpdater(logger.Logger):
                     self.module_reboot_table._del(module_key)
             elif midplane_access is False and current_midplane_state == 'False':
                 if self.is_module_reboot_system_up_expired(module_key):
-                    self.log_warning("Unexpected: Module {} midplane connectivity is not restored in 3 minutes".format(module_key))
+                    self.log_warning("Unexpected: Module {} midplane connectivity is not restored in {} seconds".format(module_key, self.linecard_reboot_timeout))
                     
             # Update db with midplane information
             fvs = swsscommon.FieldValuePairs([(CHASSIS_MIDPLANE_INFO_IP_FIELD, midplane_ip),

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -69,6 +69,10 @@ CHASSIS_MIDPLANE_INFO_ACCESS_FIELD = 'access'
 CHASSIS_MODULE_HOSTNAME_TABLE = 'CHASSIS_MODULE_TABLE'
 CHASSIS_MODULE_INFO_HOSTNAME_FIELD = 'hostname'
 
+CHASSIS_MODULE_REBOOT_INFO_TABLE = 'CHASSIS_MODULE_REBOOT_INFO_TABLE'
+CHASSIS_MODULE_REBOOT_TIMESTAMP_FIELD = 'timestamp'
+REBOOT_SYSTEM_UP_WARNING_TIMEOUT = 180 
+
 CHASSIS_INFO_UPDATE_PERIOD_SECS = 10
 CHASSIS_DB_CLEANUP_MODULE_DOWN_PERIOD = 30 # Minutes
 
@@ -198,6 +202,7 @@ class ModuleUpdater(logger.Logger):
                                             CHASSIS_ASIC_INFO_TABLE)
 
         self.hostname_table = swsscommon.Table(self.chassis_state_db, CHASSIS_MODULE_HOSTNAME_TABLE)
+        self.module_reboot_table = swsscommon.Table(self.chassis_state_db, CHASSIS_MODULE_REBOOT_INFO_TABLE) 
         self.down_modules = {}
         self.chassis_app_db_clean_sha = None
 
@@ -362,6 +367,29 @@ class ModuleUpdater(logger.Logger):
         else:
             return False
 
+    def is_module_reboot_expected(self, key):
+        fvs = self.module_reboot_table.get(key)
+        if isinstance(fvs, list) and fvs[0] is True:
+            return True
+        return False
+    
+    def module_reboot_set_time(self, key):
+        time_now = time.time()
+        fvs = swsscommon.FieldValuePairs([(CHASSIS_MODULE_REBOOT_TIMESTAMP_FIELD, str(time_now))])
+        self.module_reboot_table.set(key,fvs)
+        
+    def is_module_reboot_system_up_expired(self, key):
+        fvs = self.module_reboot_table.get(key)
+        if isinstance(fvs, list) and fvs[0] is True:
+            fvs = dict(fvs[-1])
+            if CHASSIS_MODULE_REBOOT_TIMESTAMP_FIELD in fvs.keys():
+                timestamp= float(fvs[CHASSIS_MODULE_REBOOT_TIMESTAMP_FIELD])
+                time_now = time.time()
+                if time_now - timestamp >= REBOOT_SYSTEM_UP_WARNING_TIMEOUT:
+                    self.module_reboot_table._del(key)
+                    return True
+        return False
+    
     def check_midplane_reachability(self):
         if not self.midplane_initialized:
             return
@@ -395,10 +423,20 @@ class ModuleUpdater(logger.Logger):
                 current_midplane_state = fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
             if midplane_access is False and current_midplane_state == 'True':
-                self.log_warning("Module {} lost midplane connectivity".format(module_key))
+                if self.is_module_reboot_expected(module_key):
+                    self.module_reboot_set_time(module_key)
+                    self.log_warning("Expected: Module {} lost midplane connectivity".format(module_key))
+                else:
+                    self.log_warning("Unexpected: Module {} lost midplane connectivity".format(module_key))
             elif midplane_access is True and current_midplane_state == 'False':
                 self.log_notice("Module {} midplane connectivity is up".format(module_key))
-
+                # clean up the reboot_info_table
+                if self.module_reboot_table.get(module_key) is not None:
+                    self.module_reboot_table._del(module_key)
+            elif midplane_access is False and current_midplane_state == 'False':
+                if self.is_module_reboot_system_up_expired(module_key):
+                    self.log_warning("Unexpected: Module {} lost midplane connectivity for more than 3 minutes".format(module_key))
+                    
             # Update db with midplane information
             fvs = swsscommon.FieldValuePairs([(CHASSIS_MIDPLANE_INFO_IP_FIELD, midplane_ip),
                                               (CHASSIS_MIDPLANE_INFO_ACCESS_FIELD, str(midplane_access))])


### PR DESCRIPTION
Modified the SUP chassisd check_midplane_reachability() function to use the CHASSIS_MODULE_REBOOT_INFO_TABLE data (which is set by Linecard "sudo reboot" command)  log expected or unexpected  module lost midplane connectivity.  This address issue  https://github.com/sonic-net/sonic-buildimage/issues/18540
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Add a new method is_module_reboot_expected() to check if CHASSIS_MODULE_REBOOT_INFO_TABLE|LINECARD# entry exists in CHASSIS_STATE_DB when a linecard is not reachable from SUP.  If entry exists, it is expected reboot.  check_midplane_reachability() will log  "pmon#chassisd: Expected: Module LINE-CARD1 lost midplane connectivity".  If entry doesn't exist, it will log "pmon#chassisd: Unexpected: Module LINE-CARD1 lost midplane connectivity".  The  CHASSIS_MODULE_REBOOT_INFO_TABLE|LINECARD# entry created and insert by linecard "sudo reboot" command by PR.  It means that Users issue a linecard reboot, "lost midplane connectivity" is expected.  Otherwise, such a linecard crash or missing heartbeat reboot, etc is unexpected.
Add new method module_reboot_set_time() and is_module_reboot_system_up_expired() to check if an expected reboot of linecard is not able to be up and detected by SUP in 3 minutes, check_midplane_reachabikity() will log  "pmon#chassisd: Unexpected: Module LINE-CARD1 lost midplane connectivity". This provides the log message to the monitoring tool to take any further action.
This PR is required and associated with the following PRs
PR https://github.com/sonic-net/sonic-buildimage/pull/18805
https://github.com/sonic-net/sonic-utilities/pull/3292
https://github.com/sonic-net/sonic-platform-daemons/pull/480
https://github.com/sonic-net/sonic-buildimage/pull/18862

<!--
     Describe your changes in detail
-->

#### Motivation and Context
This provides a proper log message whether a module "lost midplane connectivity" is expected or not.  This provides an efficient information log to the monitoring tool to take any further action. Fixes https://github.com/sonic-net/sonic-buildimage/issues/18540
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
This PR requires PRhttps://github.com/sonic-net/sonic-utilities/pull/3292 and  to work with
1) Test expected log. Use the CLI command "sudo reboot" to reboot  a linecard, then check the syslog on Supervisor.  The below message is logged
```
Apr 25 19:44:40.818378 ixre-cpm-chassis7 WARNING pmon#chassisd: Expected: Module LINE-CARD0 lost midplane connectivity
``` 
2. Test unepxpected log.  Using "sudo /sbin/reboot" or reboot a linecard with any crash method, then ccheck the syslog on Supervusor. The below message is logged.
```
Apr 25 19:50:22.549416 ixre-cpm-chassis7 WARNING pmon#chassisd: Unexpected: Module LINE-CARD0 lost midplane connectivity
``` 
3. Test the expexcted reboot with timeout case.  Use the CLI command "sudo reboot" on linecard. and keep it down for more than 4 minutes. The below messages are logged. 
```
Apr 25 01:25:53.877143 ixre-cpm-chassis7 WARNING sr_device_mgr: Unable to reach slot 1 (Linecard) via Midplane
Apr 25 01:25:58.402511 ixre-cpm-chassis7 WARNING pmon#chassisd: Module LINE-CARD0 went off-line!
Apr 25 01:26:01.658959 ixre-cpm-chassis7 WARNING pmon#chassisd: Expected: Module LINE-CARD0 lost midplane connectivity.
( 3 minutes after the first log)
Apr 25 01:29:10.259527 ixre-cpm-chassis7 WARNING pmon#chassisd: Unexpected: Module LINE-CARD0 midplane connectivity is not restored in 180 seconds
```
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
This PR needs to be back ported to branchs:
[x]  202205