### PR TITLE
Update TRANSCIEVER_INFO table for ports that doesn't exist in Config DB

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -261,9 +261,6 @@ class TestXcvrdThreadException(object):
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_SET,
                                             {'speed':'400000', 'lanes':'1,2,3,4,5,6,7,8'})
 
-        task.port_mapping.logical_to_physical['Ethernet0'] = 1
-        task.port_mapping.logical_to_asic['Ethernet0'] = 0
-
         # Case 1: get_xcvr_api() raises an exception
         task.on_port_update_event(port_change_event)
         mock_sfp.get_xcvr_api = MagicMock(side_effect=NotImplementedError)
@@ -1696,8 +1693,6 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd._wrapper_get_sfp_type', MagicMock(return_value='QSFP_DD'))
     def test_CmisManagerTask_handle_port_change_event(self):
         port_mapping = PortMapping()
-        port_mapping.logical_port_list = ['Ethernet0']
-        port_mapping.logical_to_physical['Ethernet0'] = 1
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
 
@@ -2204,7 +2199,6 @@ class TestXcvrdScript(object):
 
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_SET,
                                             {'speed':'400000', 'lanes':'1,2,3,4,5,6,7,8'})
-        task.port_mapping.logical_to_physical['Ethernet0'] = 1
         task.on_port_update_event(port_change_event)
         assert len(task.port_dict) == 1
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_INSERTED
@@ -2266,7 +2260,6 @@ class TestXcvrdScript(object):
         assert get_cmis_state_from_state_db('Ethernet1', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet1'))) == CMIS_STATE_UNKNOWN
 
         task.port_mapping.logical_port_list = MagicMock()
-        task.port_mapping.logical_to_physical['Ethernet1'] = 2
         port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
         task.on_port_update_event(port_change_event)
         assert task.isPortConfigDone
@@ -2410,7 +2403,6 @@ class TestXcvrdScript(object):
 
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_SET,
                                             {'speed':'400000', 'lanes':'1,2,3,4,5,6,7,8'})
-        task.port_mapping.logical_to_physical['Ethernet0'] = 1
         task.on_port_update_event(port_change_event)
         assert len(task.port_dict) == 1
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_INSERTED
@@ -2540,7 +2532,6 @@ class TestXcvrdScript(object):
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_UNKNOWN
 
         task.port_mapping.logical_port_list = MagicMock()
-        task.port_mapping.logical_to_physical['Ethernet0'] = 1
         port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
         task.on_port_update_event(port_change_event)
         assert task.isPortConfigDone

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -261,6 +261,9 @@ class TestXcvrdThreadException(object):
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_SET,
                                             {'speed':'400000', 'lanes':'1,2,3,4,5,6,7,8'})
 
+        task.port_mapping.logical_to_physical['Ethernet0'] = 1
+        task.port_mapping.logical_to_asic['Ethernet0'] = 0
+
         # Case 1: get_xcvr_api() raises an exception
         task.on_port_update_event(port_change_event)
         mock_sfp.get_xcvr_api = MagicMock(side_effect=NotImplementedError)
@@ -1693,6 +1696,8 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd._wrapper_get_sfp_type', MagicMock(return_value='QSFP_DD'))
     def test_CmisManagerTask_handle_port_change_event(self):
         port_mapping = PortMapping()
+        port_mapping.logical_port_list = ['Ethernet0']
+        port_mapping.logical_to_physical['Ethernet0'] = 1
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
 
@@ -2199,6 +2204,7 @@ class TestXcvrdScript(object):
 
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_SET,
                                             {'speed':'400000', 'lanes':'1,2,3,4,5,6,7,8'})
+        task.port_mapping.logical_to_physical['Ethernet0'] = 1
         task.on_port_update_event(port_change_event)
         assert len(task.port_dict) == 1
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_INSERTED
@@ -2260,6 +2266,7 @@ class TestXcvrdScript(object):
         assert get_cmis_state_from_state_db('Ethernet1', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet1'))) == CMIS_STATE_UNKNOWN
 
         task.port_mapping.logical_port_list = MagicMock()
+        task.port_mapping.logical_to_physical['Ethernet1'] = 2
         port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
         task.on_port_update_event(port_change_event)
         assert task.isPortConfigDone
@@ -2403,6 +2410,7 @@ class TestXcvrdScript(object):
 
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_SET,
                                             {'speed':'400000', 'lanes':'1,2,3,4,5,6,7,8'})
+        task.port_mapping.logical_to_physical['Ethernet0'] = 1
         task.on_port_update_event(port_change_event)
         assert len(task.port_dict) == 1
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_INSERTED
@@ -2532,6 +2540,7 @@ class TestXcvrdScript(object):
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_UNKNOWN
 
         task.port_mapping.logical_port_list = MagicMock()
+        task.port_mapping.logical_to_physical['Ethernet0'] = 1
         port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
         task.on_port_update_event(port_change_event)
         assert task.isPortConfigDone

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1393,6 +1393,23 @@ class TestXcvrdScript(object):
         xcvrd.wait_for_port_config_done('')
         assert swsscommon.Select.select.call_count == 2
 
+    def test_DaemonXcvrd_remove_ports_from_transceiver_table(self):
+        xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
+
+        mock_transceiver_info_table = MagicMock()
+        mock_transceiver_info_table.getKeys.return_value = ['EthernetXXX']
+        mock_transceiver_info_table._del = MagicMock()
+
+        xcvr_table_helper.get_intf_tbl = MagicMock(return_value=mock_transceiver_info_table)
+
+        xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
+        xcvrd.xcvr_table_helper = xcvr_table_helper
+
+        logical_ports_list = ['Ethernet0', 'Ethernet1']
+        xcvrd.remove_ports_from_transceiver_table(logical_ports_list)
+
+        mock_transceiver_info_table._del.assert_called_once_with('EthernetXXX')
+
     def test_DaemonXcvrd_initialize_port_init_control_fields_in_port_table(self):
         port_mapping = PortMapping()
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2097,7 +2097,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
                 break
 
     # remove ports from TRANSCEIVER_INFO table, if they don't exist in CONFIG DB
-    def remove_ports_from_transceiver_table(self, logical_port_list):
+    def remove_ports_from_transceiver_table(self, logical_ports_list):
         for namespace in self.namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             transceiver_info_table = self.xcvr_table_helper.get_intf_tbl(asic_id)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -712,6 +712,10 @@ class CmisManagerTask(threading.Thread):
         if pport is None:
             return
 
+        if not self.port_mapping.is_logical_port(lport):
+            helper_logger.log_info("lport {} does not exist in CONFIG DB. Ignoring port update event".format(lport))
+            return
+
         # Skip if the port/cage type is not a CMIS
         # 'index' can be -1 if STATE_DB|PORT_TABLE
         if lport not in self.port_dict:

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -712,10 +712,6 @@ class CmisManagerTask(threading.Thread):
         if pport is None:
             return
 
-        if not self.port_mapping.is_logical_port(lport):
-            helper_logger.log_info("lport {} does not exist in CONFIG DB. Ignoring port update event".format(lport))
-            return
-
         # Skip if the port/cage type is not a CMIS
         # 'index' can be -1 if STATE_DB|PORT_TABLE
         if lport not in self.port_dict:

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2105,6 +2105,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
 
             for trans_port in ports_in_transceiver_only:
                 transceiver_info_table._del(trans_port)
+                helper_logger.log_info("Port {} was removed from TRANSCEIVER_INFO table as it doesn't exist in Config DB".format(trans_port))
 
     """
     Initialize NPU_SI_SETTINGS_SYNC_STATUS_KEY field in STATE_DB PORT_TABLE|<lport>

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2178,6 +2178,15 @@ class DaemonXcvrd(daemon_base.DaemonBase):
 
         self.log_notice("XCVRD INIT: After port config is done")
         port_mapping_data = port_event_helper.get_port_mapping(self.namespaces)
+        # remove ports from TRANSCEIVER_INFO table, if they don't exist in CONFIG DB
+        logical_ports_list = port_mapping_data.logical_port_list
+        for namespace in self.namespaces:
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            transceiver_info_table = self.xcvr_table_helper.get_intf_tbl(asic_id)
+            ports_in_transceiver_only = list(set(transceiver_info_table.get_keys()) - set(logical_ports_list))
+
+            for trans_port in ports_in_transceiver_only:
+                transceiver_info_table._del(trans_port)
 
         self.initialize_port_init_control_fields_in_port_table(port_mapping_data)
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2179,7 +2179,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         for namespace in self.namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             transceiver_info_table = self.xcvr_table_helper.get_intf_tbl(asic_id)
-            ports_in_transceiver_only = list(set(transceiver_info_table.get_keys()) - set(logical_ports_list))
+            ports_in_transceiver_only = list(set(transceiver_info_table.getKeys()) - set(logical_ports_list))
 
             for trans_port in ports_in_transceiver_only:
                 transceiver_info_table._del(trans_port)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
This change https://github.com/sonic-net/sonic-platform-daemons/blob/0cb36447ebfda390d999df6516beac4c17315a7b/sonic-xcvrd/xcvrd/xcvrd.py#L2199 , caused TRANSCEIVER_INFO table to remain after config reload. 

When TRANSCEIVER_INFO table is not deleted from State DB, we have old ports there. 
if we do split to 8 in SPC4, we must deleted the adjacent port. so we have all old ports in TRANSCIVER_INFO but not in Config DB.  

To not cause any crash when trying to search for non-exist tables and ports, we should delete all ports which are not in Config DB from TRANSCEIVER_INFO table. 

example to a possible crash - 
![image](https://github.com/user-attachments/assets/14afdc80-0496-4ff7-9d53-14180251a437)

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Motivation is to be able to use cmis host mgmt feature in case we split to 8 and delete some ports from Config DB.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
with a split to 8 port
#### Additional Information (Optional)
