### PR TITLE
Credo AEC 400G firmware v4.1 needs to set low power mode when change to DPDeinit state

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1741,6 +1741,21 @@ class TestXcvrdScript(object):
         task.xcvr_table_helper.get_cfg_port_tbl = mock_table_helper.get_cfg_port_tbl
         assert task.get_configured_tx_power_from_db('Ethernet0') == -10
 
+    @pytest.mark.parametrize("appl, host_assign, vendor, expected", [
+        (1, 0x1, 'Credo', True),
+        (2, 0x11, 'Credo', False),
+        (1, 0x1, 'Molex', False)
+    ])
+    def test_CmisManagerTask_is_need_low_power_first(self, appl, host_assign, vendor, expected):
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
+
+        mock_xcvr_api = MagicMock()
+        mock_xcvr_api.get_manufacturer = MagicMock(return_value=vendor)
+        mock_xcvr_api.get_host_lane_assignment_option = MagicMock(return_value=host_assign)
+        assert task.need_lp_mode_for_dpdeinit(mock_xcvr_api, appl) == expected
+
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd.is_fast_reboot_enabled', MagicMock(return_value=(False)))
     @patch('xcvrd.xcvrd.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1144,6 +1144,31 @@ class CmisManagerTask(threading.Thread):
             if key in ["PortConfigDone", "PortInitDone"]:
                 break
 
+    def need_lp_mode_for_dpdeinit(self, api, appl):
+        """
+        Determine whether the cmis transceiver needs to enter
+        low power mode when the state is changed to DPDeinit.
+        """
+        host_assign = api.get_host_lane_assignment_option(appl)
+        vendor = api.get_manufacturer().strip()
+
+        if vendor == "Credo" and host_assign == 0x1:
+            """
+            Credo AEC 400G needs this operation to work correctly on
+            firmware v4.1. Only one application mode 400GAUI-8 is supported
+            on firmware v4.1. When 'host_assign' is 1, it means the
+            application mode 400GAUI-8 is adopted.
+            Firmware v5.1 supports more application modes like 200GAUI-4,
+            It is not required to set low power mode when entering
+            DPDeinit on v5.1, and it also works fine when set low power
+            mode is set. In conclusion, set low power mode is only
+            required on Credo AEC 400G when host_assign is 0x1 to
+            ensure it works correctly.
+            """
+            return True
+        else:
+            return False
+
     def task_worker(self):
         self.xcvr_table_helper = XcvrTableHelper(self.namespaces)
 
@@ -1357,7 +1382,19 @@ class CmisManagerTask(threading.Thread):
                             continue
                         self.log_notice("{}: force Datapath reinit".format(lport))
                         self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_DEINIT)
+                        if self.need_lp_mode_for_dpdeinit(api, appl):
+                            api.set_lpmode(True)
+                            now = datetime.datetime.now()
+                            modulePwrDownDuration = self.get_cmis_module_power_down_duration_secs(api)
+                            self.log_notice("{}: ModulePwrDown duration {} secs".format(lport, modulePwrDownDuration))
+                            self.port_dict[lport]['cmis_expired'] = now + datetime.timedelta(seconds=modulePwrDownDuration)
                     elif state == CMIS_STATE_DP_DEINIT:
+                        if self.need_lp_mode_for_dpdeinit(api, appl):
+                            if not self.check_module_state(api, ['ModuleLowPwr']):
+                                if (expired is not None) and (expired <= now):
+                                    self.log_notice("{}: timeout for 'ModuleLowPwr'".format(lport))
+                                    self.force_cmis_reinit(lport, retries + 1)
+                                continue
                         # D.2.2 Software Deinitialization
                         api.set_datapath_deinit(host_lanes_mask)
 


### PR DESCRIPTION
Credo AEC 400G firmware v4.1 needs to set low power mode when change to DPDeinit state

Description
Credo AEC 400G needs to set low power mode when changing to DPDeinit state on firmware v4.1. After https://github.com/sonic-net/sonic-platform-daemons/pull/254 is merged, low power mode will not be set when changing to DPDeinit state.

Motivation and Context
This patch adds the code to set low power mode only when changing to DPDeinit state when the transceiver's vendor is 'Credo' and 'host_assign' is '1'(Which means the application mode only has 1 logical port on the transceiver). With this patch, the Credo AEC 400G can work correctly.

How Has This Been Tested?
Insert AEC 400G on AS9716 and verify the cable is link up.