### PR TITLE
Don't process CMIS xcvrs on warm-reboot case

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1423,7 +1423,7 @@ class CmisManagerTask(threading.Thread):
 
                 try:
                     # CMIS state transitions
-                    if state == CMIS_STATE_INSERTED:
+                    if state == CMIS_STATE_INSERTED and not is_warm_reboot_enabled():
                         self.port_dict[lport]['appl'] = get_cmis_application_desired(api, host_lane_count, host_speed)
                         if self.port_dict[lport]['appl'] is None:
                             self.log_error("{}: no suitable app for the port appl {} host_lane_count {} "


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
When warm-reboot happens xcvrd gets started it treats xcvrs as going through an insertion event. In the case of optics who on insertion event might need to be reprogrammed, it will force the TX off and disable them.

On warm-reboot, we don't want to do this - the xcvrs are already programmed correctly and it will impact dataplane traffic.
<!--
     Describe your changes in detail
-->

#### Motivation and Context
Interfaces with cmis optics in breakout configurations would stay down after warm-reboot cases in sonic-mgmt test runs. 
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
I tested this using a sonic-mgmt warm-reboot case where the optics would stay down and fail entire t0 runs. Those tests now pass and the interfaces stay up.

I also checked the flap counters on the peer for those interfaces - the link stayed up and did not flap - showing warm-reboot succeeded as expected.
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
