### PR TITLE
[chassis][psud] Move the PSU parent information generation to the loop run function from the initialization function

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -405,9 +405,6 @@ class DaemonPsud(daemon_base.DaemonBase):
         fvs = swsscommon.FieldValuePairs([(CHASSIS_INFO_PSU_NUM_FIELD, str(self.num_psus))])
         self.chassis_tbl.set(CHASSIS_INFO_KEY, fvs)
 
-        # Update predefined position_in_parent and parent_name for PSU
-        self._update_psu_entity_info()
-
     def __del__(self):
         # Delete all the information from DB and then exit
         for psu_index in range(1, self.num_psus + 1):
@@ -437,6 +434,13 @@ class DaemonPsud(daemon_base.DaemonBase):
         if self.stop_event.wait(PSU_INFO_UPDATE_PERIOD_SECS):
             # We received a fatal signal
             return False
+
+        # Update predefined position_in_parent and parent_name for PSU
+        # it was in the __init__ function which means will be run only once
+        # But there's chance that the keys(PHYSICAL_ENTITY_INFO|*) got removed by other processes,
+        # like the exit function during the restart of thermalctld,
+        # hence move it to the iteration run, so the key will be filled again after removed.
+        self._update_psu_entity_info()
 
         self.update_psu_data()
         self._update_led_color()


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Move the PSU parent information generation to the loop run function from the initialization function
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Fixes https://github.com/sonic-net/sonic-platform-daemons/issues/575

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Tested on Cisco chassis, the `PHYSICAL_ENTITY_INFO|PSU *` can be re-inserted after thermalctld restart.
And monitored the stated db for memory for hours, works well:
```
admin@x-sup-2:~$ date && sudo ip netns exec asic0 /usr/bin/redis-cli INFO memory
Mon Dec 16 12:54:24 AM UTC 2024
# Memory
used_memory:3102440
used_memory_human:2.96M
used_memory_rss:19279872
used_memory_rss_human:18.39M
used_memory_peak:6644264
used_memory_peak_human:6.34M
used_memory_peak_perc:46.69%
used_memory_overhead:1595144
used_memory_startup:914032
used_memory_dataset:1507296
used_memory_dataset_perc:68.88%
allocator_allocated:3591336
allocator_active:4112384
allocator_resident:7749632
total_system_memory:32826040320
total_system_memory_human:30.57G
used_memory_lua:34816
used_memory_vm_eval:34816
used_memory_lua_human:34.00K
used_memory_scripts_eval:632
number_of_cached_scripts:1
number_of_functions:0
number_of_libraries:0
used_memory_vm_functions:32768
used_memory_vm_total:67584
used_memory_vm_total_human:66.00K
used_memory_functions:200
used_memory_scripts:832
used_memory_scripts_human:832B
maxmemory:0
maxmemory_human:0B
maxmemory_policy:noeviction
allocator_frag_ratio:1.15
allocator_frag_bytes:521048
allocator_rss_ratio:1.88
allocator_rss_bytes:3637248
rss_overhead_ratio:2.49
rss_overhead_bytes:11530240
mem_fragmentation_ratio:6.29
mem_fragmentation_bytes:16215752
mem_not_counted_for_evict:0
mem_replication_backlog:0
mem_total_replication_buffers:0
mem_clients_slaves:0
mem_clients_normal:554040
mem_cluster_links:0
mem_aof_buffer:0
mem_allocator:jemalloc-5.3.0
active_defrag_running:0
lazyfree_pending_objects:0
lazyfreed_objects:0

admin@x-sup-2:~$ date && sudo ip netns exec asic0 /usr/bin/redis-cli INFO memory
Mon Dec 16 03:05:14 AM UTC 2024
# Memory
used_memory:3182072
used_memory_human:3.03M
used_memory_rss:19447808
used_memory_rss_human:18.55M
used_memory_peak:6644264
used_memory_peak_human:6.34M
used_memory_peak_perc:47.89%
used_memory_overhead:1694744
used_memory_startup:914032
used_memory_dataset:1487328
used_memory_dataset_perc:65.58%
allocator_allocated:3607320
allocator_active:4112384
allocator_resident:7954432
total_system_memory:32826040320
total_system_memory_human:30.57G
used_memory_lua:34816
used_memory_vm_eval:34816
used_memory_lua_human:34.00K
used_memory_scripts_eval:632
number_of_cached_scripts:1
number_of_functions:0
number_of_libraries:0
used_memory_vm_functions:32768
used_memory_vm_total:67584
used_memory_vm_total_human:66.00K
used_memory_functions:200
used_memory_scripts:832
used_memory_scripts_human:832B
maxmemory:0
maxmemory_human:0B
maxmemory_policy:noeviction
allocator_frag_ratio:1.14
allocator_frag_bytes:505064
allocator_rss_ratio:1.93
allocator_rss_bytes:3842048
rss_overhead_ratio:2.44
rss_overhead_bytes:11493376
mem_fragmentation_ratio:6.19
mem_fragmentation_bytes:16304072
mem_not_counted_for_evict:0
mem_replication_backlog:0
mem_total_replication_buffers:0
mem_clients_slaves:0
mem_clients_normal:654600
mem_cluster_links:0
mem_aof_buffer:0
mem_allocator:jemalloc-5.3.0
active_defrag_running:0
lazyfree_pending_objects:0
lazyfreed_objects:0

```
#### Additional Information (Optional)
