### PR TITLE
Handling exceptions in CMIS SM to prevent xcvrd crash

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -121,7 +121,12 @@ helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 #
 # Helper functions =============================================================
 #
-
+def log_exception_traceback():
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    msg = traceback.format_exception(exc_type, exc_value, exc_traceback)
+    for tb_line in msg:
+        for tb_line_split in tb_line.splitlines():
+            helper_logger.log_error(tb_line_split)
 
 def is_cmis_api(api):
    return isinstance(api, CmisApi)
@@ -1359,6 +1364,11 @@ class CmisManagerTask(threading.Thread):
                     # Skip if these essential routines are not available
                     self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
                     continue
+                except Exception as e:
+                    self.log_error("{}: Exception in xcvr api: {}".format(lport, e))
+                    log_exception_traceback()
+                    self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
+                    continue
 
                 # CMIS expiration and retries
                 #
@@ -1587,8 +1597,9 @@ class CmisManagerTask(threading.Thread):
                         self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
                         self.post_port_active_apsel_to_db(api, lport, host_lanes_mask)
 
-                except (NotImplementedError, AttributeError) as e:
+                except Exception as e:
                     self.log_error("{}: internal errors due to {}".format(lport, e))
+                    log_exception_traceback()
                     self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
 
         self.log_notice("Stopped")
@@ -1606,11 +1617,7 @@ class CmisManagerTask(threading.Thread):
             self.task_worker()
         except Exception as e:
             helper_logger.log_error("Exception occured at {} thread due to {}".format(threading.current_thread().getName(), repr(e)))
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            msg = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            for tb_line in msg:
-                for tb_line_split in tb_line.splitlines():
-                    helper_logger.log_error(tb_line_split)
+            log_exception_traceback()
             self.exc = e
             self.main_thread_stop_event.set()
 
@@ -1770,11 +1777,7 @@ class DomInfoUpdateTask(threading.Thread):
             self.task_worker()
         except Exception as e:
             helper_logger.log_error("Exception occured at {} thread due to {}".format(threading.current_thread().getName(), repr(e)))
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            msg = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            for tb_line in msg:
-                for tb_line_split in tb_line.splitlines():
-                    helper_logger.log_error(tb_line_split)
+            log_exception_traceback()
             self.exc = e
             self.main_thread_stop_event.set()
 
@@ -2195,11 +2198,7 @@ class SfpStateUpdateTask(threading.Thread):
             self.task_worker(self.task_stopping_event, self.sfp_error_event)
         except Exception as e:
             helper_logger.log_error("Exception occured at {} thread due to {}".format(threading.current_thread().getName(), repr(e)))
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            msg = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            for tb_line in msg:
-                for tb_line_split in tb_line.splitlines():
-                    helper_logger.log_error(tb_line_split)
+            log_exception_traceback()
             self.exc = e
             self.main_thread_stop_event.set()
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Currently, the CmisManagerTask thread crashes upon encountering an exception which causes the entire XCVRD process to restart. The CmisManagerTask thread crash scenarios are more often seen during instances of failure to read EEPROM of the transceivers.

Crash snippet
```
Apr  1 13:39:29.652330 STG01-0101-0200-02T2-lc01 ERR pmon#: Exception occured at CmisManagerTask thread due to TypeError("'NoneType' object is not subscriptable")
Apr  1 13:39:29.654469 STG01-0101-0200-02T2-lc01 ERR pmon#: Traceback (most recent call last):
Apr  1 13:39:29.654498 STG01-0101-0200-02T2-lc01 ERR pmon#:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1693, in run
Apr  1 13:39:29.654498 STG01-0101-0200-02T2-lc01 ERR pmon#:     self.task_worker()
Apr  1 13:39:29.654498 STG01-0101-0200-02T2-lc01 ERR pmon#:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1655, in task_worker
Apr  1 13:39:29.654518 STG01-0101-0200-02T2-lc01 ERR pmon#:     if not self.check_datapath_state(api, host_lanes_mask, ['DataPathInitialized']):
Apr  1 13:39:29.654531 STG01-0101-0200-02T2-lc01 ERR pmon#:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1263, in check_datapath_state
Apr  1 13:39:29.654531 STG01-0101-0200-02T2-lc01 ERR pmon#:     if dpstate[key] not in states:
Apr  1 13:39:29.654569 STG01-0101-0200-02T2-lc01 ERR pmon#: TypeError: 'NoneType' object is not subscriptable
Apr  1 13:39:29.654752 STG01-0101-0200-02T2-lc01 ERR pmon#: Xcvrd: exception found at child thread CmisManagerTask due to TypeError("'NoneType' object is not subscriptable")
Apr  1 13:39:29.654752 STG01-0101-0200-02T2-lc01 ERR pmon#: Exiting main loop as child thread raised exception!
```
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
In order to avoid restarting of XCVRD triggered due to CmisManagerTask thread crash, this PR will ensure to move the CMIS SM to `CMIS_STATE_FAILED` state for the corresponding ports which have generated an exception. This will also help in ensuring that if module EEPROM access fails for 1 or more ports, the corresponding port will transition to `CMIS_STATE_FAILED` instead.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
An exception was manually generated while CMIS SM was in `CMIS_STATE_INSERTED` and it was ensured that XCVRD did not crash.
```
Apr 30 08:58:01.283582 sonic NOTICE pmon#xcvrd[16173]: CMIS: Ethernet0: 400G, lanemask=0xff, state=INSERTED, appl 1 host_lane_count 8 retries=0
Apr 30 08:58:01.283582 sonic ERR pmon#xcvrd[16173]: CMIS: Ethernet0: internal errors due to 'PATELMI: Simulated KeyError!!!'
Apr 30 08:58:01.285296 sonic ERR pmon#xcvrd[16173]: Traceback (most recent call last):
Apr 30 08:58:01.285296 sonic ERR pmon#xcvrd[16173]:   File "/usr/local/lib/python3.11/dist-packages/xcvrd/xcvrd.py", line 1404, in task_worker
Apr 30 08:58:01.285296 sonic ERR pmon#xcvrd[16173]:     raise KeyError("PATELMI: Simulated KeyError!!!")
Apr 30 08:58:01.285296 sonic ERR pmon#xcvrd[16173]: KeyError: 'PATELMI: Simulated KeyError!!!'

root@sonic:/home/admin# redis-cli -n 6 hget "TRANSCEIVER_STATUS|Ethernet0" cmis_state
"FAILED"
root@sonic:/home/admin# 
```
Also, CMIS initialization was successful on the same port after the exception was not seen any more.

#### Additional Information (Optional)
MSFT ADO - 27441561