### PR TITLE
[xcvrd] DPB support on platforms with CmisManagerTask enabled

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -239,6 +239,26 @@ class TestXcvrdThreadException(object):
         assert("sonic-xcvrd/xcvrd/xcvrd.py" in str(trace))
         assert("wait_for_port_config_done" in str(trace))
 
+        port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
+        port_mapping.handle_port_change_event(port_change_event)
+        cmis_manager = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
+        cmis_manager.wait_for_port_config_done = MagicMock() #no-op
+        cmis_manager.update_port_transceiver_status_table_sw_cmis_state = MagicMock(side_effect = NotImplementedError)
+        exception_received = None
+        trace = None
+        try:
+            cmis_manager.start()
+            cmis_manager.join()
+        except Exception as e1:
+            exception_received = e1
+            trace = traceback.format_exc()
+
+        assert not cmis_manager.is_alive()
+        assert(type(exception_received) == NotImplementedError)
+        assert("NotImplementedError" in str(trace) and "effect" in str(trace))
+        assert("sonic-xcvrd/xcvrd/xcvrd.py" in str(trace))
+        assert("update_port_transceiver_status_table_sw_cmis_state" in str(trace))
+
     @patch('xcvrd.xcvrd.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))
     @patch('xcvrd.xcvrd.CmisManagerTask.wait_for_port_config_done', MagicMock())
     @patch('xcvrd.xcvrd.is_fast_reboot_enabled', MagicMock(return_value=(False)))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2167,20 +2167,13 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         # Load new platform api class
         try:
             import sonic_platform.platform
-            import sonic_platform_base.sonic_sfp.sfputilhelper
             platform_chassis = sonic_platform.platform.Platform().get_chassis()
             self.log_info("chassis loaded {}".format(platform_chassis))
-            # we have to make use of sfputil for some features
-            # even though when new platform api is used for all vendors.
-            # in this sense, we treat it as a part of new platform api.
-            # we have already moved sfputil to sonic_platform_base
-            # which is the root of new platform api.
-            platform_sfputil = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper()
         except Exception as e:
             self.log_warning("Failed to load chassis due to {}".format(repr(e)))
 
         # Load platform specific sfputil class
-        if platform_chassis is None or platform_sfputil is None:
+        if platform_chassis is None:
             try:
                 platform_sfputil = self.load_platform_util(PLATFORM_SPECIFIC_MODULE_NAME, PLATFORM_SPECIFIC_CLASS_NAME)
             except Exception as e:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->


#### Description

This commit fixes DPB support with CMIS transceivers.

CmisManagerTask's `port_dict` must be updated according to the port add/remove events.
This commit removes the `port_mapping` field from CmisManagerTask as
`port_mapping` was mostly used just for storing `asic_id` information
and that can be simply done by `port_dict` instead.

Added a helper method `get_asic_id()` method to CmisManagerTask for
getting `asic_id` from `logical_port`.

#### Motivation and Context

fixes https://github.com/sonic-net/sonic-buildimage/issues/18893

#### How Has This Been Tested?

I tested on the VS environment.

#### Additional Information (Optional)
