### PR TITLE
[SmartSwitch] Extend implementation of the DPU chassis daemon.

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -790,20 +790,73 @@ class ChassisdDaemon(daemon_base.DaemonBase):
         self.log_info("Shutting down...")
 
 
+class DpuStateManagerTask(ProcessTaskBase):
+
+    def __init__(self, log_identifier, dpu_state_updater):
+        super(DpuStateManagerTask, self).__init__()
+
+        self.logger = logger.Logger(log_identifier)
+        self.dpu_state_updater = dpu_state_updater
+        self.state_db = daemon_base.db_connect('STATE_DB')
+        self.app_db = daemon_base.db_connect('APPL_DB')
+
+    def task_worker(self):
+        sel = swsscommon.Select()
+        selectable = [
+            swsscommon.SubscriberStateTable(self.app_db, 'PORT_TABLE'),
+            swsscommon.SubscriberStateTable(self.state_db, 'SYSTEM_READY')
+        ]
+
+        for s in selectable:
+            sel.addSelectable(s)
+
+        try:
+            while True:
+                (state, c) = sel.select(SELECT_TIMEOUT)
+
+                if state == swsscommon.Select.TIMEOUT:
+                    continue
+
+                if state != swsscommon.Select.OBJECT:
+                    continue
+
+                for s in selectable:
+                    s.pops()
+
+                self.dpu_state_updater.update_state()
+
+        except KeyboardInterrupt:
+            pass
+
+
 class DpuChassisdDaemon(ChassisdDaemon):
 
     def run(self):
         self.log_info("Starting up...")
 
+        poll_dpu_state = True
+        if not try_get(self.platform_chassis.get_dataplane_state, default=None) and not \
+                try_get(self.platform_chassis.get_controlplane_state, default=None):
+            poll_dpu_state = False
+
         dpu_updater = DpuStateUpdater(SYSLOG_IDENTIFIER, self.platform_chassis)
+        dpu_state_mng = None
+
+        if not poll_dpu_state:
+            dpu_state_mng = DpuStateManagerTask(SYSLOG_IDENTIFIER, dpu_updater)
+            dpu_state_mng.task_run()
 
         # Start main loop
         self.log_info("Start daemon main loop")
 
         while not self.stop.wait(CHASSIS_INFO_UPDATE_PERIOD_SECS):
-            dpu_updater.update_state()
+            if poll_dpu_state:
+                dpu_updater.update_state()
 
         self.log_info("Stop daemon main loop")
+
+        if dpu_state_mng:
+            dpu_state_mng.task_stop()
 
         dpu_updater.deinit()
 

--- a/sonic-chassisd/tests/mock_swsscommon.py
+++ b/sonic-chassisd/tests/mock_swsscommon.py
@@ -54,6 +54,7 @@ class FieldValuePairs:
         pass
 
 class Select:
+    OBJECT = 0
     TIMEOUT = 1
 
     def addSelectable(self, selectable):
@@ -66,7 +67,12 @@ class Select:
         return self.TIMEOUT, None
 
 class SubscriberStateTable(Table):
-    pass
+
+    def pop(self):
+        return None
+
+    def pops(self):
+        return None
 
 class RedisPipeline:
     def __init__(self, db):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Extend the DPU chassis daemon to support subscriptions to data planes and control plane state changes.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This allows the optimization of CPU usage and removes the delay in state change processing compared to polling.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
New unit tests were added to cover new functionality.

#### Additional Information (Optional)
