### PR TITLE
[xcvrd] silence port update event warnings

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/port_event_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/port_event_helper.py
@@ -102,7 +102,7 @@ class PortChangeObserver:
                 port_tbl.filter = d['FILTER'] if 'FILTER' in d else None
                 asic_context[port_tbl] = asic_id
                 sel.addSelectable(port_tbl)
-                self.logger.log_warning("subscribing to port_tbl {} - {} DB of namespace {} ".format(
+                self.logger.log_notice("subscribing to port_tbl {} - {} DB of namespace {} ".format(
                                             port_tbl, list(d.values())[0], namespace))
         self.sel, self.asic_context = sel, asic_context
 
@@ -144,7 +144,7 @@ class PortChangeObserver:
                     if not multi_asic.is_front_panel_port(port_name, role):
                         continue
 
-                    self.logger.log_warning("$$$ {} handle_port_update_event() : op={} DB:{} Table:{} fvp {}".format(
+                    self.logger.log_notice("$$$ {} handle_port_update_event() : op={} DB:{} Table:{} fvp {}".format(
                                                             port_name, op, port_tbl.db_name, port_tbl.table_name, fvp))
                     if 'index' not in fvp:
                        fvp['index'] = '-1'
@@ -193,7 +193,7 @@ class PortChangeObserver:
                                                             db_name,
                                                             table_name)
                 # This is the final event considered for processing
-                self.logger.log_warning("*** {} handle_port_update_event() fvp {}".format(
+                self.logger.log_notice("*** {} handle_port_update_event() fvp {}".format(
                     key, fvp))
                 if port_change_event is not None:
                     has_event = True


### PR DESCRIPTION
#### Description

All port events are currently logged at the WARN level.  Reduce to NOTICE.

Example:
```
2024 Dec  1 15:31:29.155436 sw2 WARNING pmon#xcvrd[32]: $$$ Ethernet0 handle_port_update_event() : op=SET DB:STATE_DB Table:TRANSCEIVER_INFO fvp {'type': 'SFP/SFP+/SFP28', 'dom_capability': 'N/A', 'encoding': 'NRZ', 'nominal_bit_rate': '255', 'manufacturer': 'FS              ', 'is_replaceable': 'False', 'specification_compliance': "{'10G Ethernet Compliance': '10GBASE-LR', 'Infiniband Compliance': 'Unknown', 'ESCON Compliance': 'Unknown', 'SONET Compliance Codes': 'Unknown', 'Ethernet Compliance': 'Unknown', 'Fibre Channel Link Length': 'Short distance (S)', 'Fibre Channel Transmitter Technology': 'Unknown', 'SFP+CableTechnology': 'Unknown', 'Fibre Channel Transmission Media': 'Unknown', 'Fibre Channel Speed': 'Unknown'}", 'vendor_date': '2024-07-27   ', 'vendor_rev': '1A  ', 'model': 'SFP-10/25GLR-31 ', 'ext_identifier': 'GBIC/SFP defined by two-wire interface ID', 'vendor_oui': '64-9d-99', 'cable_type': 'Length SMF (100m)', 'application_advertisement': 'N/A', 'ext_rateselect_compliance': 'Unknown', 'connector': 'LC', 'serial': 'C2407624540     ', 'cable_length': '100.0'}
```

#### Motivation and Context

Warnings should only be used to alert an administrator that something could cause issues.  Typically warnings will be evaluated by an administrator as tagged by their SIEM, so it makes sense to reduce the workload by not incorrectly tagging these log messages.

Reduced the log level to NOTICE which will still appear at the default log levels in case anyone is parsing these events in their SIEM.

#### How Has This Been Tested?

Build as part of my private fork at https://github.com/bradh352/sonic-buildimage and loaded onto physical switches.

#### Additional Information (Optional)
Signed-off-by: Brad House (@bradh352)
