### PR TITLE
Fix for dpu midplane state update affecting dpu control_plane/data_plane state :issue-21371

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -765,28 +765,22 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
 
     def update_dpu_state(self, key, state):
         """
-        Update DPU state in chassisStateDB using the given key.
+        Update specific DPU state fields in chassisStateDB using the given key.
         """
         try:
             # Connect to the CHASSIS_STATE_DB using daemon_base
             if not self.chassis_state_db:
                 self.chassis_state_db = daemon_base.db_connect("CHASSIS_STATE_DB")
 
-            # Fetch the current data for the given key and convert it to a dict
-            current_data = self._convert_to_dict(self.chassis_state_db.hgetall(key))
-
-            if current_data:
-                self.chassis_state_db.delete(key)
-
-            # Prepare the updated data
+            # Prepare the fields to update
             updates = {
                 "dpu_midplane_link_state": state,
                 "dpu_midplane_link_reason": "",
                 "dpu_midplane_link_time": datetime.now().strftime("%a %b %d %I:%M:%S %p UTC %Y"),
             }
-            current_data.update(updates)
 
-            for field, value in current_data.items():
+            # Update each field directly
+            for field, value in updates.items():
                 self.chassis_state_db.hset(key, field, value)
 
         except Exception as e:


### PR DESCRIPTION
Fix for dpu midplane state update affecting dpu control_plane/data_plane state

#### Description
The dpu midplane update and the dpu cp/dp state update happen in parallel. The midplane state update function reads the data from redis-DB, udpates the midplane state and then writes back the entire table. It appears like the DPU cp/dp state update sometimes goes in between the midplane read and and write causing a wrong update of dpu cp/dp states. The fix is to avoid reading the table and just write only the dpu midplane state.  This will solve the problem.

#### Fixes: https://github.com/sonic-net/sonic-buildimage/issues/21371

#### Motivation and Context
The dpu midplane update and the dpu cp/dp state update happen in parallel. The midplane state update function reads the data from redis-DB, udpates the midplane state and then writes back the entire table. It appears like the DPU cp/dp state update sometimes goes in between the midplane read and and write causing a wrong update of dpu cp/dp states. The fix is to avoid reading the table and just write only the dpu midplane state.  This will solve the problem.

#### How Has This Been Tested?
Toggle the DPU on/off state multiple times and see if the state is reflected properly.  Since, this code path is nvidia specific relying on their testing as well.

#### Additional Information (Optional)
