### PR TITLE
[xcvrd] Add to support MEDIA_LANE_SPEED_KEY in media_settings.json

### DIFF
--- a/sonic-xcvrd/tests/media_settings_with_media_lane_speed_key_format.json
+++ b/sonic-xcvrd/tests/media_settings_with_media_lane_speed_key_format.json
@@ -1,0 +1,54 @@
+{
+    "GLOBAL_MEDIA_SETTINGS": {
+        "1-32": {
+           "10000,CR":{
+                "preemphasis": {
+                    "lane0":"0x16440A",
+                    "lane1":"0x16440A",
+                    "lane2":"0x16440A",
+                    "lane3":"0x16440A"
+                }
+            },
+            "25000,CR":{
+                "preemphasis": {
+                    "lane0":"0x16440B",
+                    "lane1":"0x16440B",
+                    "lane2":"0x16440B",
+                    "lane3":"0x16440B"
+                }
+            },
+            "50000,CR":{
+                "preemphasis": {
+                    "lane0":"0x16440C",
+                    "lane1":"0x16440C",
+                    "lane2":"0x16440C",
+                    "lane3":"0x16440C"
+                }
+            },
+            "10000":{
+                "preemphasis": {
+                    "lane0":"0x1A400A",
+                    "lane1":"0x1A400A",
+                    "lane2":"0x1A400A",
+                    "lane3":"0x1A400A"
+                }
+            },
+            "25000":{
+                "preemphasis": {
+                    "lane0":"0x1A400B",
+                    "lane1":"0x1A400B",
+                    "lane2":"0x1A400B",
+                    "lane3":"0x1A400B"
+                }
+            },
+            "50000":{
+                "preemphasis": {
+                    "lane0":"0x1A400C",
+                    "lane1":"0x1A400C",
+                    "lane2":"0x1A400C",
+                    "lane3":"0x1A400C"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Add to support MEDIA_LANE_SPEED_KEY in media_settings.json The MEDIA_LANE_SPEED_KEY consists of transceiver's media type and lane_speed information. To define MEDIA_LANE_SPEED_KEY as: "50000,CR", when the lane_speed is 50G in each lane and media type is Copper. "50000" , when the lane_speed is 50G in each lane, and its media type is Fiber.

* Add "def get_media_lane_speed_key" Use the this API to to query the MEDIA_LANE_SPEED_KEY for the transceiver.

* Modify "def get_media_settings_key" to add new key for MEDIA_LANE_SPEED_KEY.

* Modify "def get_media_settings_value" to parse MEDIA_LANE_SPEED_KEY.

* Add unit test with "media_settings_with_media_lane_speed_key_format.json" as sample "media_settings.json" file.

* Fix unit test error due to adding MEDIA_LANE_SPEED_KEY.

* Add unit test for "def get_media_lane_speed_key".

* Add unit test for getting media settings value with MEDIA_LANE_SPEED_KEY.

<!-- Provide a general summary of your changes in the Title above -->

#### Description

     This feature used to support to the media_settings.sjon with MEDIA_LANE_SPEED_KEY.

#### Motivation and Context
    To configure the transceiver's pre-emphasis message based on the transceiver's media_type and Lane_speed information, use MEDIA_LANE_SPEED_KEY in media_settings.json is for this purpose

#### How Has This Been Tested?
# To  test the feature in "sonic-buildimage" build folder.
- cd sonic-buildimage

# To get into sonic-docker build environment
- make NOSTRETCH=1 NOBUSTER=1 NOBULLSEYE=1  KEEP_SLAVE_ON=yes target/python-wheels/bullseye/sonic_utilities-1.2-py3-none-any.whl
- /sonic$

# To install the following deb packages    
- /sonic$ sudo dpkg -i ./target/debs/bullseye/libnl-3-200_*.deb
- /sonic$ sudo dpkg -i ./target/debs/bullseye/libnl-genl-3-200_*.deb
- /sonic$ sudo dpkg -i ./target/debs/bullseye/libnl-route-3-200_*.deb
- /sonic$ sudo dpkg -i ./target/debs/bullseye/libnl-nf-3-200_*.deb
- /sonic$ sudo dpkg -i ./target/debs/bullseye/libyang_1.0.73_amd64.deb
- /sonic$ sudo dpkg -i ./target/debs/bullseye/libswsscommon_1.0.0_amd64.deb
- /sonic$ sudo dpkg -i ./target/debs/bullseye/python3-swsscommon_1.0.0_amd64.deb

- /sonic$ sudo pip3 install ./target/python-wheels/bullseye/swsssdk-2.0.1-py3-none-any.whl
- /sonic$ sudo pip3 install ./target/python-wheels/bullseye/sonic_py_common-1.0-py3-none-any.whl
- /sonic$ sudo pip3 install ./target/python-wheels/bullseye/sonic_yang_mgmt-1.0-py3-none-any.whl
- /sonic$ sudo pip3 install ./target/python-wheels/bullseye/sonic_yang_models-1.0-py3-none-any.whl
- /sonic$ sudo pip3 install ./target/python-wheels/bullseye/sonic_config_engine-1.0-py3-none-any.whl
- /sonic$ sudo pip3 install ./target/python-wheels/bookworm/sonic_platform_common-1.0-py3-none-any.whl

# To run the pytset for test_xcvrd.py as:
- /sonic$ cd src/sonic-platform-daemons/sonic-xcvrd/
- /sonic/src/sonic-platform-daemons/sonic-xcvrd$ pytest-3 -s tests/test_xcvrd.py

#### Test log Information
Please refer to to test log before check-in-code and after check-in code as logs, it shows all adding testing cases are PASS.
[pytest-after-checed-in-code-log.txt](https://github.com/user-attachments/files/16390109/pytest-after-checed-in-code-log.txt)
[pytest-before-checed-in-code-log.txt](https://github.com/user-attachments/files/16390110/pytest-before-checed-in-code-log.txt)


