### PR TITLE
Remove redundant xcvr_table_helper init during CmisManagerTask init

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -204,6 +204,7 @@ class TestXcvrdThreadException(object):
         task.get_host_tx_status = MagicMock(return_value='true')
         task.get_port_admin_status = MagicMock(return_value='up')
         task.get_cfg_port_tbl = MagicMock()
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl.return_value = mock_get_status_tbl
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_SET,
                                             {'speed':'400000', 'lanes':'1,2,3,4,5,6,7,8'})
@@ -1460,6 +1461,7 @@ class TestXcvrdScript(object):
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_SET)
         task.on_port_update_event(port_change_event)
 
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl = MagicMock(return_value=None)
         task.update_port_transceiver_status_table_sw_cmis_state("Ethernet0", CMIS_STATE_INSERTED)
 
@@ -1505,6 +1507,7 @@ class TestXcvrdScript(object):
         cfg_port_tbl = MagicMock()
         cfg_port_tbl.get = MagicMock(return_value=(True, (('laser_freq', 193100),)))
         mock_table_helper.get_cfg_port_tbl = MagicMock(return_value=cfg_port_tbl)
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_cfg_port_tbl = mock_table_helper.get_cfg_port_tbl
         assert task.get_configured_laser_freq_from_db('Ethernet0') == 193100
 
@@ -1516,6 +1519,7 @@ class TestXcvrdScript(object):
         cfg_port_tbl = MagicMock()
         cfg_port_tbl.get = MagicMock(return_value=(True, (('tx_power', -10),)))
         mock_table_helper.get_cfg_port_tbl = MagicMock(return_value=cfg_port_tbl)
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_cfg_port_tbl = mock_table_helper.get_cfg_port_tbl
         assert task.get_configured_tx_power_from_db('Ethernet0') == -10
 
@@ -1690,6 +1694,7 @@ class TestXcvrdScript(object):
         host_lanes_mask = 0xff
 
         # Case: table does not exist
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=None)
         task.post_port_active_apsel_to_db(mock_xcvr_api, lport, host_lanes_mask)
         assert mock_field_value_pairs.call_count == 0
@@ -1747,6 +1752,7 @@ class TestXcvrdScript(object):
         port_mapping = PortMapping()
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=int_tbl)
 
         # case: partial lanes update
@@ -1893,6 +1899,7 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
         task.port_mapping.logical_port_list = ['Ethernet0']
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl.return_value = mock_get_status_tbl
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
@@ -1959,6 +1966,7 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
         task.port_mapping.logical_port_list = ['Ethernet1']
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl.return_value = mock_get_status_tbl
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
@@ -2095,6 +2103,7 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
         task.port_mapping.logical_port_list = ['Ethernet0']
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl.return_value = mock_get_status_tbl
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
@@ -2230,6 +2239,7 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
         task.port_mapping.logical_port_list = ['Ethernet0']
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl.return_value = mock_get_status_tbl
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -821,7 +821,6 @@ class CmisManagerTask(threading.Thread):
         self.main_thread_stop_event = main_thread_stop_event
         self.port_dict = {}
         self.port_mapping = copy.deepcopy(port_mapping)
-        self.xcvr_table_helper = XcvrTableHelper(namespaces)
         self.isPortInitDone = False
         self.isPortConfigDone = False
         self.skip_cmis_mgr = skip_cmis_mgr


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
During XCVRD boot-up, following messages are seen
```
/var/log/syslog.95.gz:Jun 28 09:59:05.175489 svcstr-7050-acs-2 NOTICE pmon#xcvrd[30]: :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: STATE_DB
/var/log/syslog.95.gz:Jun 28 09:59:05.175489 svcstr-7050-acs-2 NOTICE pmon#xcvrd[30]: message repeated 3 times: [ :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: STATE_DB]
/var/log/syslog.95.gz:Jun 28 09:59:05.175489 svcstr-7050-acs-2 NOTICE pmon#xcvrd[30]: :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: APPL_DB
/var/log/syslog.95.gz:Jun 28 09:59:05.175489 svcstr-7050-acs-2 NOTICE pmon#xcvrd[30]: :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: CONFIG_DB
/var/log/syslog.95.gz:Jun 28 09:59:05.175489 svcstr-7050-acs-2 NOTICE pmon#xcvrd[30]: :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: STATE_DB
```

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The above messages are seen since the already established connections to redis-db from `xcvrd` main thread are closed by `CmisManagerTask` thread. Following is the sequence

1. In the context of `xcvrd` main thread, the `CmisManagerTask.xcvr_table_helper` is initialized [here](https://github.com/sonic-net/sonic-platform-daemons/blob/d6a4635fb9f8c84d671179a438c2807c0f34bb75/sonic-xcvrd/xcvrd/xcvrd.py#L824). This initiates connections to redis-db.
2. Once the `CmisManagerTask` thread is spawned, the previously established connections from the `xcvrd` main thread to redis-db are closed by `CmisManagerTask` thread. Also, new connections are initiated in context of `CmisManagerTask` thread through [this](https://github.com/sonic-net/sonic-platform-daemons/blob/d6a4635fb9f8c84d671179a438c2807c0f34bb75/sonic-xcvrd/xcvrd/xcvrd.py#L1306). This causes the messages to appear.

In order to fix the current issue, the XcvrTableHelper instantiation from `CmisManagerTask.__init__` has now been removed since the instantiation is already being done as part of `task_worker` function in the context of `CmisManagerTask` thread.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Ensured that the messages are not seen any more during `xcvrd` boot-up.
Also, ensured that the CmisManagerTask thread is running without any crashes. Also, issued shut/no shut on a port to ensure that `CmisManagerTask` and `xcvrd` are stable.

#### Additional Information (Optional)
MSFT ADO - 28645242