### PR TITLE
Prevent ET8001-2FR4 do a CMIS reinit even only with the alias name set

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1777,7 +1777,7 @@ class TestXcvrdScript(object):
         (1, 0x0F, {0 : 1, 1 : 1, 2 : 1, 3 : 1}, DEFAULT_DP_STATE, DEFAULT_CONFIG_STATUS, False),
         (1, 0x0F, {0 : 1, 1 : 1, 2 : 1, 3 : 0}, DEFAULT_DP_STATE, DEFAULT_CONFIG_STATUS, True),
         (1, 0xF0, {4 : 1, 5 : 1, 6 : 1, 7 : 1}, DEFAULT_DP_STATE, DEFAULT_CONFIG_STATUS, False),
-        (1, 0xF0, {4 : 1, 5 : 1, 6 : 1, 7 : 1}, DEFAULT_DP_STATE, CONFIG_LANE_8_UNDEFINED, True),
+        (1, 0xF0, {4 : 1, 5 : 1, 6 : 1, 7 : 1}, DEFAULT_DP_STATE, CONFIG_LANE_8_UNDEFINED, False),
         (1, 0xF0, {4 : 1, 5 : 7, 6 : 1, 7 : 1}, DEFAULT_DP_STATE, DEFAULT_CONFIG_STATUS, True),
         (4, 0xF0, {4 : 1, 5 : 7, 6 : 1, 7 : 1}, DEFAULT_DP_STATE, DEFAULT_CONFIG_STATUS, True),
         (3, 0xC0, {7 : 3, 8 : 3}, DEFAULT_DP_STATE, DEFAULT_CONFIG_STATUS, False),

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1046,7 +1046,7 @@ class CmisManagerTask(threading.Thread):
                     skip = False
                     break
                 name = "ConfigStatusLane{}".format(lane + 1)
-                if conf_state[name] != 'ConfigSuccess':
+                if conf_state[name] != 'ConfigSuccess' and conf_state[name] != 'ConfigUndefined':
                     skip = False
                     break
             return (not skip)


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
When breakout ET8001-2FR4 to 2x400G, and configstates would be ConfigSuccess for 4 lanes and ConfigUndefined for the others.
```
root@ais800-64o-1:/home/admin# show interfaces transceiver status Ethernet0
Ethernet0:
        Tx fault flag on media lane 1: N/A
        Tx fault flag on media lane 2: N/A
        Tx fault flag on media lane 3: N/A
        Tx fault flag on media lane 4: N/A
        Tx fault flag on media lane 5: N/A
        Tx fault flag on media lane 6: N/A
        Tx fault flag on media lane 7: N/A
        Tx fault flag on media lane 8: N/A
        Rx loss of signal flag on media lane 1: False
        Rx loss of signal flag on media lane 2: False
        Rx loss of signal flag on media lane 3: False
        Rx loss of signal flag on media lane 4: False
        Rx loss of signal flag on media lane 5: False
        Rx loss of signal flag on media lane 6: False
        Rx loss of signal flag on media lane 7: False
        Rx loss of signal flag on media lane 8: False
        TX disable status on lane 1: False
        TX disable status on lane 2: False
        TX disable status on lane 3: False
        TX disable status on lane 4: False
        TX disable status on lane 5: False
        TX disable status on lane 6: False
        TX disable status on lane 7: False
        TX disable status on lane 8: False
        Disabled TX channels: 0
        Current module state: ModuleReady
        Reason of entering the module fault state: No Fault detected
        Datapath firmware fault: False
        Module firmware fault: False
        Module state changed: False
        Data path state indicator on host lane 1: DataPathActivated
        Data path state indicator on host lane 2: DataPathActivated
        Data path state indicator on host lane 3: DataPathActivated
        Data path state indicator on host lane 4: DataPathActivated
        Data path state indicator on host lane 5: DataPathActivated
        Data path state indicator on host lane 6: DataPathActivated
        Data path state indicator on host lane 7: DataPathActivated
        Data path state indicator on host lane 8: DataPathActivated
        Tx output status on media lane 1: True
        Tx output status on media lane 2: True
        Tx output status on media lane 3: True
        Tx output status on media lane 4: True
        Tx output status on media lane 5: True
        Tx output status on media lane 6: True
        Tx output status on media lane 7: True
        Tx output status on media lane 8: True
        Rx output status on host lane 1: True
        Rx output status on host lane 2: True
        Rx output status on host lane 3: True
        Rx output status on host lane 4: True
        Rx output status on host lane 5: True
        Rx output status on host lane 6: True
        Rx output status on host lane 7: True
        Rx output status on host lane 8: True
        Tx loss of signal flag on host lane 1: False
        Tx loss of signal flag on host lane 2: False
        Tx loss of signal flag on host lane 3: False
        Tx loss of signal flag on host lane 4: False
        Tx loss of signal flag on host lane 5: False
        Tx loss of signal flag on host lane 6: False
        Tx loss of signal flag on host lane 7: False
        Tx loss of signal flag on host lane 8: False
        Tx clock and data recovery loss of lock on host lane 1: False
        Tx clock and data recovery loss of lock on host lane 2: False
        Tx clock and data recovery loss of lock on host lane 3: False
        Tx clock and data recovery loss of lock on host lane 4: False
        Tx clock and data recovery loss of lock on host lane 5: False
        Tx clock and data recovery loss of lock on host lane 6: False
        Tx clock and data recovery loss of lock on host lane 7: False
        Tx clock and data recovery loss of lock on host lane 8: False
        Rx clock and data recovery loss of lock on media lane 1: False
        Rx clock and data recovery loss of lock on media lane 2: False
        Rx clock and data recovery loss of lock on media lane 3: False
        Rx clock and data recovery loss of lock on media lane 4: False
        Rx clock and data recovery loss of lock on media lane 5: False
        Rx clock and data recovery loss of lock on media lane 6: False
        Rx clock and data recovery loss of lock on media lane 7: False
        Rx clock and data recovery loss of lock on media lane 8: False
        Configuration status for the data path of host line 1: ConfigUndefined
        Configuration status for the data path of host line 2: ConfigUndefined
        Configuration status for the data path of host line 3: ConfigUndefined
        Configuration status for the data path of host line 4: ConfigUndefined
        Configuration status for the data path of host line 5: ConfigSuccess
        Configuration status for the data path of host line 6: ConfigSuccess
        Configuration status for the data path of host line 7: ConfigSuccess
        Configuration status for the data path of host line 8: ConfigSuccess
```
When execute the api "api.scs_apply_datapath_init(host_lanes_mask)" for 0xf0,
the config status of lanes 1...4 would be ConfigUndefined and the config status of lanes 5...8 would be ConfigSuccess.
If the config state is ConfigUndefined, then it would do CMIS reinit for any set in the CONFIG_DB PORT table.
If the config state is ConfigUndefined, then it would do CMIS reinit when restart pmon.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
In is_cmis_application_update_required, it check if the application is the same and if datapath is DataPathActivated.
It would not happen that the state of the config is fail, but the dataptach is activated.
I think skip CMIS int when config state is ConfigUndefined is saved.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
