### PR TITLE
[xcvrd] Fix issue: do not print error log when module support non-ethernet application

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -160,6 +160,7 @@ def get_cmis_application_desired(api, host_lane_count, speed):
         get_interface_speed(app_info.get('host_electrical_interface_id')) == speed):
             return (index & 0xf)
 
+    helper_logger.log_error(f'Failed to get desired application from {appl_dict}')
     return None
 
 
@@ -193,8 +194,7 @@ def get_interface_speed(ifname):
         speed = 10000
     elif '1000BASE' in ifname:
         speed = 1000
-    else:
-        helper_logger.log_error("No interface speed found for: '{}'".format(ifname))
+
     return speed
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
In function `get_interface_speed`, it will log an error if the application name does not contain a valid speed. However, many modules support both ethernet and non-ethernet (e.g. IB) application, non-ethernet application would not contain a valid speed. For such module, the function `get_interface_speed` logs an error to syslog:

```
Jun 12 20:09:57.315556 sonic ERR pmon#xcvrd: No interface speed found for: 'IB HDR (Arch.Spec.Vol.2)'
``` 

Actually, this is not an error because the module will finally find a proper application via the for loop in function `get_cmis_application_desired`

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

Remove the unexpected error log since it could be a false alarm. Also, log the module applications if it cannot find a proper application.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Manual test

#### Additional Information (Optional)
