### PR TITLE
reset active application code as 'N/A' when port shutdown

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1871,6 +1871,26 @@ class TestXcvrdScript(object):
         assert task.get_cmis_host_lanes_mask(mock_xcvr_api, appl, host_lane_count, subport) == expected
 
     @patch('swsscommon.swsscommon.FieldValuePairs')
+    def test_CmisManagerTask_reset_port_active_apsel_to_db_error_cases(self, mock_field_value_pairs):
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
+        lport = "Ethernet0"
+        host_lanes_mask = 0xff
+
+        # Case: table does not exist
+        task.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=None)
+        task.reset_port_active_apsel_to_db(lport, host_lanes_mask)
+        assert mock_field_value_pairs.call_count == 0
+
+        # Case: lport is not in the table
+        int_tbl = MagicMock()
+        int_tbl.get = MagicMock(return_value=(False, dict))
+        task.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=int_tbl)
+        task.reset_port_active_apsel_to_db(lport, host_lanes_mask)
+        assert mock_field_value_pairs.call_count == 0
+
+    @patch('swsscommon.swsscommon.FieldValuePairs')
     def test_CmisManagerTask_post_port_active_apsel_to_db_error_cases(self, mock_field_value_pairs):
         mock_xcvr_api = MagicMock()
         mock_xcvr_api.get_active_apsel_hostlane = MagicMock()

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1879,6 +1879,7 @@ class TestXcvrdScript(object):
         host_lanes_mask = 0xff
 
         # Case: table does not exist
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=None)
         task.reset_port_active_apsel_to_db(lport, host_lanes_mask)
         assert mock_field_value_pairs.call_count == 0
@@ -2404,10 +2405,13 @@ class TestXcvrdScript(object):
         task.get_configured_laser_freq_from_db = MagicMock(return_value=193100)
         task.configure_tx_output_power = MagicMock(return_value=1)
         task.configure_laser_frequency = MagicMock(return_value=1)
+        task.reset_port_active_apsel_to_db = MagicMock()
 
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
 
+        assert mock_xcvr_api.tx_disable_channel.call_count == 1
+        assert task.reset_port_active_apsel_to_db.call_count == 1
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_READY
 
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_status_tbl')
@@ -2539,10 +2543,12 @@ class TestXcvrdScript(object):
         task.get_configured_laser_freq_from_db = MagicMock(return_value=193100)
         task.configure_tx_output_power = MagicMock(return_value=1)
         task.configure_laser_frequency = MagicMock(return_value=1)
+        task.reset_port_active_apsel_to_db = MagicMock()
 
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
 
+        assert task.reset_port_active_apsel_to_db.call_count == 1
         assert mock_xcvr_api.tx_disable_channel.call_count == 1
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_READY
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1244,51 +1244,38 @@ class CmisManagerTask(threading.Thread):
             self.log_error("{} Tuning in progress, subport selection may fail!".format(lport))
         return api.set_laser_freq(freq, grid)
 
-    def post_port_active_apsel_to_db(self, api, lport, host_lanes_mask):
-        try:
-            act_apsel = api.get_active_apsel_hostlane()
-            appl_advt = api.get_application_advertisement()
-        except NotImplementedError:
-            helper_logger.log_error("Required feature is not implemented")
-            return
+    def post_port_active_apsel_to_db(self, api, lport, host_lanes_mask, reset_apsel=False):
+        if reset_apsel == False:
+            try:
+                act_apsel = api.get_active_apsel_hostlane()
+                appl_advt = api.get_application_advertisement()
+            except NotImplementedError:
+                helper_logger.log_error("Required feature is not implemented")
+                return
 
         tuple_list = []
         for lane in range(self.CMIS_MAX_HOST_LANES):
             if ((1 << lane) & host_lanes_mask) == 0:
                 continue
-            act_apsel_lane = act_apsel.get('ActiveAppSelLane{}'.format(lane + 1), 'N/A')
-            tuple_list.append(('active_apsel_hostlane{}'.format(lane + 1),
-                               str(act_apsel_lane)))
+            if reset_apsel == False:
+                act_apsel_lane = act_apsel.get('ActiveAppSelLane{}'.format(lane + 1), 'N/A')
+                tuple_list.append(('active_apsel_hostlane{}'.format(lane + 1),
+                                   str(act_apsel_lane)))
+            else:
+                tuple_list.append(('active_apsel_hostlane{}'.format(lane + 1), 'N/A'))
 
         # also update host_lane_count and media_lane_count
         if len(tuple_list) > 0:
-            appl_advt_act = appl_advt.get(act_apsel_lane)
-            host_lane_count = appl_advt_act.get('host_lane_count', 'N/A') if appl_advt_act else 'N/A'
-            tuple_list.append(('host_lane_count', str(host_lane_count)))
-            media_lane_count = appl_advt_act.get('media_lane_count', 'N/A') if appl_advt_act else 'N/A'
-            tuple_list.append(('media_lane_count', str(media_lane_count)))
+            if reset_apsel == False:
+                appl_advt_act = appl_advt.get(act_apsel_lane)
+                host_lane_count = appl_advt_act.get('host_lane_count', 'N/A') if appl_advt_act else 'N/A'
+                tuple_list.append(('host_lane_count', str(host_lane_count)))
+                media_lane_count = appl_advt_act.get('media_lane_count', 'N/A') if appl_advt_act else 'N/A'
+                tuple_list.append(('media_lane_count', str(media_lane_count)))
+            else:
+                tuple_list.append(('host_lane_count', 'N/A'))
+                tuple_list.append(('media_lane_count', 'N/A'))
 
-        asic_index = self.port_mapping.get_asic_id_for_logical_port(lport)
-        intf_tbl = self.xcvr_table_helper.get_intf_tbl(asic_index)
-        if not intf_tbl:
-            helper_logger.log_warning("Active ApSel db update: TRANSCEIVER_INFO table not found for {}".format(lport))
-            return
-        found, _ = intf_tbl.get(lport)
-        if not found:
-            helper_logger.log_warning("Active ApSel db update: {} not found in INTF_TABLE".format(lport))
-            return
-        fvs = swsscommon.FieldValuePairs(tuple_list)
-        intf_tbl.set(lport, fvs)
-        self.log_notice("{}: updated TRANSCEIVER_INFO_TABLE {}".format(lport, tuple_list))
-
-    def reset_port_active_apsel_to_db(self, lport, host_lanes_mask):
-        tuple_list = []
-        for lane in range(self.CMIS_MAX_HOST_LANES):
-            if ((1 << lane) & host_lanes_mask) == 0:
-                continue
-            tuple_list.append(('active_apsel_hostlane{}'.format(lane + 1), 'N/A'))
-        tuple_list.append(('host_lane_count', 'N/A'))
-        tuple_list.append(('media_lane_count', 'N/A'))
         asic_index = self.port_mapping.get_asic_id_for_logical_port(lport)
         intf_tbl = self.xcvr_table_helper.get_intf_tbl(asic_index)
         if not intf_tbl:
@@ -1489,7 +1476,7 @@ class CmisManagerTask(threading.Thread):
                                self.log_notice("{} Forcing Tx laser OFF".format(lport))
                                # Force DataPath re-init
                                api.tx_disable_channel(media_lanes_mask, True)
-                               self.reset_port_active_apsel_to_db(lport, host_lanes_mask)
+                               self.post_port_active_apsel_to_db(lport, host_lanes_mask, reset_apsel=True)
                            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
                            continue
                     # Configure the target output power if ZR module


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
In the add_rack test, it would compare the TRANSCEIVER_INFO for two cases:
case 1. config reload (the admin status of Ethernet64 is down in config_db.json)
case 2. config reload (the admin status of Ethernet64 is up in config_db.json) and then shutdown Ethernet64

In case 1. it would not do CMIS init and the active application is 'N/A'.
In case 2. it would do CMIS init first and then disable TX. The active application would retain the value of the last CMIS init.
=> Modify the code to reset the active application on port shutdown to ensure that the active application would be the same for the above two cases.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
```
root@ais800-64o-1:/# show interfaces status Ethernet0
  Interface        Lanes    Speed    MTU    FEC          Alias    Vlan    Oper    Admin                           Type    Asym PFC
-----------  -----------  -------  -----  -----  -------------  ------  ------  -------  -----------------------------  ----------
  Ethernet0  25,26,27,28     400G   9100    N/A  Eth1/1(Port1)  routed      up       up  OSFP 8X Pluggable Transceiver         off
root@ais800-64o-1:/# show interfaces transceiver eeprom Ethernet0
Ethernet0: SFP EEPROM detected
        Active Firmware: N/A
        Active application selected code assigned to host lane 1: 2
        Active application selected code assigned to host lane 2: 2
        Active application selected code assigned to host lane 3: 2
        Active application selected code assigned to host lane 4: 2
        Active application selected code assigned to host lane 5: N/A
        Active application selected code assigned to host lane 6: N/A
        Active application selected code assigned to host lane 7: N/A
        Active application selected code assigned to host lane 8: N/A
        Application Advertisement: 800G L C2M (placeholder) - Host Assign (0x1) - 800GBASE-DR8-2 (placeholder) - Media Assign (0x1)
                                   400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400G-FR4/400GBASE-FR4 (Cl 151) - Media Assign (0x11)
                                   200GAUI-2-L C2M (Annex 120G) - Host Assign (0x55) - Undefined - Media Assign (0x55)
                                   100GAUI-1-L C2M (Annex 120G) - Host Assign (0xff) - 100G-FR/100GBASE-FR1 (Cl 140) - Media Assign (0xff)
                                   200GAUI-4 C2M (Annex 120E) - Host Assign (0x11) - 200GBASE-FR4 (Cl 122) - Media Assign (0x11)
        CMIS Rev: 5.0
        Connector: LC
        Encoding: N/A
        Extended Identifier: Power Class 7 (14.0W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: 4
        Identifier: OSFP 8X Pluggable Transceiver
        Inactive Firmware: N/A
        Length Cable Assembly(m): 0.0
        Media Interface Technology: 1310 nm EML
        Media Lane Count: 4
        Module Hardware Rev: 1.0
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: sm_media_interface
        Supported Max Laser Frequency: N/A
        Supported Max TX Power: N/A
        Supported Min Laser Frequency: N/A
        Supported Min TX Power: N/A
        Vendor Date Code(YYYY-MM-DD Lot): 2024-03-22
        Vendor Name: Edgecore
        Vendor OUI: 3c-2c-99
        Vendor PN: ET8001-2FR4
        Vendor Rev: 50
        Vendor SN: L12412000257
root@ais800-64o-1:/# config interface shutdown Ethernet0
root@ais800-64o-1:/# show interfaces transceiver eeprom Ethernet0
Ethernet0: SFP EEPROM detected
        Active Firmware: N/A
        Active application selected code assigned to host lane 1: N/A
        Active application selected code assigned to host lane 2: N/A
        Active application selected code assigned to host lane 3: N/A
        Active application selected code assigned to host lane 4: N/A
        Active application selected code assigned to host lane 5: N/A
        Active application selected code assigned to host lane 6: N/A
        Active application selected code assigned to host lane 7: N/A
        Active application selected code assigned to host lane 8: N/A
        Application Advertisement: 800G L C2M (placeholder) - Host Assign (0x1) - 800GBASE-DR8-2 (placeholder) - Media Assign (0x1)
                                   400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400G-FR4/400GBASE-FR4 (Cl 151) - Media Assign (0x11)
                                   200GAUI-2-L C2M (Annex 120G) - Host Assign (0x55) - Undefined - Media Assign (0x55)
                                   100GAUI-1-L C2M (Annex 120G) - Host Assign (0xff) - 100G-FR/100GBASE-FR1 (Cl 140) - Media Assign (0xff)
                                   200GAUI-4 C2M (Annex 120E) - Host Assign (0x11) - 200GBASE-FR4 (Cl 122) - Media Assign (0x11)
        CMIS Rev: 5.0
        Connector: LC
        Encoding: N/A
        Extended Identifier: Power Class 7 (14.0W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: N/A
        Identifier: OSFP 8X Pluggable Transceiver
        Inactive Firmware: N/A
        Length Cable Assembly(m): 0.0
        Media Interface Technology: 1310 nm EML
        Media Lane Count: N/A
        Module Hardware Rev: 1.0
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: sm_media_interface
        Supported Max Laser Frequency: N/A
        Supported Max TX Power: N/A
        Supported Min Laser Frequency: N/A
        Supported Min TX Power: N/A
        Vendor Date Code(YYYY-MM-DD Lot): 2024-03-22
        Vendor Name: Edgecore
        Vendor OUI: 3c-2c-99
        Vendor PN: ET8001-2FR4
        Vendor Rev: 50
        Vendor SN: L12412000257
```

#### Additional Information (Optional)
