### PR TITLE
Have sff_mgr bring a linkup port out of lpmode

### DIFF
--- a/sonic-xcvrd/xcvrd/sff_mgr.py
+++ b/sonic-xcvrd/xcvrd/sff_mgr.py
@@ -436,7 +436,7 @@ class SffManagerTask(threading.Thread):
                     # Skip if these essential routines are not available
                     continue
                 
-                if xcvr_inserted:
+                if xcvr_inserted or (admin_status_changed and data[self.ADMIN_STATUS] == "up"):
                     set_lp_success = (
                         sfp.set_lpmode(False) 
                         if isinstance(api, Sff8472Api) 


### PR DESCRIPTION
Because the sff_mgr only brings ports out of low-power mode during xcvr insertion we see tests like `platform_tests/api/test_sfp.py::TestSfpApi::test_reset` fail.
`platform_tests/api/test_sfp.py::TestSfpApi::test_reset` does sfp_reset which puts the port back into low-power mode and then does a shut/no shut of the port expecting the port to come out of low-power mode.
With this change we'll now pull the port out of low-power mode on link up and `platform_tests/api/test_sfp.py::TestSfpApi::test_reset` will pass.

https://github.com/aristanetworks/sonic/issues/121
