### PR TITLE
Initialize application specific fields as 'N/A' in TRANSCEIVER_INFO table

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1667,6 +1667,29 @@ class TestXcvrdScript(object):
         appl = get_cmis_application_desired(mock_xcvr_api, host_lane_count, speed)
         assert task.get_cmis_host_lanes_mask(mock_xcvr_api, appl, host_lane_count, subport) == expected
 
+    @patch('swsscommon.swsscommon.FieldValuePairs')
+    def test_CmisManagerTask_post_port_active_apsel_to_db_error_cases(self, mock_field_value_pairs):
+        mock_xcvr_api = MagicMock()
+        mock_xcvr_api.get_active_apsel_hostlane = MagicMock()
+        mock_xcvr_api.get_application_advertisement = MagicMock()
+
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
+        lport = "Ethernet0"
+        host_lanes_mask = 0xff
+
+        # Case: table does not exist
+        task.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=None)
+        task.post_port_active_apsel_to_db(mock_xcvr_api, lport, host_lanes_mask)
+        assert mock_field_value_pairs.call_count == 0
+
+        # Case: lport is not in the table
+        int_tbl = MagicMock()
+        int_tbl.get = MagicMock(return_value=(False, dict))
+        task.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=int_tbl)
+        task.post_port_active_apsel_to_db(mock_xcvr_api, lport, host_lanes_mask)
+        assert mock_field_value_pairs.call_count == 0
 
     def test_CmisManagerTask_post_port_active_apsel_to_db(self):
         mock_xcvr_api = MagicMock()
@@ -1709,6 +1732,7 @@ class TestXcvrdScript(object):
         ])
 
         int_tbl = Table("STATE_DB", TRANSCEIVER_INFO_TABLE)
+        int_tbl.get = MagicMock(return_value=(True, dict))
 
         port_mapping = PortMapping()
         stop_event = threading.Event()

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1269,7 +1269,7 @@ class CmisManagerTask(threading.Thread):
         asic_index = self.port_mapping.get_asic_id_for_logical_port(lport)
         intf_tbl = self.xcvr_table_helper.get_intf_tbl(asic_index)
         if not intf_tbl:
-            helper_logger.log_warning("Active ApSel db update: intf_tbl not found for {}".format(lport))
+            helper_logger.log_warning("Active ApSel db update: TRANSCEIVER_INFO table not found for {}".format(lport))
             return
         found, _ = intf_tbl.get(lport)
         if not found:
@@ -1501,6 +1501,11 @@ class CmisManagerTask(threading.Thread):
 
                         if not need_update:
                             # No application updates
+                            # As part of xcvrd restart, the TRANSCEIVER_INFO table is deleted and
+                            # created with default value of 'N/A' for all the active apsel fields.
+                            # The below (post_port_active_apsel_to_db) will ensure that the
+                            # active apsel fields are updated correctly in the DB since
+                            # the CMIS state remains unchanged during xcvrd restart
                             self.post_port_active_apsel_to_db(api, lport, host_lanes_mask)
                             self.log_notice("{}: no CMIS application update required...READY".format(lport))
                             self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1269,7 +1269,7 @@ class CmisManagerTask(threading.Thread):
         asic_index = self.port_mapping.get_asic_id_for_logical_port(lport)
         intf_tbl = self.xcvr_table_helper.get_intf_tbl(asic_index)
         if not intf_tbl:
-            self.log_error("Active ApSel db update: intf_tbl not found for {}".format(lport))
+            helper_logger.log_warning("Active ApSel db update: intf_tbl not found for {}".format(lport))
             return
         found, _ = intf_tbl.get(lport)
         if not found:

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1273,7 +1273,7 @@ class CmisManagerTask(threading.Thread):
             return
         found, _ = intf_tbl.get(lport)
         if not found:
-            helper_logger.log_debug("Active ApSel db update: {} not found in INTF_TABLE".format(lport))
+            helper_logger.log_warning("Active ApSel db update: {} not found in INTF_TABLE".format(lport))
             return
         fvs = swsscommon.FieldValuePairs(tuple_list)
         intf_tbl.set(lport, fvs)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -478,30 +478,20 @@ def post_port_sfp_info_to_db(logical_port_name, port_mapping, table, transceiver
                         if 'media_interface_code' in port_info_dict else 'N/A'),
                         ('host_electrical_interface', port_info_dict['host_electrical_interface']
                         if 'host_electrical_interface' in port_info_dict else 'N/A'),
-                        ('host_lane_count', str(port_info_dict['host_lane_count'])
-                        if 'host_lane_count' in port_info_dict else 'N/A'),
-                        ('media_lane_count', str(port_info_dict['media_lane_count'])
-                        if 'media_lane_count' in port_info_dict else 'N/A'),
+                        ('host_lane_count', 'N/A'),
+                        ('media_lane_count', 'N/A'),
                         ('host_lane_assignment_option', str(port_info_dict['host_lane_assignment_option'])
                         if 'host_lane_assignment_option' in port_info_dict else 'N/A'),
                         ('media_lane_assignment_option', str(port_info_dict['media_lane_assignment_option'])
                         if 'media_lane_assignment_option' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane1', str(port_info_dict['active_apsel_hostlane1'])
-                        if 'active_apsel_hostlane1' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane2', str(port_info_dict['active_apsel_hostlane2'])
-                        if 'active_apsel_hostlane2' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane3', str(port_info_dict['active_apsel_hostlane3'])
-                        if 'active_apsel_hostlane3' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane4', str(port_info_dict['active_apsel_hostlane4'])
-                        if 'active_apsel_hostlane4' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane5', str(port_info_dict['active_apsel_hostlane5'])
-                        if 'active_apsel_hostlane5' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane6', str(port_info_dict['active_apsel_hostlane6'])
-                        if 'active_apsel_hostlane6' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane7', str(port_info_dict['active_apsel_hostlane7'])
-                        if 'active_apsel_hostlane7' in port_info_dict else 'N/A'),
-                        ('active_apsel_hostlane8', str(port_info_dict['active_apsel_hostlane8'])
-                        if 'active_apsel_hostlane8' in port_info_dict else 'N/A'),
+                        ('active_apsel_hostlane1', 'N/A'),
+                        ('active_apsel_hostlane2', 'N/A'),
+                        ('active_apsel_hostlane3', 'N/A'),
+                        ('active_apsel_hostlane4', 'N/A'),
+                        ('active_apsel_hostlane5', 'N/A'),
+                        ('active_apsel_hostlane6', 'N/A'),
+                        ('active_apsel_hostlane7', 'N/A'),
+                        ('active_apsel_hostlane8', 'N/A'),
                         ('media_interface_technology', port_info_dict['media_interface_technology']
                         if 'media_interface_technology' in port_info_dict else 'N/A'),
                         ('supported_max_tx_power', str(port_info_dict['supported_max_tx_power'])
@@ -1278,6 +1268,13 @@ class CmisManagerTask(threading.Thread):
 
         asic_index = self.port_mapping.get_asic_id_for_logical_port(lport)
         intf_tbl = self.xcvr_table_helper.get_intf_tbl(asic_index)
+        if not intf_tbl:
+            self.log_error("Active ApSel db update: intf_tbl not found for {}".format(lport))
+            return
+        found, _ = intf_tbl.get(lport)
+        if not found:
+            helper_logger.log_debug("Active ApSel db update: {} not found in INTF_TABLE".format(lport))
+            return
         fvs = swsscommon.FieldValuePairs(tuple_list)
         intf_tbl.set(lport, fvs)
         self.log_notice("{}: updated TRANSCEIVER_INFO_TABLE {}".format(lport, tuple_list))
@@ -1504,6 +1501,7 @@ class CmisManagerTask(threading.Thread):
 
                         if not need_update:
                             # No application updates
+                            self.post_port_active_apsel_to_db(api, lport, host_lanes_mask)
                             self.log_notice("{}: no CMIS application update required...READY".format(lport))
                             self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
                             continue


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
For a given logical port, CmisManagerTask thread updates the application specific fields in TRANSCEIVER_INFO table only for the relevant active lanes for a given subport.
However, the "show interfaces transceiver eeprom PORT_NAME" CLI shows data for all the 8 lanes and not just the active lanes for the given logical port. However, the data of non-active lanes is incorrect. This needs to be corrected.

In the below example, logical ports Ethernet16 through Ethernet22 are subports 1 through subport 4 respectively. Each logical ports has different values of "Active application selected code assigned to host lane" for their corresponding non-active lanes (the corresponding active lanes are populated correctly).
```
admin@th5-sw3:~$ show int trans eeprom -d Ethernet16 | grep code
        Active application selected code assigned to host lane 1: 5
        Active application selected code assigned to host lane 2: 5
        Active application selected code assigned to host lane 3: 1
        Active application selected code assigned to host lane 4: 1
        Active application selected code assigned to host lane 5: 1
        Active application selected code assigned to host lane 6: 1
        Active application selected code assigned to host lane 7: 1
        Active application selected code assigned to host lane 8: 1
admin@th5-sw3:~$ show int trans eeprom -d Ethernet18 | grep code
        Active application selected code assigned to host lane 1: 0
        Active application selected code assigned to host lane 2: 0
        Active application selected code assigned to host lane 3: 5
        Active application selected code assigned to host lane 4: 5
        Active application selected code assigned to host lane 5: 0
        Active application selected code assigned to host lane 6: 0
        Active application selected code assigned to host lane 7: 0
        Active application selected code assigned to host lane 8: 0
admin@th5-sw3:~$ show int trans eeprom -d Ethernet20 | grep code
        Active application selected code assigned to host lane 1: 5
        Active application selected code assigned to host lane 2: 5
        Active application selected code assigned to host lane 3: 5
        Active application selected code assigned to host lane 4: 5
        Active application selected code assigned to host lane 5: 5
        Active application selected code assigned to host lane 6: 5
        Active application selected code assigned to host lane 7: 5
        Active application selected code assigned to host lane 8: 5
admin@th5-sw3:~$ show int trans eeprom -d Ethernet22 | grep code
        Active application selected code assigned to host lane 1: 5
        Active application selected code assigned to host lane 2: 5
        Active application selected code assigned to host lane 3: 5
        Active application selected code assigned to host lane 4: 5
        Active application selected code assigned to host lane 5: 0
        Active application selected code assigned to host lane 6: 0
        Active application selected code assigned to host lane 7: 5
        Active application selected code assigned to host lane 8: 5

admin@th5-sw3:~$
```

MSFT ADO - 28628591

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
1. Initializing the application related data consumed by "show interfaces transceiver eeprom" CLI with "N/A"
2. Ensuring that the active app select relevant fields are updated to the DB in case if CMIS application update is not required.
3. Added check to ensure intf_tbl is present before `TRANSCEIVER_INFO` table is updated with the application specific values. This helps in handling case wherein xcvrd restarts and the the CMIS SM is triggered due to CONFIG_DB update but TRANSCEIVER_INFO table is not yet created by the SfpStateUpdateTask thread or xcvrd main thread with all other fields (such as transceiver type, serial number vendor PN etc).

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
1. Ensured CLI output for all subports after device boot-up
2. Ensured CLI output for all subports after xcvrd restart
3. Ensured CLI output for all subports after performing xcvr OIR

```
root@str3-8111-03:/home/admin# show int transceiver info Ethernet32
Ethernet32: SFP EEPROM detected
        Active Firmware: 94.7.0
        Active application selected code assigned to host lane 1: 3
        Active application selected code assigned to host lane 2: 3
        Active application selected code assigned to host lane 3: 3
        Active application selected code assigned to host lane 4: 3
        Active application selected code assigned to host lane 5: N/A
        Active application selected code assigned to host lane 6: N/A
        Active application selected code assigned to host lane 7: N/A
        Active application selected code assigned to host lane 8: N/A
        Application Advertisement: 800G L C2M (placeholder) - Host Assign (0x1) - Undefined - Media Assign (0x1)
                                   800G S C2M (placeholder) - Host Assign (0x1) - Undefined - Media Assign (0x1)
                                   400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   400GAUI-4-S C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   100GAUI-1-L C2M (Annex 120G) - Host Assign (0xff) - 100G-FR/100GBASE-FR1 (Cl 140) - Media Assign (0xff)
                                   100GAUI-1-S C2M (Annex 120G) - Host Assign (0xff) - 100G-FR/100GBASE-FR1 (Cl 140) - Media Assign (0xff)
        CMIS Rev: 5.0
        Connector: MPO 1x12
        Encoding: N/A
        Extended Identifier: Power Class 8 (17.0W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: 4
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware: 0.0.0
        Length Cable Assembly(m): 0.0
        Media Interface Technology: 1310 nm EML
        Media Lane Count: 4
        Module Hardware Rev: 1.11
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: sm_media_interface
        Supported Max Laser Frequency: N/A
        Supported Max TX Power: N/A
        Supported Min Laser Frequency: N/A
        Supported Min TX Power: N/A
        Vendor Date Code(YYYY-MM-DD Lot): 2022-10-10   
        Vendor Name: VENDOR_A
        Vendor OUI: 11-aa-bb
        Vendor PN: A123456
        Vendor Rev: 2C
        Vendor SN: SN1234     
root@str3-8111-03:/home/admin# show int transceiver info Ethernet36
Ethernet36: SFP EEPROM detected
        Active Firmware: 94.7.0
        Active application selected code assigned to host lane 1: N/A
        Active application selected code assigned to host lane 2: N/A
        Active application selected code assigned to host lane 3: N/A
        Active application selected code assigned to host lane 4: N/A
        Active application selected code assigned to host lane 5: 3
        Active application selected code assigned to host lane 6: 3
        Active application selected code assigned to host lane 7: 3
        Active application selected code assigned to host lane 8: 3
        Application Advertisement: 800G L C2M (placeholder) - Host Assign (0x1) - Undefined - Media Assign (0x1)
                                   800G S C2M (placeholder) - Host Assign (0x1) - Undefined - Media Assign (0x1)
                                   400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   400GAUI-4-S C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   100GAUI-1-L C2M (Annex 120G) - Host Assign (0xff) - 100G-FR/100GBASE-FR1 (Cl 140) - Media Assign (0xff)
                                   100GAUI-1-S C2M (Annex 120G) - Host Assign (0xff) - 100G-FR/100GBASE-FR1 (Cl 140) - Media Assign (0xff)
        CMIS Rev: 5.0
        Connector: MPO 1x12
        Encoding: N/A
        Extended Identifier: Power Class 8 (17.0W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: 4
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware: 0.0.0
        Length Cable Assembly(m): 0.0
        Media Interface Technology: 1310 nm EML
        Media Lane Count: 4
        Module Hardware Rev: 1.11
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: sm_media_interface
        Supported Max Laser Frequency: N/A
        Supported Max TX Power: N/A
        Supported Min Laser Frequency: N/A
        Supported Min TX Power: N/A
        Vendor Date Code(YYYY-MM-DD Lot): 2022-10-10   
        Vendor Name: VENDOR_A
        Vendor OUI: 11-aa-bb
        Vendor PN: A123456
        Vendor Rev: 2C
        Vendor SN: SN1234     
root@str3-8111-03:/home/admin# 
```
#### Additional Information (Optional)
