### PR TITLE
[xcvrd] Fix swsscommon set port table handle in media_settings parser

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -365,7 +365,7 @@ def notify_media_setting(logical_port_name, transceiver_dict,
             fvs[index] = (str(media_key), str(val_str))
             index += 1
 
-        xcvr_table_helper.get_app_port_tbl(asic_index).set(port_name, fvs)
+        xcvr_table_helper.get_app_set_port_tbl(asic_index).set(port_name, fvs)
         xcvr_table_helper.get_state_port_tbl(asic_index).set(logical_port_name, [(NPU_SI_SETTINGS_SYNC_STATUS_KEY, NPU_SI_SETTINGS_NOTIFIED_VALUE)])
         helper_logger.log_notice("Notify media setting: Published ASIC-side SI setting "
                                  "for lport {} in APP_DB".format(logical_port_name))

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvr_table_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvr_table_helper.py
@@ -25,6 +25,7 @@ class XcvrTableHelper:
 		self.cfg_port_tbl, self.state_port_tbl, self.pm_tbl, self.firmware_info_tbl = {}, {}, {}, {}, {}, {}, {}, {}, {}
         self.state_db = {}
         self.cfg_db = {}
+        self.app_set_port_tbl = {}
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
@@ -39,6 +40,7 @@ class XcvrTableHelper:
             self.app_port_tbl[asic_id] = swsscommon.ProducerStateTable(appl_db, swsscommon.APP_PORT_TABLE_NAME)
             self.cfg_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
             self.cfg_port_tbl[asic_id] = swsscommon.Table(self.cfg_db[asic_id], swsscommon.CFG_PORT_TABLE_NAME)
+            self.app_set_port_tbl[asic_id] = swsscommon.Table(appl_db, swsscommon.APP_PORT_TABLE_NAME)
 
     def get_intf_tbl(self, asic_id):
         return self.int_tbl[asic_id]
@@ -60,6 +62,9 @@ class XcvrTableHelper:
 
     def get_app_port_tbl(self, asic_id):
         return self.app_port_tbl[asic_id]
+
+    def get_app_set_port_tbl(self, asic_id):
+        return self.app_set_port_tbl[asic_id]
 
     def get_state_db(self, asic_id):
         return self.state_db[asic_id]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

instead of ProducerStateTable for settings kvp, the xcvrd daemon should be just using swsscommon.Table which is what this PR fixes. 

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
