### PR TITLE
[chassis][pmon] Fix the PMON traceback issue while chassis is rebooting

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -362,13 +362,14 @@ class ModuleUpdater(logger.Logger):
            self.hostname_table.set(hostname_key, hostname_fvs)
 
         # Asics that are on the "not online" modules need to be cleaned up
-        asics = list(self.asic_table.getKeys())
-        for asic in asics:
-            fvs = self.asic_table.get(asic)
-            if isinstance(fvs, list):
-                fvs = dict(fvs[-1])
-            if fvs[CHASSIS_MODULE_INFO_NAME_FIELD] in notOnlineModules:
-                self.asic_table._del(asic)
+        if notOnlineModules:
+            asics = list(self.asic_table.getKeys())
+            for asic in asics:
+                fvs = self.asic_table.get(asic)
+                if isinstance(fvs, list):
+                    fvs = dict(fvs[-1])
+                if CHASSIS_MODULE_INFO_NAME_FIELD in fvs.keys() and fvs[CHASSIS_MODULE_INFO_NAME_FIELD] in notOnlineModules:
+                    self.asic_table._del(asic)
 
     def _get_module_info(self, module_index):
         """


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
During chassis reboot,  PMON on the LC could be in the middle of running module_db_update() which may try to access the CHASSIS_STATE_DB on the SUP to get the ASIC info.  If the ASIC table info on SUP has been removed due to reboot, the dictionary could be empty. Directly check its value could cause KeyErr.  This PR add code to checks if key exists before using its value.  Fixes https://github.com/sonic-net/sonic-buildimage/issues/20543
<!--
     Describe your changes in detail
-->

#### Motivation and Context
This is timing related issue in the chassis setup.  Per discussion, we should always check if the key exists in the dictionary. This PR add code to check if the key CHASSIS_MODULE_INFO_NAME_FIELD is in fvs before checking its value.  This will avoid the traceback occurs.  Fixes https://github.com/sonic-net/sonic-buildimage/issues/20543
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

This is needed by 202405 branch

#### How Has This Been Tested?
This issue is not easy to reproduce.  This issue was trigger by "sudo reboot" on SUP.  For my unit test, I modified PMON code to trigger the code to run and verify the change.
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Additional Information (Optional)
