### PR TITLE
Reduce log level for lane speed key construction failure

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -79,7 +79,7 @@ def get_lane_speed_key(physical_port, port_speed, lane_count):
             if host_electrical_interface_id:
                 lane_speed_key = LANE_SPEED_KEY_PREFIX + host_electrical_interface_id.split()[0]
         if not lane_speed_key:
-            helper_logger.log_error("No host_electrical_interface_id found for CMIS module on physical port {}"
+            helper_logger.log_notice("No host_electrical_interface_id found for CMIS module on physical port {}"
                                     ", failed to construct lane_speed_key".format(physical_port))
     else:
         # Directly calculate lane speed and use it as key, this is especially useful for

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -78,9 +78,6 @@ def get_lane_speed_key(physical_port, port_speed, lane_count):
             host_electrical_interface_id = appl_adv_dict[app_id].get('host_electrical_interface_id')
             if host_electrical_interface_id:
                 lane_speed_key = LANE_SPEED_KEY_PREFIX + host_electrical_interface_id.split()[0]
-        if not lane_speed_key:
-            helper_logger.log_notice("No host_electrical_interface_id found for CMIS module on physical port {}"
-                                    ", failed to construct lane_speed_key".format(physical_port))
     else:
         # Directly calculate lane speed and use it as key, this is especially useful for
         # non-CMIS transceivers which typically have no host_electrical_interface_id


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Removed the lane_speed key construction failure log from media_settings_parser.

#### Motivation and Context
The lane_speed_key is one of the key types used for the media_settings.json lookup.
This type of key is not relevant for all vendors, and thus it is not mandatory.
After some discussion, it was decided to completely remove this error log.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
