### PR TITLE
add run-time psu sensors updating support

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -12,6 +12,8 @@
 import signal
 import sys
 import threading
+import os
+import subprocess
 from datetime import datetime
 
 from sonic_platform.psu import Psu
@@ -279,6 +281,7 @@ class PsuStatus(object):
     def __init__(self, logger, psu, psu_index):
         self.psu = psu
         self.psu_index = psu_index
+        self.psu_model = None
         self.presence = True
         self.power_good = True
         self.voltage_good = True
@@ -577,6 +580,15 @@ class DaemonPsud(daemon_base.DaemonBase):
 
         if set_led:
             self._set_psu_led(psu, psu_status)
+
+        if self.first_run and power_good:
+            psu_status.psu_model = psu.get_model()
+        if not self.first_run and os.path.exists('/usr/share/sonic/platform/psu_sensors_conf_updater') and power_good and psu.get_model() != psu_status.psu_model:
+            psu_status.psu_model = psu.get_model()
+            subprocess.run("cp -f /etc/sensors.d/sensors.conf /tmp/sensors.conf.orig", shell=True)
+            subprocess.run("bash -c 'source /usr/share/sonic/platform/psu_sensors_conf_updater && update_psu_sensors_configuration /tmp/sensors.conf.orig'", shell=True)
+            subprocess.run("cp -f /tmp/sensors.conf /etc/sensors.d/", shell=True)
+            subprocess.run("service sensord restart", shell=True)
 
         fvs = swsscommon.FieldValuePairs(
             [(PSU_INFO_MODEL_FIELD, str(try_get(psu.get_model, NOT_AVAILABLE))),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

once the psud detect a psu model changing, it would firstly regenerate sensors.conf and then restart sensord to active the new configuration.

#### Description
<!--
     Describe your changes in detail
-->

This PR is correspond to the https://github.com/sonic-net/sonic-buildimage/pull/18528 to call that script during run-time once a psu changing event had been detected, and relevant sensors configuration would be updated.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
physically changing a psu during run-time and check the sensors command output

#### Additional Information (Optional)
