### PR TITLE
[Smartswitch][DPU] Addition of DPU Chassis for thermalctld

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -26,7 +26,7 @@ SYSLOG_IDENTIFIER = 'thermalctld'
 NOT_AVAILABLE = 'N/A'
 CHASSIS_INFO_KEY = 'chassis 1'
 PHYSICAL_ENTITY_INFO_TABLE = 'PHYSICAL_ENTITY_INFO'
-INVALID_SLOT = -1
+INVALID_SLOT_OR_DPU = -1
 
 ERR_UNKNOWN = 1
 
@@ -523,9 +523,11 @@ class TemperatureUpdater(logger.Logger):
         self.all_thermals = set()
 
         self.is_chassis_system = chassis.is_modular_chassis()
-        if self.is_chassis_system:
-            my_slot = try_get(chassis.get_my_slot, INVALID_SLOT)
-            if my_slot != INVALID_SLOT:
+        self.is_smartswitch_dpu = chassis.is_smartswitch() and chassis.is_dpu()
+        self.is_chassis_upd_required = self.is_chassis_system or self.is_smartswitch_dpu
+        if self.is_chassis_upd_required:
+            my_slot = try_get(chassis.get_my_slot if self.is_chassis_system else chassis.get_dpu_id, INVALID_SLOT_OR_DPU)
+            if my_slot != INVALID_SLOT_OR_DPU:
                 try:
                     # Modular chassis does not have to have table CHASSIS_STATE_DB.
                     # So catch the exception here and ignore it.
@@ -540,7 +542,7 @@ class TemperatureUpdater(logger.Logger):
             table_keys = self.table.getKeys()
             for tk in table_keys:
                 self.table._del(tk)
-                if self.is_chassis_system and self.chassis_table is not None:
+                if self.is_chassis_upd_required and self.chassis_table is not None:
                     self.chassis_table._del(tk)
         if self.phy_entity_table:
             phy_entity_keys = self.phy_entity_table.getKeys()
@@ -593,6 +595,7 @@ class TemperatureUpdater(logger.Logger):
                 available_thermals.add((thermal, parent_name, thermal_index))
                 self._refresh_temperature_status(parent_name, thermal, thermal_index)
 
+        # As there are no modules present in DPU, this IF condition is not updated to consider DPU chassis
         if self.is_chassis_system:
             for module_index, module in enumerate(self.chassis.get_all_modules()):
                 module_name = try_get(module.get_name, 'Module {}'.format(module_index + 1))
@@ -702,7 +705,7 @@ class TemperatureUpdater(logger.Logger):
                 ])
 
             self.table.set(name, fvs)
-            if self.is_chassis_system and self.chassis_table is not None:
+            if self.is_chassis_upd_required and self.chassis_table is not None:
                 self.chassis_table.set(name, fvs)
         except Exception as e:
             self.log_warning('Failed to update thermal status for {} - {}'.format(name, repr(e)))

--- a/sonic-thermalctld/tests/mock_platform.py
+++ b/sonic-thermalctld/tests/mock_platform.py
@@ -335,7 +335,10 @@ class MockChassis(chassis_base.ChassisBase):
         self._replaceable = False
 
         self._is_chassis_system = False
+        self._is_dpu = False
+        self._is_smartswitch = False
         self._my_slot = module_base.ModuleBase.MODULE_INVALID_SLOT
+        self._dpu_id = None
         self._thermal_manager = MockThermalManager()
 
     def make_absent_fan(self):
@@ -445,6 +448,26 @@ class MockChassis(chassis_base.ChassisBase):
     def is_replaceable(self):
         return self._replaceable
 
+    def is_dpu(self):
+        return self._is_dpu
+
+    def is_smartswitch(self):
+        return self._is_smartswitch
+
+    def set_smartswitch(self, is_true):
+        self._is_smartswitch = is_true
+
+    def set_dpu(self, is_true):
+        self._is_dpu = is_true
+
+    def set_dpu_id(self, dpu_id):
+        self._dpu_id = dpu_id
+
+    def get_dpu_id(self):
+        # The default behaviour is Not implemented Error
+        if not self._dpu_id:
+            raise NotImplementedError
+        return self._dpu_id
 
 class MockModule(module_base.ModuleBase):
     def __init__(self):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Enabled `thermalctld` to run on DPU chassis to update data to `CHASSIS_STATE_DB` based on dpu_id
<!--
     Describe your changes in detail
-->

#### Motivation and Context
`thermalctld` is required to update the TEMPERATURE_INFO table to `CHASSIS_STATE_DB` as the data has to be proccessed by the switch in order to handle thermal algorithms at the switch side
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
