### PR TITLE
Fix for #19116 [xcvrd] typo "log_notifce" results in port oper down

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1945,11 +1945,12 @@ class TestXcvrdScript(object):
         task.configure_tx_output_power = MagicMock(return_value=1)
         task.configure_laser_frequency = MagicMock(return_value=1)
 
+        # Shouldn't proceed to DP_DEINIT on error
         task.is_appl_reconfigure_required = MagicMock(return_value=True)
         mock_xcvr_api.decommission_all_datapaths = MagicMock(return_value=False)
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
-        assert get_cmis_state_from_state_db('Ethernet1', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet1'))) == CMIS_STATE_FAILED
+        assert not get_cmis_state_from_state_db('Ethernet1', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet1'))) == CMIS_STATE_DP_DEINIT
 
     @pytest.mark.parametrize("lport, expected_dom_polling", [
         ('Ethernet0', 'disabled'),

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1479,7 +1479,7 @@ class CmisManagerTask(threading.Thread):
                         if True == self.is_appl_reconfigure_required(api, appl):
                             self.log_notice("{}: Decommissioning all lanes/datapaths to default AppSel=0".format(lport))
                             if True != api.decommission_all_datapaths():
-                                self.log_notifce("{}: Failed to default to AppSel=0".format(lport))
+                                self.log_notice("{}: Failed to default to AppSel=0".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
                                 continue
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Fix for https://github.com/sonic-net/sonic-buildimage/issues/19116 [xcvrd] typo "log_notifce" results in port oper down

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
