### PR TITLE
Fix for 'log_notifce()' typo in xcvrd.py

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1479,7 +1479,7 @@ class CmisManagerTask(threading.Thread):
                         if True == self.is_appl_reconfigure_required(api, appl):
                             self.log_notice("{}: Decommissioning all lanes/datapaths to default AppSel=0".format(lport))
                             if True != api.decommission_all_datapaths():
-                                self.log_notifce("{}: Failed to default to AppSel=0".format(lport))
+                                self.log_notice("{}: Failed to default to AppSel=0".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
                                 continue
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR fixes the following issue: https://github.com/sonic-net/sonic-buildimage/issues/19116

#### Description
     Typo fix: log_notifce() --> log_notice()


#### Motivation and Context
PR https://github.com/sonic-net/sonic-platform-daemons/pull/459 introduces a typo "log_notifce".
Check line: https://github.com/sonic-net/sonic-platform-daemons/blob/9ffce2036d53571bd23b4a630ac285039e383c4f/sonic-xcvrd/xcvrd/xcvrd.py#L1482.

It causes an exception in cmis task manager which results in port down:

May 27 20:38:17.489639 sonic ERR pmon#xcvrd: CMIS: Ethernet96: internal errors due to 'CmisManagerTask' object has no attribute 'log_notifce'


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
