### PR TITLE
Take non-CMIS xcvrs out of lpmode in SFF Manager

### DIFF
--- a/sonic-xcvrd/xcvrd/sff_mgr.py
+++ b/sonic-xcvrd/xcvrd/sff_mgr.py
@@ -14,6 +14,7 @@ try:
 
     from .xcvrd_utilities.port_event_helper import PortChangeObserver
     from .xcvrd_utilities.xcvr_table_helper import XcvrTableHelper
+    from sonic_platform_base.sonic_xcvr.api.public.sff8472 import Sff8472Api
 except ImportError as e:
     raise ImportError(str(e) + " - required module not found")
 
@@ -434,6 +435,18 @@ class SffManagerTask(threading.Thread):
                 except (AttributeError, NotImplementedError):
                     # Skip if these essential routines are not available
                     continue
+                
+                if xcvr_inserted:
+                    set_lp_success = (
+                        sfp.set_lpmode(False) 
+                        if isinstance(api, Sff8472Api) 
+                        else api.set_lpmode(False)
+                    )
+                    if not set_lp_success:
+                        self.log_error(
+                            "{}: Failed to take module out of low power mode.".format(
+                                lport)
+                        )
 
                 if active_lanes is None:
                     active_lanes = self.get_active_lanes_for_lport(lport, subport_idx,


### PR DESCRIPTION
#### Description
Fix non-CMIS transceivers in down state by bringing them out of low power mode in the SFF Manager Task.
This is intended to work together with the change in https://github.com/sonic-net/sonic-buildimage/pull/20886.

#### Motivation and Context
Non-CMIS transceivers were not functioning correctly when put into Low Power mode. So XCVRD now brings them out of lpmode.

#### How Has This Been Tested?
Loaded an image containing this change alongside the change from https://github.com/sonic-net/sonic-buildimage/pull/20886 on an Arista chassis containing a Clearwater2 linecard.
Verified that without this image some interfaces were in a down state but with the image all interfaces came up as expected.

#### Additional Information (Optional)
