### PR TITLE
[PMON][psud] Fix the repeated NOTICE log message on Chassis platform

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -268,6 +268,8 @@ class PsuChassisInfo(logger.Logger):
                                   'PSU supplied power warning: {}W supplied-power less than {}W consumed-power'.format(
                                       self.total_supplied_power, self.total_consumed_power)
                                   )
+        if self.first_run:
+            self.first_run = False
 
         return set_led
 

--- a/sonic-psud/tests/test_PsuChassisInfo.py
+++ b/sonic-psud/tests/test_PsuChassisInfo.py
@@ -76,14 +76,14 @@ class TestPsuChassisInfo(object):
 
         # Test good values while in good state
         ret = chassis_info.update_master_status()
-        assert ret == True
+        assert ret == False
         assert chassis_info.master_status_good == True
 
         # Test unknown total_supplied_power (0.0)
         chassis_info.total_supplied_power = 0.0
         chassis_info.master_status_good = False
         ret = chassis_info.update_master_status()
-        assert ret == True
+        assert ret == False
         assert chassis_info.master_status_good == False
 
         # Test bad values while in good state
@@ -282,6 +282,15 @@ class TestPsuChassisInfo(object):
         assert ret == True
         assert psud.Psu.get_status_master_led() == MockPsu.STATUS_LED_COLOR_RED
 
+        # first time with good power usage
+        chassis_info = psud.PsuChassisInfo(SYSLOG_IDENTIFIER, chassis)
+        chassis_info.total_supplied_power = 510.0
+        chassis_info.total_consumed_power = 350.0
+        ret = chassis_info.update_master_status()
+        assert ret == True
+        assert psud.Psu.get_status_master_led() == MockPsu.STATUS_LED_COLOR_GREEN
+
+        chassis_info = psud.PsuChassisInfo(SYSLOG_IDENTIFIER, chassis)
         chassis_info.total_supplied_power = 510.0
         chassis_info.total_consumed_power = 350.0
         chassis_info.master_status_good = True


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
#### Description
In psud script, first_run is always true in PsuChassisInfo class. This causes the method update_master_status() always set the psu status_master_led and log the status change messages although the status is not changed. The same NOTICE message is repeated and never stop.  Address this issue, added code to set the first_run to False after the first run.  This initializes set_led to False before the calculation.  So that it won't be True to trigger the set_status_maste_led() and log the same message while the status has NO change.
<!--
     Describe your changes in detail
-->

#### Motivation and Context
This PR fixes https://github.com/sonic-net/sonic-buildimage/issues/19780 and not set the LED to the same state or log the same message when there is NO change. 
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Checking the syslog on the SUP.  The following message will not be repeated if the status is not changed
```
pmon#psud: PSU supplied power warning cleared: supplied power is back to norma
```
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
