### PR TITLE
[chassis][pmon][chassid] Enhance the chassid module on-line or off-line log messages with physical slot number

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -315,7 +315,7 @@ class ModuleUpdater(logger.Logger):
                         # identifying module operational status change. But the clean up will not be attempted for supervisor
 
                         if down_module_key not in self.down_modules:
-                            self.log_warning("Module {} went off-line!".format(key))
+                            self.log_warning("Module {} (Slot {}) went off-line!".format(key, module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD]))
                             self.down_modules[down_module_key] = {}
                             self.down_modules[down_module_key]['down_time'] = time.time()
                             self.down_modules[down_module_key]['cleaned'] = False
@@ -323,10 +323,10 @@ class ModuleUpdater(logger.Logger):
                 else:
                     # Module is operational. Remove it from down time tracking.
                     if down_module_key in self.down_modules:
-                        self.log_notice("Module {} recovered on-line!".format(key))
+                        self.log_notice("Module {} (Slot {}) recovered on-line!".format(key, module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD]))
                         del self.down_modules[down_module_key]
                     elif prev_status != ModuleBase.MODULE_STATUS_ONLINE:
-                        self.log_notice("Module {} is on-line!".format(key))
+                        self.log_notice("Module {} (Slot {}) is on-line!".format(key, module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD] ))
 
                     module_cfg_status = self.get_module_admin_status(key)
 

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -319,6 +319,7 @@ class ModuleUpdater(logger.Logger):
                             self.down_modules[down_module_key] = {}
                             self.down_modules[down_module_key]['down_time'] = time.time()
                             self.down_modules[down_module_key]['cleaned'] = False
+                            self.down_modules[down_module_key]['slot'] = module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD]
                     continue
                 else:
                     # Module is operational. Remove it from down time tracking.
@@ -452,17 +453,17 @@ class ModuleUpdater(logger.Logger):
             if midplane_access is False and current_midplane_state == 'True':
                 if self.is_module_reboot_expected(module_key):
                     self.module_reboot_set_time(module_key)
-                    self.log_warning("Expected: Module {} lost midplane connectivity".format(module_key))
+                    self.log_warning("Expected: Module {} (Slot {}) lost midplane connectivity".format(module_key, module.get_slot()))
                 else:
-                    self.log_warning("Unexpected: Module {} lost midplane connectivity".format(module_key))
+                    self.log_warning("Unexpected: Module {} (Slot {}) lost midplane connectivity".format(module_key, module.get_slot()))
             elif midplane_access is True and current_midplane_state == 'False':
-                self.log_notice("Module {} midplane connectivity is up".format(module_key))
+                self.log_notice("Module {} (Slot {}) midplane connectivity is up".format(module_key, module.get_slot()))
                 # clean up the reboot_info_table
                 if self.module_reboot_table.get(module_key) is not None:
                     self.module_reboot_table._del(module_key)
             elif midplane_access is False and current_midplane_state == 'False':
                 if self.is_module_reboot_system_up_expired(module_key):
-                    self.log_warning("Unexpected: Module {} midplane connectivity is not restored in {} seconds".format(module_key, self.linecard_reboot_timeout))
+                    self.log_warning("Unexpected: Module {} (Slot {}) midplane connectivity is not restored in {} seconds".format(module_key, module.get_slot(), self.linecard_reboot_timeout))
                     
             # Update db with midplane information
             fvs = swsscommon.FieldValuePairs([(CHASSIS_MIDPLANE_INFO_IP_FIELD, midplane_ip),
@@ -549,11 +550,12 @@ class ModuleUpdater(logger.Logger):
         for module in self.down_modules:
             if self.down_modules[module]['cleaned'] == False:
                 down_time = self.down_modules[module]['down_time']
+                slot = self.down_modules[module]['slot']
                 delta = (time_now - down_time) / 60
                 if delta >= CHASSIS_DB_CLEANUP_MODULE_DOWN_PERIOD:
                     if module.startswith(ModuleBase.MODULE_TYPE_LINE):
                         # Module is down for more than 30 minutes. Do the chassis clean up
-                        self.log_notice("Module {} is down for long time. Initiating chassis app db clean up".format(module))
+                        self.log_notice("Module {} (Slot {}) is down for long time. Initiating chassis app db clean up".format(module, slot))
                         self._cleanup_chassis_app_db(module)
                     self.down_modules[module]['cleaned'] = True
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Per MSFT request, we enhance the module on-line and off-line messages with physical slot number

Before enhance:
pmon#chassisd: Module LINE-CARD0 is on-line!
pmon#chassisd: Module LINE-CARD0  went off-line!
pmon#chassisd: Module LINE-CARD0 recovered on-line!
pmon#chassisd: Module FABRIC-CARD6 is on-line!

After Enhance:
pmon#chassisd: Module LINE-CARD0 (Slot 1) is on-line!
pmon#chassisd: Module LINE-CARD0 (Slot 1) went off-line!
pmon#chassisd: Module LINE-CARD0 (Slot 1) recovered on-line!
pmon#chassisd: Module FABRIC-CARD6 (Slot 7) is on-line!

This change is required by 202205 branch also.

<!--
     Describe your changes in detail
-->

#### Motivation and Context
Per MSFT's request -- In order to easily identify a module within a chassis, we need to report the physical slot number whenever we raised “module” related syslogs.

<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Tested with Master branch and 202205 branch.
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
