### PR TITLE
Add high power class support for non-CMIS modules in xcvrd

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -200,7 +200,7 @@ class TestXcvrdThreadException(object):
     @patch('xcvrd.sff_mgr.PortChangeObserver', MagicMock(side_effect=NotImplementedError))
     def test_SffManagerTask_task_run_with_exception(self):
         stop_event = threading.Event()
-        sff_mgr = SffManagerTask(DEFAULT_NAMESPACE, stop_event, MagicMock(), helper_logger)
+        sff_mgr = SffManagerTask(True, DEFAULT_NAMESPACE, stop_event, MagicMock(), helper_logger)
         exception_received = None
         trace = None
         try:
@@ -1432,7 +1432,7 @@ class TestXcvrdScript(object):
 
     def test_SffManagerTask_handle_port_change_event(self):
         stop_event = threading.Event()
-        task = SffManagerTask(DEFAULT_NAMESPACE, stop_event, MagicMock(), helper_logger)
+        task = SffManagerTask(True, DEFAULT_NAMESPACE, stop_event, MagicMock(), helper_logger)
 
         port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
         task.on_port_update_event(port_change_event)
@@ -1470,7 +1470,7 @@ class TestXcvrdScript(object):
         assert len(task.port_dict) == 0
 
     def test_SffManagerTask_get_active_lanes_for_lport(self):
-        sff_manager_task = SffManagerTask(DEFAULT_NAMESPACE,
+        sff_manager_task = SffManagerTask(True, DEFAULT_NAMESPACE,
                                  threading.Event(),
                                  MagicMock(),
                                  helper_logger)
@@ -1524,7 +1524,7 @@ class TestXcvrdScript(object):
         assert result == expected_result
 
     def test_SffManagerTask_get_active_lanes_for_lport_with_invalid_input(self):
-        sff_manager_task = SffManagerTask(DEFAULT_NAMESPACE,
+        sff_manager_task = SffManagerTask(True, DEFAULT_NAMESPACE,
                                  threading.Event(),
                                  MagicMock(),
                                  helper_logger)
@@ -1547,7 +1547,7 @@ class TestXcvrdScript(object):
     def test_SffManagerTask_get_host_tx_status(self, mock_get_state_port_tbl):
         mock_get_state_port_tbl.return_value.hget.return_value = (True, 'true')
 
-        sff_manager_task = SffManagerTask(DEFAULT_NAMESPACE,
+        sff_manager_task = SffManagerTask(True, DEFAULT_NAMESPACE,
                                  threading.Event(),
                                  MagicMock(),
                                  helper_logger)
@@ -1561,7 +1561,7 @@ class TestXcvrdScript(object):
     def test_SffManagerTask_get_admin_status(self, mock_get_cfg_port_tbl):
         mock_get_cfg_port_tbl.return_value.hget.return_value = (True, 'up')
 
-        sff_manager_task = SffManagerTask(DEFAULT_NAMESPACE,
+        sff_manager_task = SffManagerTask(True, DEFAULT_NAMESPACE,
                                  threading.Event(),
                                  MagicMock(),
                                  helper_logger)
@@ -1587,7 +1587,7 @@ class TestXcvrdScript(object):
         mock_chassis.get_all_sfps = MagicMock(return_value=[mock_sfp])
         mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
 
-        task = SffManagerTask(DEFAULT_NAMESPACE,
+        task = SffManagerTask(True, DEFAULT_NAMESPACE,
                               threading.Event(),
                               mock_chassis,
                               helper_logger)

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -202,7 +202,7 @@ class TestXcvrdThreadException(object):
     @patch('xcvrd.sff_mgr.PortChangeObserver', MagicMock(side_effect=NotImplementedError))
     def test_SffManagerTask_task_run_with_exception(self):
         stop_event = threading.Event()
-        sff_mgr = SffManagerTask(True, DEFAULT_NAMESPACE, stop_event, MagicMock(), helper_logger)
+        sff_mgr = SffManagerTask(DEFAULT_NAMESPACE, stop_event, MagicMock(), helper_logger)
         exception_received = None
         trace = None
         try:
@@ -1654,7 +1654,7 @@ class TestXcvrdScript(object):
 
     def test_SffManagerTask_handle_port_change_event(self):
         stop_event = threading.Event()
-        task = SffManagerTask(True, DEFAULT_NAMESPACE, stop_event, MagicMock(), helper_logger)
+        task = SffManagerTask(DEFAULT_NAMESPACE, stop_event, MagicMock(), helper_logger)
 
         port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
         task.on_port_update_event(port_change_event)
@@ -1692,7 +1692,7 @@ class TestXcvrdScript(object):
         assert len(task.port_dict) == 0
 
     def test_SffManagerTask_get_active_lanes_for_lport(self):
-        sff_manager_task = SffManagerTask(True, DEFAULT_NAMESPACE,
+        sff_manager_task = SffManagerTask(DEFAULT_NAMESPACE,
                                  threading.Event(),
                                  MagicMock(),
                                  helper_logger)
@@ -1746,7 +1746,7 @@ class TestXcvrdScript(object):
         assert result == expected_result
 
     def test_SffManagerTask_get_active_lanes_for_lport_with_invalid_input(self):
-        sff_manager_task = SffManagerTask(True, DEFAULT_NAMESPACE,
+        sff_manager_task = SffManagerTask(DEFAULT_NAMESPACE,
                                  threading.Event(),
                                  MagicMock(),
                                  helper_logger)
@@ -1769,7 +1769,7 @@ class TestXcvrdScript(object):
     def test_SffManagerTask_get_host_tx_status(self, mock_get_state_port_tbl):
         mock_get_state_port_tbl.return_value.hget.return_value = (True, 'true')
 
-        sff_manager_task = SffManagerTask(True, DEFAULT_NAMESPACE,
+        sff_manager_task = SffManagerTask(DEFAULT_NAMESPACE,
                                  threading.Event(),
                                  MagicMock(),
                                  helper_logger)
@@ -1783,7 +1783,7 @@ class TestXcvrdScript(object):
     def test_SffManagerTask_get_admin_status(self, mock_get_cfg_port_tbl):
         mock_get_cfg_port_tbl.return_value.hget.return_value = (True, 'up')
 
-        sff_manager_task = SffManagerTask(True, DEFAULT_NAMESPACE,
+        sff_manager_task = SffManagerTask(DEFAULT_NAMESPACE,
                                  threading.Event(),
                                  MagicMock(),
                                  helper_logger)
@@ -1793,45 +1793,45 @@ class TestXcvrdScript(object):
         mock_get_cfg_port_tbl.assert_called_once_with(0)
         mock_get_cfg_port_tbl.return_value.hget.assert_called_once_with(lport, 'admin_status')
 
-    def test_SffManagerTask_handle_high_power_class(self):
+    def test_SffManagerTask_enable_high_power_class(self):
         mock_xcvr_api = MagicMock()
         mock_xcvr_api.get_power_class = MagicMock(return_value=5)
         mock_xcvr_api.set_high_power_class = MagicMock(return_value=True)
         lport = 'Ethernet0'
 
-        sff_manager_task = SffManagerTask(True, DEFAULT_NAMESPACE,
+        sff_manager_task = SffManagerTask(DEFAULT_NAMESPACE,
                                           threading.Event(),
                                           MagicMock(),
                                           helper_logger)
 
         # Test with normal case
-        sff_manager_task.handle_high_power_class(mock_xcvr_api, lport)
+        sff_manager_task.enable_high_power_class(mock_xcvr_api, lport)
         assert mock_xcvr_api.get_power_class.call_count == 1
         assert mock_xcvr_api.set_high_power_class.call_count == 1
 
         # Test with get_power_class failed
         mock_xcvr_api.get_power_class.return_value = None
-        sff_manager_task.handle_high_power_class(mock_xcvr_api, lport)
+        sff_manager_task.enable_high_power_class(mock_xcvr_api, lport)
         assert mock_xcvr_api.get_power_class.call_count == 2
         assert mock_xcvr_api.set_high_power_class.call_count == 1
 
         # Test for no need to set high power class
         mock_xcvr_api.get_power_class.return_value = 4
-        sff_manager_task.handle_high_power_class(mock_xcvr_api, lport)
+        sff_manager_task.enable_high_power_class(mock_xcvr_api, lport)
         assert mock_xcvr_api.get_power_class.call_count == 3
         assert mock_xcvr_api.set_high_power_class.call_count == 1
 
         # Test for set_high_power_class failed
         mock_xcvr_api.get_power_class.return_value = 5
         mock_xcvr_api.set_high_power_class.return_value = False
-        sff_manager_task.handle_high_power_class(mock_xcvr_api, lport)
+        sff_manager_task.enable_high_power_class(mock_xcvr_api, lport)
         assert mock_xcvr_api.get_power_class.call_count == 4
         assert mock_xcvr_api.set_high_power_class.call_count == 2
 
         # Test for set_high_power_class not supported
         mock_xcvr_api.get_power_class.return_value = 5
         mock_xcvr_api.set_high_power_class = MagicMock(side_effect=AttributeError("Attribute not found"))
-        sff_manager_task.handle_high_power_class(mock_xcvr_api, lport)
+        sff_manager_task.enable_high_power_class(mock_xcvr_api, lport)
         assert mock_xcvr_api.get_power_class.call_count == 5
         assert mock_xcvr_api.set_high_power_class.call_count == 1
 
@@ -1852,7 +1852,7 @@ class TestXcvrdScript(object):
         mock_chassis.get_all_sfps = MagicMock(return_value=[mock_sfp])
         mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
 
-        task = SffManagerTask(True, DEFAULT_NAMESPACE,
+        task = SffManagerTask(DEFAULT_NAMESPACE,
                               threading.Event(),
                               mock_chassis,
                               helper_logger)

--- a/sonic-xcvrd/xcvrd/sff_mgr.py
+++ b/sonic-xcvrd/xcvrd/sff_mgr.py
@@ -441,8 +441,8 @@ class SffManagerTask(threading.Thread):
 
                 if xcvr_inserted:
                     try:
-                        if api.handle_high_power_class():
-                            self.log_notice("{}: done handling high power class".format(lport))
+                        if api.set_high_power_class(True):
+                            self.log_notice("{}: done enabling high power class".format(lport))
                         else:
                             self.log_error("{}: failed to enable high power class".format(lport))
                     except (AttributeError, NotImplementedError):

--- a/sonic-xcvrd/xcvrd/sff_mgr.py
+++ b/sonic-xcvrd/xcvrd/sff_mgr.py
@@ -299,8 +299,15 @@ class SffManagerTask(threading.Thread):
                 self.log_error("{}: failed to get power class".format(lport))
                 return
 
+            # According to SFF-8636, section 6.2.6:
+            # In order to protect legacy host systems designed to support only
+            # the original 4 power classes, the High Power Class Enable control
+            # was defined at byte 93, bit 2. Modules in power classes 5, 6, 7 or
+            # 8 are required to limit power consumption to no more than a power
+            # class 4 module if the High Power Class Enable, byte 93 bit 2
+            # control is not set. For power class < 5, there's no such power
+            # consumption limiting, so no need to enable high power class.
             if power_class < 5:
-                # No action needed for power class < 5
                 return
 
             if xcvr_api.set_high_power_class(power_class, True):

--- a/sonic-xcvrd/xcvrd/sff_mgr.py
+++ b/sonic-xcvrd/xcvrd/sff_mgr.py
@@ -465,8 +465,10 @@ class SffManagerTask(threading.Thread):
                 except (AttributeError, NotImplementedError):
                     # Skip if these essential routines are not available
                     continue
-                
+
                 if xcvr_inserted or (admin_status_changed and data[self.ADMIN_STATUS] == "up"):
+                    self.handle_high_power_class(api, lport)
+
                     set_lp_success = (
                         sfp.set_lpmode(False) 
                         if isinstance(api, Sff8472Api) 
@@ -477,9 +479,6 @@ class SffManagerTask(threading.Thread):
                             "{}: Failed to take module out of low power mode.".format(
                                 lport)
                         )
-
-                if xcvr_inserted:
-                    self.handle_high_power_class(api, lport)
 
                 if not self.enable_sff_mgr_controlled_tx:
                     continue

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2052,12 +2052,12 @@ class SfpStateUpdateTask(threading.Thread):
 
 
 class DaemonXcvrd(daemon_base.DaemonBase):
-    def __init__(self, log_identifier, skip_cmis_mgr=False, enable_sff_mgr=False):
+    def __init__(self, log_identifier, skip_cmis_mgr=False, enable_sff_mgr_controlled_tx=False):
         super(DaemonXcvrd, self).__init__(log_identifier, enable_runtime_log_config=True)
         self.stop_event = threading.Event()
         self.sfp_error_event = threading.Event()
         self.skip_cmis_mgr = skip_cmis_mgr
-        self.enable_sff_mgr = enable_sff_mgr
+        self.enable_sff_mgr_controlled_tx = enable_sff_mgr_controlled_tx
         self.namespaces = ['']
         self.threads = []
 
@@ -2222,7 +2222,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         port_mapping_data = self.init()
 
         # Start the SFF manager
-        sff_manager = SffManagerTask(self.enable_sff_mgr, self.namespaces, self.stop_event, platform_chassis, helper_logger)
+        sff_manager = SffManagerTask(self.enable_sff_mgr_controlled_tx, self.namespaces, self.stop_event, platform_chassis, helper_logger)
         sff_manager.start()
         self.threads.append(sff_manager)
 
@@ -2304,10 +2304,10 @@ class DaemonXcvrd(daemon_base.DaemonBase):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--skip_cmis_mgr', action='store_true')
-    parser.add_argument('--enable_sff_mgr', action='store_true')
+    parser.add_argument('--enable_sff_mgr_controlled_tx', action='store_true')
 
     args = parser.parse_args()
-    xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER, args.skip_cmis_mgr, args.enable_sff_mgr)
+    xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER, args.skip_cmis_mgr, args.enable_sff_mgr_controlled_tx)
     xcvrd.run()
 
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2222,13 +2222,9 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         port_mapping_data = self.init()
 
         # Start the SFF manager
-        sff_manager = None
-        if self.enable_sff_mgr:
-            sff_manager = SffManagerTask(self.namespaces, self.stop_event, platform_chassis, helper_logger)
-            sff_manager.start()
-            self.threads.append(sff_manager)
-        else:
-            self.log_notice("Skipping SFF Task Manager")
+        sff_manager = SffManagerTask(self.enable_sff_mgr, self.namespaces, self.stop_event, platform_chassis, helper_logger)
+        sff_manager.start()
+        self.threads.append(sff_manager)
 
         # Start the CMIS manager
         cmis_manager = None


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

HLD: https://github.com/sonic-net/SONiC/pull/1867

#### Description
<!--
     Describe your changes in detail
-->

- Add xcvrd/sff_mgr support for enabling high power class if module's power class is greater or equal to 5 (Refer to SFF-8636 spec 6.2.6 Control Functions (Page 00h, Bytes 86-99) for byte 93 definition)


#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

Without enabling high power class for those modules, the module won't operate properly with power output and link won't come up.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Verified the module operate with proper power output.



#### Additional Information (Optional)
