### PR TITLE
[xcvrd] Skip VDM threshold DB update for flat memory transceivers

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -3889,34 +3889,6 @@ class TestXcvrdScript(object):
         mock_api.is_flat_memory = MagicMock(side_effect=NotImplementedError)
         assert xcvrd_util.is_transceiver_flat_memory(1)
 
-    def test_is_transceiver_copper_based(self):
-        from xcvrd.xcvrd_utilities.utils import XCVRDUtils
-        mock_sfp = MagicMock()
-        xcvrd_util = XCVRDUtils({1: mock_sfp}, MagicMock())
-
-        # Test case where get_xcvr_api returns None
-        mock_sfp.get_xcvr_api = MagicMock(return_value=None)
-        assert xcvrd_util.is_transceiver_copper_based(1)
-
-        # Test case where is_copper returns True
-        mock_api = MagicMock()
-        mock_api.is_copper = MagicMock(return_value=True)
-        mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
-        assert xcvrd_util.is_transceiver_copper_based(1)
-
-        # Test case where is_copper returns False
-        mock_api.is_copper = MagicMock(return_value=False)
-        assert not xcvrd_util.is_transceiver_copper_based(1)
-
-        # Test case where get_xcvr_api raises KeyError
-        xcvrd_util.sfp_obj_dict = {}
-        assert xcvrd_util.is_transceiver_copper_based(1)
-
-        # Test case where is_copper raises NotImplementedError
-        xcvrd_util.sfp_obj_dict = {1: mock_sfp}
-        mock_api.is_copper = MagicMock(side_effect=NotImplementedError)
-        assert xcvrd_util.is_transceiver_copper_based(1)
-
 def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
     wait_time = 0
     while wait_time <= total_wait_time:

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -621,13 +621,6 @@ class TestXcvrdScript(object):
             assert VDM_THRESHOLD_TABLES[f'vdm_{t}_threshold_tbl'][0].get_size() == 0
         vdm_db_utils.xcvrd_utils.is_transceiver_flat_memory = MagicMock(return_value=False)
 
-        # Ensure table is empty if transceiver is copper based
-        vdm_db_utils.xcvrd_utils.is_transceiver_copper_based = MagicMock(return_value=True)
-        vdm_db_utils.post_port_vdm_thresholds_to_db(logical_port_name)
-        for t in VDM_THRESHOLD_TYPES:
-            assert VDM_THRESHOLD_TABLES[f'vdm_{t}_threshold_tbl'][0].get_size() == 0
-        vdm_db_utils.xcvrd_utils.is_transceiver_copper_based = MagicMock(return_value=False)
-
         # Ensure table is empty if get_vdm_values_func returns None
         vdm_db_utils.vdm_utils.get_vdm_thresholds = MagicMock(return_value=None)
         vdm_db_utils.post_port_vdm_thresholds_to_db(logical_port_name)

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -614,6 +614,20 @@ class TestXcvrdScript(object):
 
         vdm_db_utils.xcvrd_utils.get_transceiver_presence = MagicMock(return_value=True)
 
+        # Ensure table is empty if transceiver is flat memory
+        vdm_db_utils.xcvrd_utils.is_transceiver_flat_memory = MagicMock(return_value=True)
+        vdm_db_utils.post_port_vdm_thresholds_to_db(logical_port_name)
+        for t in VDM_THRESHOLD_TYPES:
+            assert VDM_THRESHOLD_TABLES[f'vdm_{t}_threshold_tbl'][0].get_size() == 0
+        vdm_db_utils.xcvrd_utils.is_transceiver_flat_memory = MagicMock(return_value=False)
+
+        # Ensure table is empty if transceiver is copper based
+        vdm_db_utils.xcvrd_utils.is_transceiver_copper_based = MagicMock(return_value=True)
+        vdm_db_utils.post_port_vdm_thresholds_to_db(logical_port_name)
+        for t in VDM_THRESHOLD_TYPES:
+            assert VDM_THRESHOLD_TABLES[f'vdm_{t}_threshold_tbl'][0].get_size() == 0
+        vdm_db_utils.xcvrd_utils.is_transceiver_copper_based = MagicMock(return_value=False)
+
         # Ensure table is empty if get_vdm_values_func returns None
         vdm_db_utils.vdm_utils.get_vdm_thresholds = MagicMock(return_value=None)
         vdm_db_utils.post_port_vdm_thresholds_to_db(logical_port_name)
@@ -3846,6 +3860,62 @@ class TestXcvrdScript(object):
 
         mock_sfp.get_presence = MagicMock(side_effect=NotImplementedError)
         assert not xcvrd_util.get_transceiver_presence(1)
+
+    def test_is_transceiver_flat_memory(self):
+        from xcvrd.xcvrd_utilities.utils import XCVRDUtils
+        mock_sfp = MagicMock()
+        xcvrd_util = XCVRDUtils({1: mock_sfp}, MagicMock())
+
+        # Test case where get_xcvr_api returns None
+        mock_sfp.get_xcvr_api = MagicMock(return_value=None)
+        assert xcvrd_util.is_transceiver_flat_memory(1)
+
+        # Test case where is_flat_memory returns True
+        mock_api = MagicMock()
+        mock_api.is_flat_memory = MagicMock(return_value=True)
+        mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
+        assert xcvrd_util.is_transceiver_flat_memory(1)
+
+        # Test case where is_flat_memory returns False
+        mock_api.is_flat_memory = MagicMock(return_value=False)
+        assert not xcvrd_util.is_transceiver_flat_memory(1)
+
+        # Test case where get_xcvr_api raises KeyError
+        xcvrd_util.sfp_obj_dict = {}
+        assert xcvrd_util.is_transceiver_flat_memory(1)
+
+        # Test case where is_flat_memory raises NotImplementedError
+        xcvrd_util.sfp_obj_dict = {1: mock_sfp}
+        mock_api.is_flat_memory = MagicMock(side_effect=NotImplementedError)
+        assert xcvrd_util.is_transceiver_flat_memory(1)
+
+    def test_is_transceiver_copper_based(self):
+        from xcvrd.xcvrd_utilities.utils import XCVRDUtils
+        mock_sfp = MagicMock()
+        xcvrd_util = XCVRDUtils({1: mock_sfp}, MagicMock())
+
+        # Test case where get_xcvr_api returns None
+        mock_sfp.get_xcvr_api = MagicMock(return_value=None)
+        assert xcvrd_util.is_transceiver_copper_based(1)
+
+        # Test case where is_copper returns True
+        mock_api = MagicMock()
+        mock_api.is_copper = MagicMock(return_value=True)
+        mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
+        assert xcvrd_util.is_transceiver_copper_based(1)
+
+        # Test case where is_copper returns False
+        mock_api.is_copper = MagicMock(return_value=False)
+        assert not xcvrd_util.is_transceiver_copper_based(1)
+
+        # Test case where get_xcvr_api raises KeyError
+        xcvrd_util.sfp_obj_dict = {}
+        assert xcvrd_util.is_transceiver_copper_based(1)
+
+        # Test case where is_copper raises NotImplementedError
+        xcvrd_util.sfp_obj_dict = {1: mock_sfp}
+        mock_api.is_copper = MagicMock(side_effect=NotImplementedError)
+        assert xcvrd_util.is_transceiver_copper_based(1)
 
 def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
     wait_time = 0

--- a/sonic-xcvrd/xcvrd/dom/utilities/vdm/db_utils.py
+++ b/sonic-xcvrd/xcvrd/dom/utilities/vdm/db_utils.py
@@ -91,10 +91,7 @@ class VDMDBUtils(DBUtils):
         if not self.xcvrd_utils.get_transceiver_presence(physical_port):
             return
 
-        if self.xcvrd_utils.is_transceiver_flat_memory(physical_port):
-            return
-
-        if self.xcvrd_utils.is_transceiver_copper_based(physical_port):
+        if self.xcvrd_utils.is_transceiver_flat_memory(physical_port) or self.xcvrd_utils.is_transceiver_copper_based(physical_port):
             return
 
         try:

--- a/sonic-xcvrd/xcvrd/dom/utilities/vdm/db_utils.py
+++ b/sonic-xcvrd/xcvrd/dom/utilities/vdm/db_utils.py
@@ -91,6 +91,12 @@ class VDMDBUtils(DBUtils):
         if not self.xcvrd_utils.get_transceiver_presence(physical_port):
             return
 
+        if self.xcvrd_utils.is_transceiver_flat_memory(physical_port):
+            return
+
+        if self.xcvrd_utils.is_transceiver_copper_based(physical_port):
+            return
+
         try:
             if db_cache is not None and physical_port in db_cache:
                 vdm_threshold_type_value_dict = db_cache[physical_port]

--- a/sonic-xcvrd/xcvrd/dom/utilities/vdm/db_utils.py
+++ b/sonic-xcvrd/xcvrd/dom/utilities/vdm/db_utils.py
@@ -91,7 +91,7 @@ class VDMDBUtils(DBUtils):
         if not self.xcvrd_utils.get_transceiver_presence(physical_port):
             return
 
-        if self.xcvrd_utils.is_transceiver_flat_memory(physical_port) or self.xcvrd_utils.is_transceiver_copper_based(physical_port):
+        if self.xcvrd_utils.is_transceiver_flat_memory(physical_port):
             return
 
         try:

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/utils.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/utils.py
@@ -23,13 +23,3 @@ class XCVRDUtils:
         except (KeyError, NotImplementedError):
             self.logger.log_error(f"Failed to check flat memory for port {physical_port}")
             return True
-
-    def is_transceiver_copper_based(self, physical_port):
-        try:
-            api = self.sfp_obj_dict[physical_port].get_xcvr_api()
-            if not api:
-                return True
-            return api.is_copper()
-        except (KeyError, NotImplementedError):
-            self.logger.log_error(f"Failed to check copper for port {physical_port}")
-            return True

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/utils.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/utils.py
@@ -13,3 +13,23 @@ class XCVRDUtils:
         except (KeyError, NotImplementedError):
             self.logger.log_error(f"Failed to get presence for port {physical_port}")
             return False
+
+    def is_transceiver_flat_memory(self, physical_port):
+        try:
+            api = self.sfp_obj_dict[physical_port].get_xcvr_api()
+            if not api:
+                return True
+            return api.is_flat_memory()
+        except (KeyError, NotImplementedError):
+            self.logger.log_error(f"Failed to check flat memory for port {physical_port}")
+            return True
+
+    def is_transceiver_copper_based(self, physical_port):
+        try:
+            api = self.sfp_obj_dict[physical_port].get_xcvr_api()
+            if not api:
+                return True
+            return api.is_copper()
+        except (KeyError, NotImplementedError):
+            self.logger.log_error(f"Failed to check copper for port {physical_port}")
+            return True


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
The following traceback is seen with the latest image for DAC cables.
```
2025 Mar 17 17:24:19.889826 sonic-dut ERR pmon#xcvrd[67]: Traceback (most recent call last):
2025 Mar 17 17:24:19.889997 sonic-dut WARNING pmon#xcvrd[67]: *** ('Ethernet259', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'false', 'index': '-1', 'port_name': 'Ethernet259', 'asic_id': 0, 'op': 'SET'}
2025 Mar 17 17:24:19.890132 sonic-dut ERR pmon#xcvrd[67]:   File "/usr/local/lib/python3.11/dist-packages/xcvrd/xcvrd.py", line 1878, in run
2025 Mar 17 17:24:19.890201 sonic-dut ERR pmon#xcvrd[67]:     self.task_worker(self.task_stopping_event, self.sfp_error_event)
2025 Mar 17 17:24:19.890397 sonic-dut WARNING pmon#xcvrd[67]: *** ('Ethernet21', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'false', 'index': '-1', 'port_name': 'Ethernet21', 'asic_id': 0, 'op': 'SET'}
2025 Mar 17 17:24:19.890516 sonic-dut ERR pmon#xcvrd[67]:   File "/usr/local/lib/python3.11/dist-packages/xcvrd/xcvrd.py", line 1671, in task_worker
2025 Mar 17 17:24:19.890609 sonic-dut ERR pmon#xcvrd[67]:     self.init()
2025 Mar 17 17:24:19.890757 sonic-dut WARNING pmon#xcvrd[67]: *** ('Ethernet86', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'false', 'index': '-1', 'port_name': 'Ethernet86', 'asic_id': 0, 'op': 'SET'}
2025 Mar 17 17:24:19.890810 sonic-dut ERR pmon#xcvrd[67]:   File "/usr/local/lib/python3.11/dist-packages/xcvrd/xcvrd.py", line 1590, in init
2025 Mar 17 17:24:19.890856 sonic-dut ERR pmon#xcvrd[67]:     self.retry_eeprom_set = self._post_port_sfp_info_and_dom_thr_to_db_once(port_mapping_data, self.xcvr_table_helper, self.main_thread_stop_event)
2025 Mar 17 17:24:19.891031 sonic-dut WARNING pmon#xcvrd[67]: *** ('Ethernet294', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'false', 'index': '-1', 'port_name': 'Ethernet294', 'asic_id': 0, 'op': 'SET'}
2025 Mar 17 17:24:19.891059 sonic-dut ERR pmon#xcvrd[67]:                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025 Mar 17 17:24:19.891104 sonic-dut ERR pmon#xcvrd[67]:   File "/usr/local/lib/python3.11/dist-packages/xcvrd/xcvrd.py", line 1547, in _post_port_sfp_info_and_dom_thr_to_db_once
2025 Mar 17 17:24:19.891255 sonic-dut WARNING pmon#xcvrd[67]: *** ('Ethernet289', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'false', 'index': '-1', 'port_name': 'Ethernet289', 'asic_id': 0, 'op': 'SET'}
2025 Mar 17 17:24:19.891290 sonic-dut ERR pmon#xcvrd[67]:     self.vdm_db_utils.post_port_vdm_thresholds_to_db(logical_port_name)
2025 Mar 17 17:24:19.891332 sonic-dut ERR pmon#xcvrd[67]:   File "/usr/local/lib/python3.11/dist-packages/xcvrd/dom/utilities/vdm/db_utils.py", line 70, in post_port_vdm_thresholds_to_db
2025 Mar 17 17:24:19.891490 sonic-dut WARNING pmon#xcvrd[67]: *** ('Ethernet128', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'false', 'index': '-1', 'port_name': 'Ethernet128', 'asic_id': 0, 'op': 'SET'}
2025 Mar 17 17:24:19.891525 sonic-dut ERR pmon#xcvrd[67]:     return self._post_port_vdm_thresholds_or_flags_to_db(logical_port_name, self.xcvr_table_helper.get_vdm_threshold_tbl,
2025 Mar 17 17:24:19.891569 sonic-dut ERR pmon#xcvrd[67]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025 Mar 17 17:24:19.891721 sonic-dut WARNING pmon#xcvrd[67]: *** ('Ethernet2', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'false', 'index': '-1', 'port_name': 'Ethernet2', 'asic_id': 0, 'op': 'SET'}
2025 Mar 17 17:24:19.891757 sonic-dut ERR pmon#xcvrd[67]:   File "/usr/local/lib/python3.11/dist-packages/xcvrd/dom/utilities/vdm/db_utils.py", line 100, in _post_port_vdm_thresholds_or_flags_to_db
2025 Mar 17 17:24:19.891794 sonic-dut ERR pmon#xcvrd[67]:     vdm_values_dict = get_vdm_values_func(physical_port)
2025 Mar 17 17:24:19.891839 sonic-dut ERR pmon#xcvrd[67]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025 Mar 17 17:24:19.891990 sonic-dut WARNING pmon#xcvrd[67]: *** ('Ethernet471', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'false', 'index': '-1', 'port_name': 'Ethernet471', 'asic_id': 0, 'op': 'SET'}
2025 Mar 17 17:24:19.892029 sonic-dut ERR pmon#xcvrd[67]:   File "/usr/local/lib/python3.11/dist-packages/xcvrd/dom/utilities/vdm/utils.py", line 39, in get_vdm_thresholds
2025 Mar 17 17:24:19.892067 sonic-dut ERR pmon#xcvrd[67]:     return self.sfp_obj_dict[physical_port].get_transceiver_vdm_thresholds()
2025 Mar 17 17:24:19.892109 sonic-dut ERR pmon#xcvrd[67]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025 Mar 17 17:24:19.892262 sonic-dut WARNING pmon#xcvrd[67]: *** ('Ethernet118', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'false', 'index': '-1', 'port_name': 'Ethernet118', 'asic_id': 0, 'op': 'SET'}
2025 Mar 17 17:24:19.892302 sonic-dut ERR pmon#xcvrd[67]:   File "/usr/local/lib/python3.11/dist-packages/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py", line 76, in get_transceiver_vdm_thresholds
2025 Mar 17 17:24:19.892340 sonic-dut ERR pmon#xcvrd[67]:     return api.get_transceiver_vdm_thresholds() if api is not None else None
2025 Mar 17 17:24:19.892381 sonic-dut ERR pmon#xcvrd[67]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025 Mar 17 17:24:19.892544 sonic-dut WARNING pmon#xcvrd[67]: *** ('Ethernet343', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'false', 'index': '-1', 'port_name': 'Ethernet343', 'asic_id': 0, 'op': 'SET'}
2025 Mar 17 17:24:19.892585 sonic-dut ERR pmon#xcvrd[67]:   File "/usr/local/lib/python3.11/dist-packages/sonic_platform_base/sonic_xcvr/api/public/cmis.py", line 2566, in get_transceiver_vdm_thresholds
2025 Mar 17 17:24:19.892625 sonic-dut ERR pmon#xcvrd[67]:     vdm_raw_dict = self.get_vdm(self.vdm.VDM_THRESHOLD)
2025 Mar 17 17:24:19.892666 sonic-dut ERR pmon#xcvrd[67]:                                 ^^^^^^^^^^^^^^^^^^^^^^
2025 Mar 17 17:24:19.892812 sonic-dut WARNING pmon#xcvrd[67]: *** ('Ethernet224', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'true', 'index': '-1', 'port_name': 'Ethernet224', 'asic_id': 0, 'op': 'SET'}
2025 Mar 17 17:24:19.892857 sonic-dut ERR pmon#xcvrd[67]: AttributeError: 'NoneType' object has no attribute 'VDM_THRESHOLD'
2025 Mar 17 17:24:19.893100 sonic-dut NOTICE pmon#xcvrd[67]: Stop daemon main loop
2025 Mar 17 17:24:19.893330 sonic-dut WARNING pmon#xcvrd[67]: *** ('Ethernet230', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'false', 'index': '-1', 'port_name': 'Ethernet230', 'asic_id': 0, 'op': 'SET'}
2025 Mar 17 17:24:19.893330 sonic-dut ERR pmon#xcvrd[67]: Xcvrd: exception found at child thread SfpStateUpdateTask due to AttributeError("'NoneType' object has no attribute 'VDM_THRESHOLD'")
2025 Mar 17 17:24:19.893412 sonic-dut ERR pmon#xcvrd[67]: Exiting main loop as child thread raised exception!
2025 Mar 17 17:24:19.904444 sonic-dut INFO pmon#supervisord 2025-03-17 17:24:19,904 WARN exited: xcvrd (terminated by SIGKILL; not expected)
```

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
With https://github.com/sonic-net/sonic-platform-daemons/pull/582 merged, we are now updating the VDM threshold data for all types of transceivers.

However, for transceivers which are CMIS compliant but have flat memory, they don't have VDM support. The driver handler for fetching the VDM threshold data does not check if the CMIS transceiver supports VDM or not, which causes xcvrd to crash.
https://github.com/sonic-net/sonic-platform-common/blob/e5aedb6bab10a16d0167488eb9e291805c397c8f/sonic_platform_base/sonic_xcvr/api/public/cmis.py#L2619 

To address this issue, ensure that a transceiver is flat memory based before reading the VDM threshold data from the transceiver. 

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
1. Ensured that xcvrd is stable and VDM threshold table is present for CMIS optics supporting VDM
2. Ensured that xcvrd is stable and VDM threshold table is present for C-CMIS optics supporting VDM
3. Ensured that xcvrd is stable and VDM threshold table is not present for
3.1 CMIS optics not supporting VDM + does not have flat memory
3.2 CMIS optics but has flat memory
3.3 10G SFP

#### Additional Information (Optional)
MSFT ADO - 31849344