### PR TITLE
Xcvrd crash and restart should not cause link flap on platforms needing custom NPU SI settings

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -350,6 +350,8 @@ class TestXcvrdScript(object):
         mock_state_port_table.get = MagicMock(return_value=(None, None))
         assert xcvr_table_helper.get_state_db_port_table_val_by_key("Ethernet0", port_mapping, NPU_SI_SETTINGS_SYNC_STATUS_KEY) == None
 
+        mock_state_port_table.get = MagicMock(return_value=(True, {'A' : 'B'}))
+        assert xcvr_table_helper.get_state_db_port_table_val_by_key("Ethernet0", port_mapping, NPU_SI_SETTINGS_SYNC_STATUS_KEY) == None
         mock_state_port_table.get = MagicMock(return_value=(True, {NPU_SI_SETTINGS_SYNC_STATUS_KEY : NPU_SI_SETTINGS_DEFAULT_VALUE}))
         assert xcvr_table_helper.get_state_db_port_table_val_by_key("Ethernet0", port_mapping, NPU_SI_SETTINGS_SYNC_STATUS_KEY) == NPU_SI_SETTINGS_DEFAULT_VALUE
 

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -335,6 +335,31 @@ class TestXcvrdScript(object):
         mock_xcvr_api.__class__ = mock_class
         assert is_cmis_api(mock_xcvr_api) == expected_return_value
 
+    def test_get_state_db_port_table_val_by_key(self):
+        xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
+        port_mapping = PortMapping()
+
+        assert xcvr_table_helper.get_state_db_port_table_val_by_key("Ethernet0", None, NPU_SI_SETTINGS_SYNC_STATUS_KEY) == None
+
+        port_mapping.get_asic_id_for_logical_port = MagicMock(return_value=0)
+        xcvr_table_helper.get_state_port_tbl = MagicMock(return_value=None)
+        assert xcvr_table_helper.get_state_db_port_table_val_by_key("Ethernet0", port_mapping, NPU_SI_SETTINGS_SYNC_STATUS_KEY) == None
+
+        mock_state_port_table = MagicMock()
+        xcvr_table_helper.get_state_port_tbl = MagicMock(return_value=mock_state_port_table)
+        mock_state_port_table.get = MagicMock(return_value=(None, None))
+        assert xcvr_table_helper.get_state_db_port_table_val_by_key("Ethernet0", port_mapping, NPU_SI_SETTINGS_SYNC_STATUS_KEY) == None
+
+        mock_state_port_table.get = MagicMock(return_value=(True, {NPU_SI_SETTINGS_SYNC_STATUS_KEY : NPU_SI_SETTINGS_DEFAULT_VALUE}))
+        assert xcvr_table_helper.get_state_db_port_table_val_by_key("Ethernet0", port_mapping, NPU_SI_SETTINGS_SYNC_STATUS_KEY) == NPU_SI_SETTINGS_DEFAULT_VALUE
+
+    def test_is_npu_si_settings_update_required(self):
+        xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
+        port_mapping = PortMapping()
+        xcvr_table_helper.get_state_db_port_table_val_by_key = MagicMock(side_effect=[None, NPU_SI_SETTINGS_NOTIFIED_VALUE])
+        assert xcvr_table_helper.is_npu_si_settings_update_required("Ethernet0", port_mapping)
+        assert not xcvr_table_helper.is_npu_si_settings_update_required("Ethernet0", port_mapping)
+
     @patch('xcvrd.xcvrd._wrapper_get_sfp_type')
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))
@@ -864,10 +889,11 @@ class TestXcvrdScript(object):
             }
         }
         app_port_tbl = Table("APPL_DB", 'PORT_TABLE')
+        xcvr_table_helper.get_app_port_tbl = MagicMock(return_value=app_port_tbl)
         port_mapping = PortMapping()
         port_change_event = PortChangeEvent('Ethernet0', index, 0, PortChangeEvent.PORT_ADD)
         port_mapping.handle_port_change_event(port_change_event)
-        media_settings_parser.notify_media_setting(logical_port_name, xcvr_info_dict, app_port_tbl, mock_cfg_table, port_mapping)
+        media_settings_parser.notify_media_setting(logical_port_name, xcvr_info_dict, xcvr_table_helper, port_mapping)
 
     @patch('xcvrd.xcvrd_utilities.optics_si_parser.g_optics_si_dict', optics_si_settings_dict)
     @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))
@@ -1210,6 +1236,24 @@ class TestXcvrdScript(object):
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
         xcvrd.wait_for_port_config_done('')
         assert swsscommon.Select.select.call_count == 2
+
+    def test_DaemonXcvrd_initialize_port_init_control_fields_in_port_table(self):
+        port_mapping = PortMapping()
+        xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
+
+        port_mapping.logical_port_list = ['Ethernet0']
+        port_mapping.get_asic_id_for_logical_port = MagicMock(return_value=0)
+        mock_xcvrd_table_helper = MagicMock()
+        mock_xcvrd_table_helper.get_state_port_tbl = MagicMock(return_value=None)
+        xcvrd.xcvr_table_helper = mock_xcvrd_table_helper
+        xcvrd.initialize_port_init_control_fields_in_port_table(port_mapping)
+
+        mock_state_db = MagicMock()
+        mock_xcvrd_table_helper.get_state_port_tbl = MagicMock(return_value=mock_state_db)
+        mock_state_db.get = MagicMock(return_value=(False, {}))
+
+        xcvrd.initialize_port_init_control_fields_in_port_table(port_mapping)
+        mock_state_db.set.call_count = 2
 
     @patch('xcvrd.xcvrd.DaemonXcvrd.init')
     @patch('xcvrd.xcvrd.DaemonXcvrd.deinit')
@@ -3060,6 +3104,7 @@ class TestXcvrdScript(object):
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
         with patch("subprocess.check_output") as mock_run:
             mock_run.return_value = "true"
+            xcvrd.initialize_port_init_control_fields_in_port_table = MagicMock()
 
             xcvrd.init()
 
@@ -3086,6 +3131,7 @@ class TestXcvrdScript(object):
         xcvrdaemon = DaemonXcvrd(SYSLOG_IDENTIFIER)
         with patch("subprocess.check_output") as mock_run:
             mock_run.return_value = "false"
+            xcvrdaemon.initialize_port_init_control_fields_in_port_table = MagicMock()
 
             xcvrdaemon.init()
 

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -10,6 +10,7 @@ import re
 from sonic_py_common import device_info, logger
 from swsscommon import swsscommon
 from xcvrd import xcvrd
+from .xcvr_table_helper import *
 
 g_dict = {}
 
@@ -20,6 +21,7 @@ LANE_SPEED_KEY = 'lane_speed_key'
 SYSLOG_IDENTIFIER = "xcvrd"
 helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
+PHYSICAL_PORT_NOT_EXIST = -1
 
 def load_media_settings():
     global g_dict
@@ -264,12 +266,24 @@ def get_speed_and_lane_count(port, cfg_port_tbl):
 
 
 def notify_media_setting(logical_port_name, transceiver_dict,
-                         app_port_tbl, cfg_port_tbl, port_mapping):
+                         xcvr_table_helper, port_mapping):
 
     if not media_settings_present():
         return
 
-    port_speed, lane_count = get_speed_and_lane_count(logical_port_name, cfg_port_tbl)
+    if not xcvr_table_helper:
+        helper_logger.log_error("Notify media setting: xcvr_table_helper "
+                                "not initialized for lport {}".format(logical_port_name))
+        return
+
+    if not xcvr_table_helper.is_npu_si_settings_update_required(logical_port_name, port_mapping):
+        helper_logger.log_notice("Notify media setting: Media settings already "
+                                 "notified for lport {}".format(logical_port_name))
+        return
+
+    asic_index = port_mapping.get_asic_id_for_logical_port(logical_port_name)
+
+    port_speed, lane_count = get_speed_and_lane_count(logical_port_name, xcvr_table_helper.get_cfg_port_tbl(asic_index))
 
     ganged_port = False
     ganged_member_num = 1
@@ -320,4 +334,7 @@ def notify_media_setting(logical_port_name, transceiver_dict,
             fvs[index] = (str(media_key), str(media_val_str))
             index += 1
 
-        app_port_tbl.set(port_name, fvs)
+        xcvr_table_helper.get_app_port_tbl(asic_index).set(port_name, fvs)
+        xcvr_table_helper.get_state_port_tbl(asic_index).set(logical_port_name, [(NPU_SI_SETTINGS_SYNC_STATUS_KEY, NPU_SI_SETTINGS_NOTIFIED_VALUE)])
+        helper_logger.log_notice("Notify media setting: Published ASIC-side SI setting "
+                                 "for lport {} in APP_DB".format(logical_port_name))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Ensure Xcvrd crash and restart should be handled gracefully on platforms that need custom SI settings.
The goal is to avoid link flap on platforms that need custom SI settings during xcvrd restart.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
**Changeset 1**
The changeset is partial implementation of the changes required for https://github.com/sonic-net/SONiC/pull/1432/.
Specifically, the current change adds `NPU_SI_SETTINGS_SYNC_STATUS` key to the PORT_TABLE of STATE_DB. Following is the usage of `NPU_SI_SETTINGS_SYNC_STATUS` key

Value | Modifier thread and event | Consumer thread and purpose
-- | -- | --
NPU_SI_SETTINGS_DEFAULT | 1.   XCVRD main thread during cold start of XCVRD   2. SfpStateUpdateTask during transceiver removal | XCVRD   main thread during boot-up for deciding to notify NPU SI settings
NPU_SI_SETTINGS_NOTIFIED | 1. SfpStateUpdateTask while updating and notifying the NPU SI settings | Not being   used currently


Please note that the above table needs to be further modified while implementing complete OA crash HLD. The table assumes NPU SI settings are applied from SfpStateUpdateTask thread always (unlike the HLD wherein CMIS transceivers have the NPU SI settings being sent from CmisManagerTask).

**Changeset 2**
In addition to the above change, `TRANSCEIVER_INFO` table will not be deleted as part of xcvrd deinit.
On some platforms, `TRANSCEIVER_INFO` table is used to detect transceiver presence to handle `host_tx_ready` behavior and hence, deleting `TRANSCEIVR_INFO` table will cause `host_tx_ready` to change to `false` during xcvrd shutdown.

Impact due to skipping TRANSCEIVER_INFO table deletion
```
Scenario
In case if xcvrd crashes permanently after initializing 6 out of 32 ports (i.e. xcvrd never respawns), then "show int status" CLI will show 6 transceiver present and other ports would not show xcvr present unless we use sfputil. 
```

**Changeset 3**
`PHYSICAL_PORT_NOT_EXIST` has been defined in [media_settings_parser.py](https://github.com/sonic-net/sonic-platform-daemons/pull/541/files#diff-203c0123b1323e080246e562f662ac7c2a805bbae951ebd27f365758c6469f86) to prevent crash due to undefined value.
When the media_settings_parser.py file was created, the below line was moved from xcvrd.py. However, the definition of
`PHYSICAL_PORT_NOT_EXIST` was never ported. Hence, adding the definition now.
https://github.com/sonic-net/sonic-platform-daemons/blob/8c89f6ba2975a7699861f2c6d77083cebb62e97c/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py#L280

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
On platforms which do not restart xcvrd upon swss/syncd crash/restart, following behavior is observed
The first xcvrd crash after swss/syncd restarts will cause a link flap for ports which require NPU SI settings.
This is expected since as part of swss crash handling, the entire PORT_TABLE of STATE_DB is deleted. 
Since xcvrd is not restarted as part of swss/syncd crash handling, the NPU_SI_SETTINGS_SYNC_STATUS field is never populated. Hence, when xcvrd crashes/restarts first time after swss/syncd crash is triggered, xcvrd will update the NPU SI settings in the APPL_DB which in turn forces the port to go through a link flap while OA configures the NPU SI settings

Test summary
1. Platforms with xcvrd not restarting during swss/syncd crash

Event | Xcvrd restarted | NPU SI settings renotify | NPU_SI_SETTINGS_SYNC_STATUS   value after action   (for optics which require NPU SI settings) | Link flap
-- | -- | -- | -- | --
Config shut | N/A | No | NPU_SI_SETTINGS_NOTIFIED | N/A
Config no shut | N/A | No | NPU_SI_SETTINGS_NOTIFIED | N/A
Xcvrd restart | Yes | No | NPU_SI_SETTINGS_NOTIFIED | No
Xcvrd kill | Yes | No | NPU_SI_SETTINGS_NOTIFIED | No
Crash xcvrd just before updating   NPU_SI_SETTINGS_SYNC_STATUS | Yes | Yes | NPU_SI_SETTINGS_NOTIFIED | N/A
Pmon restart | Yes | No | NPU_SI_SETTINGS_NOTIFIED | No
Swss   restart | No | No | Key is   deleted | Yes
Syncd   restart | No | No | Key is   deleted | Yes
config reload | Yes | Yes | NPU_SI_SETTINGS_NOTIFIED | Yes
Cold reboot | N/A | No | Inline with expected value | N/A


2. Platforms with xcvrd restarting during swss/syncd crash

Event | Xcvrd restarted | NPU SI settings renotify | NPU_SI_SETTINGS_SYNC_STATUS   value after action   (for optics   which require NPU SI settings) | Link flap
-- | -- | -- | -- | --
Config shut | N/A | No | NPU_SI_SETTINGS_NOTIFIED | N/A
Config no shut | N/A | No | NPU_SI_SETTINGS_NOTIFIED | N/A
Xcvrd restart | Yes | No | NPU_SI_SETTINGS_NOTIFIED | No
Xcvrd kill | Yes | No | NPU_SI_SETTINGS_NOTIFIED | No
Crash xcvrd just before updating   NPU_SI_SETTINGS_SYNC_STATUS | Yes | Yes | NPU_SI_SETTINGS_NOTIFIED | N/A
Pmon restart | Yes | No | NPU_SI_SETTINGS_NOTIFIED | No
Swss restart | Yes | Yes | NPU_SI_SETTINGS_NOTIFIED | Yes
Syncd  restart | Yes | Yes | NPU_SI_SETTINGS_NOTIFIED | Yes
config reload | Yes | Yes | NPU_SI_SETTINGS_NOTIFIED | Yes
Cold reboot | N/A | No | NPU_SI_SETTINGS_NOTIFIED | N/A
Warm   reboot | N/A | No | NPU_SI_SETTINGS_NOTIFIED | No


3. Verified transceiver OIR
#### Additional Information (Optional)
MSFT ADO - 29278409
