### PR TITLE
Update for the procedures for insertion/hot swap of Switch Fabric Module (SFM) by using "config chassis modules shutdown/startup" commands

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -533,9 +533,9 @@ class ModuleUpdater(logger.Logger):
             asic = CHASSIS_ASIC+str(asic_id)
 
             # Cleanup the chassis app db entries using lua script
-            redis_cmd = 'redis-cli -h redis_chassis.server -p 6380 -n 12 EVALSHA ' + self.chassis_app_db_clean_sha + ' 0 ' + lc + ' ' + asic
+            redis_cmd = ['redis-cli', '-h', 'redis_chassis.server', '-p', '6380', '-n', '12', 'EVALSHA', self.chassis_app_db_clean_sha, '0', lc, asic]
             try:
-                subp = subprocess.Popen(redis_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+                subp = subprocess.Popen(redis_cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
                 subp.communicate()
                 self.log_notice("Cleaned up chassis app db entries for {}({})/{}".format(module, lc, asic))
             except Exception:

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -90,6 +90,7 @@ INVALID_SLOT = ModuleBase.MODULE_INVALID_SLOT
 INVALID_MODULE_INDEX = -1
 INVALID_IP = '0.0.0.0'
 
+CHASSIS_MODULE_ADMIN_STATUS = 'admin_status'
 MODULE_ADMIN_DOWN = 0
 MODULE_ADMIN_UP = 1
 
@@ -257,8 +258,18 @@ class ModuleUpdater(logger.Logger):
         if isinstance(fvs, list) and fvs[0] is True:
             fvs = dict(fvs[-1])
             return fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
-        return ModuleBase.MODULE_STATUS_EMPTY        
-            
+        return ModuleBase.MODULE_STATUS_EMPTY
+
+    def get_module_admin_status(self, chassis_module_name):
+        config_db = daemon_base.db_connect("CONFIG_DB")
+        vtable = swsscommon.Table(config_db, CHASSIS_CFG_TABLE)
+        fvs = vtable.get(chassis_module_name)
+        if isinstance(fvs, list) and fvs[0] is True:
+            fvs = dict(fvs[-1])
+            return fvs[CHASSIS_MODULE_ADMIN_STATUS]
+        else:
+            return 'up'
+
     def module_db_update(self):
         notOnlineModules = []
 
@@ -317,16 +328,20 @@ class ModuleUpdater(logger.Logger):
                     elif prev_status != ModuleBase.MODULE_STATUS_ONLINE:
                         self.log_notice("Module {} is on-line!".format(key))
 
-                for asic_id, asic in enumerate(module_info_dict[CHASSIS_MODULE_INFO_ASICS]):
-                    asic_global_id, asic_pci_addr = asic
-                    asic_key = "%s%s" % (CHASSIS_ASIC, asic_global_id)
-                    if not self._is_supervisor():
-                        asic_key = "%s|%s" % (key, asic_key)
+                    module_cfg_status = self.get_module_admin_status(key)
 
-                    asic_fvs = swsscommon.FieldValuePairs([(CHASSIS_ASIC_PCI_ADDRESS_FIELD, asic_pci_addr),
-                                                            (CHASSIS_MODULE_INFO_NAME_FIELD, key),
-                                                            (CHASSIS_ASIC_ID_IN_MODULE_FIELD, str(asic_id))])
-                    self.asic_table.set(asic_key, asic_fvs)
+                    #Only populate the related tables when the module configure is up
+                    if module_cfg_status != 'down':
+                        for asic_id, asic in enumerate(module_info_dict[CHASSIS_MODULE_INFO_ASICS]):
+                            asic_global_id, asic_pci_addr = asic
+                            asic_key = "%s%s" % (CHASSIS_ASIC, asic_global_id)
+                            if not self._is_supervisor():
+                                asic_key = "%s|%s" % (key, asic_key)
+
+                            asic_fvs = swsscommon.FieldValuePairs([(CHASSIS_ASIC_PCI_ADDRESS_FIELD, asic_pci_addr),
+                                                                    (CHASSIS_MODULE_INFO_NAME_FIELD, key),
+                                                                    (CHASSIS_ASIC_ID_IN_MODULE_FIELD, str(asic_id))])
+                            self.asic_table.set(asic_key, asic_fvs)
 
         # In line card push the hostname of the module and num_asics to the chassis state db.
         # The hostname is used as key to access chassis app db entries 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For the Nokia SONiC chassis procedures for insertion/hot swap of Switch Fabric Module(SFM), 
the previous solution was using the below commands.
```
sudo nokia_cmd set shutdown-sfm <SFM-Num/Physical-Slot>
```
The below 4 PRs intend to add the below commands for the equivalent operations.
https://github.com/sonic-net/sonic-platform-daemons/pull/491
https://github.com/sonic-net/sonic-utilities/pull/3283
https://github.com/nokia/sonic-platform/pull/6
https://github.com/sonic-net/sonic-buildimage/pull/18938
```
sudo config chassis modules shutdown/startup <module name>
```
The HLD for Shutdown and Startup of the Fabric Module is below:
https://github.com/sonic-net/SONiC/pull/1694

The below PR was replaced.
https://github.com/sonic-net/sonic-buildimage/pull/18578

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. When the cli command "sudo config chassis modules startup/shutdown" runs, it directly calls config/fabric_module_set_admin_status.py to do the related operations.
#### How to verify it


```
The below test was carried out on FABRIC-CARD3 module on the supervisor card.
1. Shutdown
sudo config chassis modules shutdown FABRIC-CARD3

2. Check the status to see if the FABRIC-CARD3 was down.
$ show chassis modules status
        Name             Description    Physical-Slot    Oper-Status    Admin-Status       Serial
------------  ----------------------  ---------------  -------------  --------------  -----------
...
FABRIC-CARD3             Unavailable                4          Empty            down          N/A

sudo tail -f /var/log/syslog | grep "pmon#chassisd:"
May  1 00:07:54.192037 ixre-cpm-chassis15 WARNING pmon#chassisd: Module FABRIC-CARD3 went off-line!
 ...

 
3. Start up the module
sudo config chassis modules startup FABRIC-CARD3


4. Check the status
$ show chassis modules status
        Name             Description    Physical-Slot    Oper-Status    Admin-Status       Serial
------------  ----------------------  ---------------  -------------  --------------  -----------
...
FABRIC-CARD3                    SFM4                4         Online              up  01214400362

sudo tail -f /var/log/syslog | grep "pmon#chassisd:"
May  1 00:26:29.501687 ixre-cpm-chassis15 NOTICE pmon#chassisd: Module FABRIC-CARD3 recovered on-line!


5. To test if the operation is still valid when the system reboot. For example, first shut down, 
then after saving config and reboot, the module should keep shutdown status. 
$ sudo config save
Existing files will be overwritten, continue? [y/N]: y

Then check the status to see if the FABRIC-CARD3 was down.
$ show chassis modules status
        Name             Description    Physical-Slot    Oper-Status    Admin-Status       Serial
------------  ----------------------  ---------------  -------------  --------------  -----------
...
FABRIC-CARD3             Unavailable                4          Empty            down          N/A


```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

