### PR TITLE
[xcvrd] Fix SfpStateUpdateTask crash for RJ45 cable type

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2874,6 +2874,15 @@ class TestXcvrdScript(object):
         mock_chassis.get_sfp = MagicMock(side_effect=NotImplementedError)
         assert not _wrapper_is_flat_memory(1)
 
+    @patch('xcvrd.xcvrd.platform_chassis')
+    def test_wrapper_is_flat_memory_no_xcvr_api(self, mock_chassis):
+        mock_object = MagicMock()
+        mock_object.get_xcvr_api = MagicMock(return_value=None)
+        mock_chassis.get_sfp = MagicMock(return_value=mock_object)
+
+        from xcvrd.xcvrd import _wrapper_is_flat_memory
+        assert _wrapper_is_flat_memory(1) == True
+
     def test_check_port_in_range(self):
         range_str = '1 - 32'
         physical_port = 1

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -318,6 +318,8 @@ def _wrapper_is_flat_memory(physical_port):
         try:
             sfp = platform_chassis.get_sfp(physical_port)
             api = sfp.get_xcvr_api()
+            if not api:
+                return True
             return api.is_flat_memory()
         except NotImplementedError:
             pass


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Fix https://github.com/sonic-net/sonic-buildimage/issues/19427

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
