### PR TITLE
Time set early issue: When time set early, cannot use non-monotonic c…

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -725,7 +725,7 @@ class ThermalMonitor(ProcessTaskBase):
     # Update elapse threshold. If update used time is larger than the value, generate a warning log.
     UPDATE_ELAPSED_THRESHOLD = 30
 
-    def __init__(self, chassis):
+    def __init__(self, chassis, stop_event):
         """
         Initializer for ThermalMonitor
         :param chassis: Object representing a platform chassis
@@ -740,14 +740,14 @@ class ThermalMonitor(ProcessTaskBase):
         # Set minimum logging level to INFO
         self.logger.set_min_log_priority_info()
 
-        self.fan_updater = FanUpdater(chassis, self.task_stopping_event)
-        self.temperature_updater = TemperatureUpdater(chassis, self.task_stopping_event)
+        self.fan_updater = FanUpdater(chassis, stop_event)
+        self.temperature_updater = TemperatureUpdater(chassis, stop_event)
 
     def main(self):
-        begin = time.time()
+        begin = time.monotonic()
         self.fan_updater.update()
         self.temperature_updater.update()
-        elapsed = time.time() - begin
+        elapsed = time.monotonic() - begin
         if elapsed < self.UPDATE_INTERVAL:
             self.wait_time = self.UPDATE_INTERVAL - elapsed
         else:
@@ -797,7 +797,7 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 
         self.chassis = sonic_platform.platform.Platform().get_chassis()
 
-        self.thermal_monitor = ThermalMonitor(self.chassis)
+        self.thermal_monitor = ThermalMonitor(self.chassis, self.stop_event)
         self.thermal_monitor.task_run()
 
         self.thermal_manager = None
@@ -861,7 +861,7 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
             # We received a fatal signal
             return False
 
-        begin = time.time()
+        begin = time.monotonic()
         try:
             if self.thermal_manager:
                 self.thermal_manager.run_policy(self.chassis)
@@ -869,7 +869,7 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
             self.log_error('Caught exception while running thermal policy - {}'.format(repr(e)))
 
         interval = self.thermal_manager.get_interval() if self.thermal_manager else self.INTERVAL
-        elapsed = time.time() - begin
+        elapsed = time.monotonic() - begin
         if elapsed < interval:
             self.wait_time = interval - elapsed
         else:

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -274,7 +274,7 @@ class TestThermalMonitor(object):
     """
     def test_main(self):
         mock_chassis = MockChassis()
-        thermal_monitor = thermalctld.ThermalMonitor(mock_chassis)
+        thermal_monitor = thermalctld.ThermalMonitor(mock_chassis, multiprocessing.Event())
         thermal_monitor.fan_updater.update = mock.MagicMock()
         thermal_monitor.temperature_updater.update = mock.MagicMock()
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -327,14 +327,14 @@ def _wrapper_is_flat_memory(physical_port):
 def _wrapper_soak_sfp_insert_event(sfp_insert_events, port_dict):
     for key, value in list(port_dict.items()):
         if value == sfp_status_helper.SFP_STATUS_INSERTED:
-            sfp_insert_events[key] = time.time()
+            sfp_insert_events[key] = time.monotonic()
             del port_dict[key]
         elif value == sfp_status_helper.SFP_STATUS_REMOVED:
             if key in sfp_insert_events:
                 del sfp_insert_events[key]
 
     for key, itime in list(sfp_insert_events.items()):
-        if time.time() - itime >= MGMT_INIT_TIME_DELAY_SECS:
+        if time.monotonic() - itime >= MGMT_INIT_TIME_DELAY_SECS:
             port_dict[key] = sfp_status_helper.SFP_STATUS_INSERTED
             del sfp_insert_events[key]
 
@@ -725,7 +725,7 @@ def check_port_in_range(range_str, physical_port):
 
 
 def waiting_time_compensation_with_sleep(time_start, time_to_wait):
-    time_now = time.time()
+    time_now = time.monotonic()
     time_diff = time_now - time_start
     if time_diff < time_to_wait:
         time.sleep(time_to_wait - time_diff)
@@ -2058,7 +2058,7 @@ class SfpStateUpdateTask(threading.Thread):
             # Retry those logical ports whose EEPROM reading failed or timeout when the SFP is inserted
             self.retry_eeprom_reading()
             next_state = state
-            time_start = time.time()
+            time_start = time.monotonic()
             # Ensure not to block for any event if sfp insert event is pending
             if self.sfp_insert_events:
                 timeout = SFP_INSERT_EVENT_POLL_PERIOD_MSECS
@@ -2086,7 +2086,7 @@ class SfpStateUpdateTask(threading.Thread):
                         # So need to calc the time diff,
                         # if time diff less that the pre-defined waiting time,
                         # use sleep() to complete the time.
-                        time_now = time.time()
+                        time_now = time.monotonic()
                         time_diff = time_now - time_start
                         if time_diff < RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000:
                             time.sleep(RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000 - time_diff)
@@ -2361,7 +2361,7 @@ class SfpStateUpdateTask(threading.Thread):
 
         # Retry eeprom with an interval RETRY_EEPROM_READING_INTERVAL. No need to put sleep here
         # because _wrapper_get_transceiver_change_event has a timeout argument.
-        now = time.time()
+        now = time.monotonic()
         if now - self.last_retry_eeprom_time < self.RETRY_EEPROM_READING_INTERVAL:
             return
 


### PR DESCRIPTION
-What I did
    When time set early, cannot use non-monotonic clock. It will make the timer stop. 

-How I did it
    Use monotonic clock to implement thread timer.

-How to verify it
    Set the time earlier and check if it is correct.