### PR TITLE
[Smartswitch] Fix time format for dpu states

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -17,7 +17,7 @@ try:
     import time
     import json
     import glob
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     from sonic_py_common import daemon_base, logger, device_info
     from sonic_py_common.task_base import ProcessTaskBase
@@ -135,6 +135,16 @@ def get_chassis():
     except Exception as e:
         self.log_error("Failed to load chassis due to {}".format(repr(e)))
         sys.exit(CHASSIS_LOAD_ERROR)
+
+def get_formatted_time(datetimeobj=None, op_format=None):
+    """
+    Get the current time in specified format
+    :param datetimeobj: Optional - A datetime object already initialized with a specific time
+    :param op_format: Optional - Output Format for the time to be displayed
+    :returns time in string format
+    """
+    date_obj = datetimeobj if datetimeobj else datetime.now(timezone.utc)
+    return date_obj.strftime(op_format if op_format else "%a %b %d %I:%M:%S %p UTC %Y")
 
 #
 # Module Config Updater ========================================================
@@ -782,7 +792,7 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
             updates = {
                 "dpu_midplane_link_state": state,
                 "dpu_midplane_link_reason": "",
-                "dpu_midplane_link_time": datetime.now().strftime("%a %b %d %I:%M:%S %p UTC %Y"),
+                "dpu_midplane_link_time": get_formatted_time(),
             }
             current_data.update(updates)
 
@@ -818,7 +828,7 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
 
     def _get_current_time_str(self):
         """Returns the current time as a string in 'YYYY_MM_DD_HH_MM_SS' format."""
-        return datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+        return get_formatted_time(op_format="%Y_%m_%d_%H_%M_%S")
 
     def _get_history_path(self, module, file_name):
         """Generates the full path for history files."""
@@ -880,11 +890,9 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
 
         file_path = self._get_history_path(module, file_name)
         try:
-            dt_obj = datetime.strptime(prev_reboot_time, "%Y_%m_%d_%H_%M_%S")
+            formatted_time = get_formatted_time(datetimeobj=datetime.strptime(prev_reboot_time, "%Y_%m_%d_%H_%M_%S"))
         except ValueError:
-            dt_obj = datetime.now()
-
-        formatted_time = dt_obj.strftime("%a %b %d %I:%M:%S %p UTC %Y")
+            formatted_time = get_formatted_time()
 
         reboot_cause_dict = {
             "cause": cause,
@@ -1188,7 +1196,7 @@ class DpuStateUpdater(logger.Logger):
         return True
 
     def _time_now(self):
-        return datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        return get_formatted_time()
 
     def _update_dp_dpu_state(self, state):
         self.dpu_state_table.hset(self.name, self.DP_STATE, state)

--- a/sonic-chassisd/tests/test_dpu_chassisd.py
+++ b/sonic-chassisd/tests/test_dpu_chassisd.py
@@ -75,14 +75,14 @@ def test_dpu_state_update_api(state, expected_state):
 
 @pytest.mark.parametrize('dpu_id, dp_state, cp_state, expected_state', [
     (0, False, False, {'DPU0': 
-        {'dpu_data_plane_state': 'down', 'dpu_data_plane_time': '2000-01-01 00:00:00', 
-         'dpu_control_plane_state': 'down', 'dpu_control_plane_time': '2000-01-01 00:00:00'}}),
+        {'dpu_data_plane_state': 'down', 'dpu_data_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000',
+         'dpu_control_plane_state': 'down', 'dpu_control_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000'}}),
     (0, False, True, {'DPU0': 
-        {'dpu_data_plane_state': 'down', 'dpu_data_plane_time': '2000-01-01 00:00:00', 
-         'dpu_control_plane_state': 'up', 'dpu_control_plane_time': '2000-01-01 00:00:00'}}),
+        {'dpu_data_plane_state': 'down', 'dpu_data_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000',
+         'dpu_control_plane_state': 'up', 'dpu_control_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000'}}),
     (0, True, True, {'DPU0': 
-        {'dpu_data_plane_state': 'up', 'dpu_data_plane_time': '2000-01-01 00:00:00', 
-         'dpu_control_plane_state': 'up', 'dpu_control_plane_time': '2000-01-01 00:00:00'}}),
+        {'dpu_data_plane_state': 'up', 'dpu_data_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000',
+         'dpu_control_plane_state': 'up', 'dpu_control_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000'}}),
 ])
 def test_dpu_state_update(dpu_id, dp_state, cp_state, expected_state):
     chassis = MockDpuChassis()
@@ -102,7 +102,7 @@ def test_dpu_state_update(dpu_id, dp_state, cp_state, expected_state):
 
     with mock.patch.object(swsscommon.Table, 'hset', side_effect=hset) as hset_mock:
             dpu_updater = DpuStateUpdater(SYSLOG_IDENTIFIER, chassis)
-            dpu_updater._time_now = MagicMock(return_value='2000-01-01 00:00:00')
+            dpu_updater._time_now = MagicMock(return_value='Sat Jan 01 12:00:00 AM UTC 2000')
 
             dpu_updater.update_state()
 
@@ -112,20 +112,20 @@ def test_dpu_state_update(dpu_id, dp_state, cp_state, expected_state):
 
             # After the deinit we assume that the DPU state is down.
             assert chassis_state_db == {'DPU0': 
-                {'dpu_data_plane_state': 'down', 'dpu_data_plane_time': '2000-01-01 00:00:00', 
-                 'dpu_control_plane_state': 'down', 'dpu_control_plane_time': '2000-01-01 00:00:00'}}
+                {'dpu_data_plane_state': 'down', 'dpu_data_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000',
+                 'dpu_control_plane_state': 'down', 'dpu_control_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000'}}
 
 
 @pytest.mark.parametrize('dpu_id, dp_state, cp_state, expected_state', [
     (0, False, False, {'DPU0':
-        {'dpu_data_plane_state': 'down', 'dpu_data_plane_time': '2000-01-01 00:00:00',
-         'dpu_control_plane_state': 'down', 'dpu_control_plane_time': '2000-01-01 00:00:00'}}),
+        {'dpu_data_plane_state': 'down', 'dpu_data_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000',
+         'dpu_control_plane_state': 'down', 'dpu_control_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000'}}),
     (0, False, True, {'DPU0':
-        {'dpu_data_plane_state': 'down', 'dpu_data_plane_time': '2000-01-01 00:00:00',
-         'dpu_control_plane_state': 'up', 'dpu_control_plane_time': '2000-01-01 00:00:00'}}),
+        {'dpu_data_plane_state': 'down', 'dpu_data_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000',
+         'dpu_control_plane_state': 'up', 'dpu_control_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000'}}),
     (0, True, True, {'DPU0':
-        {'dpu_data_plane_state': 'up', 'dpu_data_plane_time': '2000-01-01 00:00:00',
-         'dpu_control_plane_state': 'up', 'dpu_control_plane_time': '2000-01-01 00:00:00'}}),
+        {'dpu_data_plane_state': 'up', 'dpu_data_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000',
+         'dpu_control_plane_state': 'up', 'dpu_control_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000'}}),
 ])
 def test_dpu_state_manager(dpu_id, dp_state, cp_state, expected_state):
     chassis = MockDpuChassis()
@@ -146,7 +146,7 @@ def test_dpu_state_manager(dpu_id, dp_state, cp_state, expected_state):
     with mock.patch.object(swsscommon.Table, 'hset', side_effect=hset):
         with mock.patch.object(swsscommon.Select, 'select', side_effect=((swsscommon.Select.OBJECT, None), (swsscommon.Select.OBJECT, None), KeyboardInterrupt)):
             dpu_updater = DpuStateUpdater(SYSLOG_IDENTIFIER, chassis)
-            dpu_updater._time_now = MagicMock(return_value='2000-01-01 00:00:00')
+            dpu_updater._time_now = MagicMock(return_value='Sat Jan 01 12:00:00 AM UTC 2000')
 
             dpu_state_mng = DpuStateManagerTask(SYSLOG_IDENTIFIER, dpu_updater)
 
@@ -158,8 +158,8 @@ def test_dpu_state_manager(dpu_id, dp_state, cp_state, expected_state):
 
             # After the deinit we assume that the DPU state is down.
             assert chassis_state_db == {'DPU0':
-                {'dpu_data_plane_state': 'down', 'dpu_data_plane_time': '2000-01-01 00:00:00',
-                 'dpu_control_plane_state': 'down', 'dpu_control_plane_time': '2000-01-01 00:00:00'}}
+                {'dpu_data_plane_state': 'down', 'dpu_data_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000',
+                 'dpu_control_plane_state': 'down', 'dpu_control_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000'}}
 
 
 def test_dpu_chassis_daemon():
@@ -180,7 +180,7 @@ def test_dpu_chassis_daemon():
         chassis_state_db[key][field] = value
 
     with mock.patch.object(swsscommon.Table, 'hset', side_effect=hset) as hset_mock:
-            with mock.patch.object(DpuStateUpdater, '_time_now', side_effect=lambda: '2000-01-01 00:00:00') as mock_time_now:
+            with mock.patch.object(DpuStateUpdater, '_time_now', side_effect=lambda: 'Sat Jan 01 12:00:00 AM UTC 2000') as mock_time_now:
 
                 daemon_chassisd = DpuChassisdDaemon(SYSLOG_IDENTIFIER, chassis)
                 daemon_chassisd.CHASSIS_INFO_UPDATE_PERIOD_SECS = MagicMock(return_value=1)
@@ -195,8 +195,8 @@ def test_dpu_chassis_daemon():
                 time.sleep(3)
 
                 assert chassis_state_db == {'DPU1':
-                    {'dpu_data_plane_state': 'up', 'dpu_data_plane_time': '2000-01-01 00:00:00',
-                    'dpu_control_plane_state': 'up', 'dpu_control_plane_time': '2000-01-01 00:00:00'}}
+                    {'dpu_data_plane_state': 'up', 'dpu_data_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000',
+                    'dpu_control_plane_state': 'up', 'dpu_control_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000'}}
 
                 daemon_chassisd.signal_handler(signal.SIGINT, None)
                 daemon_chassisd.stop.wait.return_value = True
@@ -204,5 +204,5 @@ def test_dpu_chassis_daemon():
                 thread.join()
 
                 assert chassis_state_db == {'DPU1':
-                    {'dpu_data_plane_state': 'down', 'dpu_data_plane_time': '2000-01-01 00:00:00',
-                    'dpu_control_plane_state': 'down', 'dpu_control_plane_time': '2000-01-01 00:00:00'}}
+                    {'dpu_data_plane_state': 'down', 'dpu_data_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000',
+                    'dpu_control_plane_state': 'down', 'dpu_control_plane_time': 'Sat Jan 01 12:00:00 AM UTC 2000'}}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Currently the time format being updated by the DPU and Switch are not aligned, this PR takes the common format from the HLD for all 3 states - midplane state, controlplane state and dataplane state
This also fixes the issue where the local time was represented incorrectly as UTC time


#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Current format:
```
Name    Oper-Status     State-Detail             State-Value    Time                             Reason
------  --------------  -----------------------  -------------  -------------------------------  --------
DPU0    Partial Online  dpu_midplane_link_state  up             Wed Jan 15 12:17:44 PM UTC 2025
                        dpu_control_plane_state  up             2024-11-25 04:32:45
                        dpu_data_plane_state     down           2024-11-25 04:32:45
```
After fix:
```
Name    Oper-Status     State-Detail             State-Value    Time                             Reason
------  --------------  -----------------------  -------------  -------------------------------  --------
DPU0    Partial Online  dpu_midplane_link_state  up             Wed Jan 15 12:17:44 PM UTC 2025
                        dpu_control_plane_state  up             Wed Jan 15 12:09:44 PM UTC 2025
                        dpu_data_plane_state     down           Wed Jan 15 12:09:44 PM UTC 2025
```
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
