### PR TITLE
thermalctld: Ignore exception when deleting chassisdb entry fails

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -559,8 +559,14 @@ class TemperatureUpdater(logger.Logger):
             table_keys = self.table.getKeys()
             for tk in table_keys:
                 self.table._del(tk)
-                if self.is_chassis_upd_required and self.chassis_table is not None:
-                    self.chassis_table._del(tk)
+                try:
+                    if self.is_chassis_upd_required and self.chassis_table is not None:
+                        self.chassis_table._del(tk)
+                except Exception as e:
+                    # On a chassis system it is possible we may lose connection
+                    # to the supervisor and chassisdb. If this happens then we
+                    # should simply remove our handle to chassisdb.
+                    self.chassis_table = None
         if self.phy_entity_table:
             phy_entity_keys = self.phy_entity_table.getKeys()
             for pek in phy_entity_keys:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
After sonic-mgmt tests, it does a config consistency check and if the config consistency check fails, it runs recover_chassis(). That function simultaneously runs config_reload on the supervisor and all linecards (in parallel). This means that the supervisor networking can be in the process of restarting when thermalctld exits and goes through the cleanup process of deleting entries from chassisdb.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This fixes a thermalctld crash when the supervisor and linecards simultaneously do a `config reload` (fixes sonic-net/sonic-buildimage#21058). This causes a failure during sonic-mgmt testing.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
This change has been applied in Arista internal test environment and the thermalctl crash was not seen with this change applied.

#### Additional Information (Optional)
