### PR TITLE
[xcvrd] change log content and log level when application is not found

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -160,7 +160,7 @@ def get_cmis_application_desired(api, host_lane_count, speed):
         get_interface_speed(app_info.get('host_electrical_interface_id')) == speed):
             return (index & 0xf)
 
-    helper_logger.log_error(f'Failed to get desired application from {appl_dict}')
+    helper_logger.log_notice(f'No application found from {appl_dict} with host_lane_count={host_lane_count} speed={speed}')
     return None
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Change log level to notice and add more information when application is not found for a module.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

In existing setups, there might be ports that were set to admin down. Those ports may not have correct speed configuration which would cause error logs when applying media settings:

```
Jun 17 20:27:58.041567 sonic ERR pmon#xcvrd: Failed to get desired application from {1: {'host_electrical_interface_id': 'IB HDR (Arch.Spec.Vol.2)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 17}, 2: {'host_electrical_interface_id': 'IB SDR (Arch.Spec.Vol.2)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 17}, 3: {'host_electrical_interface_id': '200GBASE-CR4 (Clause 136)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 17}, 4: {'host_electrical_interface_id': '100GBASE-CR2 (Clause 136)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 2, 'host_lane_count': 2, 'host_lane_assignment_options': 85}, 5: {'host_electrical_interface_id': '100GBASE-CR4 (Clause 92)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 17}, 6: {'host_electrical_interface_id': '50GBASE-CR2 (Ethernet Technology Consortium) with no FEC', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 2, 'host_lane_count': 2, 'host_lane_assignment_options': 85}, 7: {'host_electrical_interface_id': '50GBASE-CR (Clause 126)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 1, 'host_lane_count': 1, 'host_lane_assignment_options': 255}, 8: {'host_electrical_interface_id': '25GBASE-CR CA-N (Clause 110)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 1, 'host_lane_count': 1, 'host_lane_assignment_options': 255}}
```

So, here is the thing:

1. For media settings, we just print NOTICE log when application is not found so that we don't have to force user to correct port configuration when port is admin down
2. For CMIS state machine, we print NOTICE log here and there is another place which will print ERROR log when application is not found. We will not loss debuggablity.

```
if state == CMIS_STATE_INSERTED:
      self.port_dict[lport]['appl'] = get_cmis_application_desired(api, host_lane_count, host_speed)
      if self.port_dict[lport]['appl'] is None:
          self.log_error("{}: no suitable app for the port appl {} host_lane_count {} "
                          "host_speed {}".format(lport, appl, host_lane_count, host_speed))
```

So, I think it is safe to change the log level to NOTICE

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Manual test

#### Additional Information (Optional)
