### PR TITLE
Sensormond changes to support configurable time for logging threshold and better handling of fatal signals

### DIFF
--- a/sonic-sensormond/scripts/sensormond
+++ b/sonic-sensormond/scripts/sensormond
@@ -10,7 +10,7 @@ import sys
 import threading
 import time
 import yaml
-import argparse
+import os
 
 import sonic_platform
 from sonic_py_common import daemon_base, logger, device_info
@@ -22,6 +22,8 @@ SYSLOG_IDENTIFIER = 'sensormond'
 NOT_AVAILABLE     = 'N/A'
 CHASSIS_INFO_KEY  = 'chassis 1'
 INVALID_SLOT      = -1
+
+PLATFORM_ENV_CONF_FILE = "/usr/share/sonic/platform/platform_env.conf"
 
 PHYSICAL_ENTITY_INFO_TABLE = 'PHYSICAL_ENTITY_INFO'
 
@@ -201,7 +203,6 @@ class VoltageUpdater(SensorUpdater):
         self.log_debug("Start voltage update")
 
         sensor_list = self.fs_sensors + self.chassis.get_all_voltage_sensors()
-
         for index, voltage_sensor in enumerate(sensor_list):
             if(stop_event_signal.is_set()):
                 self.log_info("Stop signal received while running voltage update")
@@ -461,8 +462,9 @@ class SensorMonitorDaemon(daemon_base.DaemonBase):
     INITIAL_INTERVAL = 5
     # Periodic Update interval 
     UPDATE_INTERVAL = 60
+    UPDATE_ELAPSED_THRESHOLD = 30
 
-    def __init__(self, update_elapsed_threshold):
+    def __init__(self):
         '''
         Initializer of SensorMonitorDaemon
         '''
@@ -479,6 +481,17 @@ class SensorMonitorDaemon(daemon_base.DaemonBase):
 
         self._voltage_sensor_fs = []
         self._current_sensor_fs = []
+
+        if os.path.isfile(PLATFORM_ENV_CONF_FILE):
+            with open(PLATFORM_ENV_CONF_FILE, 'r') as file:
+                for line in file:
+                    content = line.split('=')
+                    if(content[0].strip() == "SENSORMOND_WARNING_TIME"):
+                        try:
+                            self.UPDATE_ELAPSED_THRESHOLD = int(content[1].strip())
+                        except ValueError as e:
+                            self.log_error(f"Failed to load warning time, falling back to default, err: {e}")
+                            break
 
         try:
             self.chassis = sonic_platform.platform.Platform().get_chassis()
@@ -559,12 +572,7 @@ class SensorMonitorDaemon(daemon_base.DaemonBase):
 # Main =========================================================================
 #
 def main():
-    parser = argparse.ArgumentParser()
-    # A threshold for monitoring being excessive can differ wildly per vendor and platform, as such allow it to be configured
-    parser.add_argument('-u', '--update_elapsed_threshold', type=int, default=30, help='configure a threshold in seconds for update to trigger a log warning, defaults to 30 seconds')
-    args = parser.parse_args()
-
-    sensor_control = SensorMonitorDaemon(args.update_elapsed_threshold)
+    sensor_control = SensorMonitorDaemon()
 
     sensor_control.log_info("Starting up...")
 

--- a/sonic-sensormond/scripts/sensormond
+++ b/sonic-sensormond/scripts/sensormond
@@ -226,6 +226,8 @@ class VoltageUpdater(SensorUpdater):
                 self._remove_voltage_sensor_from_db(voltage_sensor, parent_name, voltage_sensor_index)
                 
         self.log_debug("End Voltage updating")
+        #return true if no stop signal was received
+        return True
 
     def _refresh_voltage_status(self, parent_name, voltage_sensor, voltage_sensor_index):
         '''
@@ -364,6 +366,8 @@ class CurrentUpdater(SensorUpdater):
                 self._remove_current_sensor_from_db(current_sensor, parent_name, current_sensor_index)
                 
         self.log_debug("End Current updating")
+        #return true if no stop signal was received
+        return True
 
     def _refresh_current_status(self, parent_name, current_sensor, current_sensor_index):
         '''

--- a/sonic-sensormond/scripts/sensormond
+++ b/sonic-sensormond/scripts/sensormond
@@ -10,6 +10,7 @@ import sys
 import threading
 import time
 import yaml
+import argparse
 
 import sonic_platform
 from sonic_py_common import daemon_base, logger, device_info
@@ -191,9 +192,10 @@ class VoltageUpdater(SensorUpdater):
 
         self.fs_sensors = fs_sensors
 
-    def update(self):
+    def update(self, stop_event_signal):
         '''
         Update all voltage information to database
+        :param stop_event_signal: Event object to check if set by signal handler
         :return:
         '''
         self.log_debug("Start voltage update")
@@ -201,6 +203,9 @@ class VoltageUpdater(SensorUpdater):
         sensor_list = self.fs_sensors + self.chassis.get_all_voltage_sensors()
 
         for index, voltage_sensor in enumerate(sensor_list):
+            if(stop_event_signal.is_set()):
+                self.log_info("Stop signal received while running voltage update")
+                return False
             self._refresh_voltage_status(CHASSIS_INFO_KEY, voltage_sensor, index)
 
         if self.is_chassis_system:
@@ -210,6 +215,9 @@ class VoltageUpdater(SensorUpdater):
                 
                 for voltage_sensor_index, voltage_sensor in enumerate(module.get_all_voltage_sensors()):
                     available_voltage_sensors.add((voltage_sensor, module_name, voltage_sensor_index))
+                    if(stop_event_signal.is_set()):
+                        self.log_info("Stop signal received while running voltage update")
+                        return False
                     self._refresh_voltage_status(module_name, voltage_sensor, voltage_sensor_index)
 
             voltage_sensors_to_remove = self.module_voltage_sensors - available_voltage_sensors
@@ -322,9 +330,10 @@ class CurrentUpdater(SensorUpdater):
 
         self.fs_sensors = fs_sensors
 
-    def update(self):
+    def update(self, stop_event_signal):
         '''
         Update all current information to database
+        :param stop_event_signal: Event object to check if set by signal handler
         :return:
         '''
         self.log_debug("Start current updating")
@@ -332,6 +341,9 @@ class CurrentUpdater(SensorUpdater):
         sensor_list = self.fs_sensors + self.chassis.get_all_current_sensors()
 
         for index, current_sensor in enumerate(sensor_list):
+            if(stop_event_signal.is_set()):
+                self.log_info("Stop signal received while running current update")
+                return False
             self._refresh_current_status(CHASSIS_INFO_KEY, current_sensor, index)
 
         if self.is_chassis_system:
@@ -341,6 +353,9 @@ class CurrentUpdater(SensorUpdater):
                 
                 for current_sensor_index, current_sensor in enumerate(module.get_all_current_sensors()):
                     available_current_sensors.add((current_sensor, module_name, current_sensor_index))
+                    if(stop_event_signal.is_set()):
+                        self.log_info("Stop signal received while running current update")
+                        return False
                     self._refresh_current_status(module_name, current_sensor, current_sensor_index)
 
             current_sensors_to_remove = self.module_current_sensors - available_current_sensors
@@ -442,10 +457,8 @@ class SensorMonitorDaemon(daemon_base.DaemonBase):
     INITIAL_INTERVAL = 5
     # Periodic Update interval 
     UPDATE_INTERVAL = 60
-    # Update time threshold. If update time exceeds this threshold, log warning msg.
-    UPDATE_ELAPSED_THRESHOLD = 30
 
-    def __init__(self):
+    def __init__(self, update_elapsed_threshold):
         '''
         Initializer of SensorMonitorDaemon
         '''
@@ -522,8 +535,9 @@ class SensorMonitorDaemon(daemon_base.DaemonBase):
 
         begin = time.time()
 
-        self.voltage_updater.update()
-        self.current_updater.update()
+        if not (self.voltage_updater.update(self.stop_event) or self.current_updater.update(self.stop_event)):
+            # Fatal signal received in the process of reading voltage or current sensors
+            return False
 
         elapsed = time.time() - begin
         if elapsed <  self.interval:
@@ -541,7 +555,12 @@ class SensorMonitorDaemon(daemon_base.DaemonBase):
 # Main =========================================================================
 #
 def main():
-    sensor_control = SensorMonitorDaemon()
+    parser = argparse.ArgumentParser()
+    # A threshold for monitoring being excessive can differ wildly per vendor and platform, as such allow it to be configured
+    parser.add_argument('-u', '--update_elapsed_threshold', type=int, default=30, help='configure a threshold in seconds for update to trigger a log warning, defaults to 30 seconds')
+    args = parser.parse_args()
+
+    sensor_control = SensorMonitorDaemon(args.update_elapsed_threshold)
 
     sensor_control.log_info("Starting up...")
 

--- a/sonic-sensormond/scripts/sensormond
+++ b/sonic-sensormond/scripts/sensormond
@@ -192,7 +192,7 @@ class VoltageUpdater(SensorUpdater):
 
         self.fs_sensors = fs_sensors
 
-    def update(self, stop_event_signal):
+    def update(self, stop_event_signal = threading.Event()):
         '''
         Update all voltage information to database
         :param stop_event_signal: Event object to check if set by signal handler
@@ -332,7 +332,7 @@ class CurrentUpdater(SensorUpdater):
 
         self.fs_sensors = fs_sensors
 
-    def update(self, stop_event_signal):
+    def update(self, stop_event_signal = threading.Event()):
         '''
         Update all current information to database
         :param stop_event_signal: Event object to check if set by signal handler

--- a/sonic-sensormond/tests/test_sensormond.py
+++ b/sonic-sensormond/tests/test_sensormond.py
@@ -33,6 +33,8 @@ swsscommon.FieldValuePairs = FieldValuePairs
 VOLTAGE_INFO_TABLE_NAME = 'VOLTAGE_INFO'
 CURRENT_INFO_TABLE_NAME = 'CURRENT_INFO'
 
+UPDATE_ELAPSED_THRESHOLD = 30
+
 @pytest.fixture(scope='function', autouse=True)
 def configure_mocks():
     sensormond.SensorStatus.log_notice = mock.MagicMock()
@@ -70,7 +72,6 @@ def test_sensor_status_set_over_threshold():
     assert ret
     assert not sensor_status.over_threshold
 
-
 def test_sensor_status_set_under_threshold():
     sensor_status = sensormond.SensorStatus()
     ret = sensor_status.set_under_threshold(sensormond.NOT_AVAILABLE, sensormond.NOT_AVAILABLE)
@@ -89,7 +90,6 @@ def test_sensor_status_set_under_threshold():
     ret = sensor_status.set_under_threshold(2, 1)
     assert ret
     assert not sensor_status.under_threshold
-
 
 def test_sensor_status_set_not_available():
     SENSOR_NAME = 'Chassis 1 Sensor 1'
@@ -188,6 +188,33 @@ class TestVoltageUpdater(object):
         voltage_updater.update()
         assert len(voltage_updater.module_voltage_sensors) == 0
 
+    def test_update_with_stop_event_handling(self):
+        #test for sensor iteration stop checks
+        chassis = MockChassis()
+        voltage_updater = sensormond.VoltageUpdater(chassis, [])
+        voltage_updater.log_info = mock.MagicMock()
+
+        stop_event = threading.Event()
+        stop_event.set()
+
+        result = voltage_updater.update(stop_event)
+        assert result is False
+        voltage_updater.log_info.assert_called_with("Stop signal received while running voltage update")
+
+        #test for module sensor iteration stop checks
+        chassis = MockChassis()
+        chassis.make_module_voltage_sensor()
+        chassis.set_modular_chassis(True)
+        voltage_updater = sensormond.VoltageUpdater(chassis, [])
+        voltage_updater.log_info = mock.MagicMock()
+
+        stop_event = threading.Event()
+
+        stop_event.is_set = mock.MagicMock(side_effect=[False, True])
+
+        result = voltage_updater.update(stop_event)
+        assert result is False
+        voltage_updater.log_info.assert_called_with("Stop signal received while running voltage update")
 
 class TestCurrentUpdater(object):
     """
@@ -276,8 +303,34 @@ class TestCurrentUpdater(object):
         current_updater.update()
         assert len(current_updater.module_current_sensors) == 0
 
-# Modular chassis-related tests
+    def test_update_with_stop_event_handling(self):
+        #test for sensor iteration stop checks
+        chassis = MockChassis()
+        current_updater = sensormond.CurrentUpdater(chassis, [])
+        current_updater.log_info = mock.MagicMock()
 
+        stop_event = threading.Event()
+        stop_event.set()
+        
+        result = current_updater.update(stop_event)
+        assert result is False
+        current_updater.log_info.assert_called_with("Stop signal received while running current update")
+        
+        #test for module sensor iteration stop checks
+        chassis = MockChassis()
+        chassis.make_module_current_sensor()
+        chassis.set_modular_chassis(True)
+        current_updater = sensormond.CurrentUpdater(chassis, [])
+        current_updater.log_info = mock.MagicMock()
+
+        stop_event = threading.Event()
+        stop_event.is_set = mock.MagicMock(side_effect=[False, True])
+        
+        result = current_updater.update(stop_event)
+        assert result is False
+        current_updater.log_info.assert_called_with("Stop signal received while running current update")
+
+# Modular chassis-related tests
 
 def test_updater_voltage_sensor_check_modular_chassis():
     chassis = MockChassis()
@@ -296,7 +349,6 @@ def test_updater_voltage_sensor_check_modular_chassis():
     voltage_updater = sensormond.VoltageUpdater(chassis, [])
     assert voltage_updater.chassis_table != None
     assert voltage_updater.chassis_table.table_name == '{}_{}'.format(VOLTAGE_INFO_TABLE_NAME, str(my_slot))
-
 
 def test_updater_voltage_sensor_check_chassis_table():
     chassis = MockChassis()
@@ -331,7 +383,6 @@ def test_updater_voltage_sensor_check_min_max():
     assert slot_dict['minimum_voltage'] == str(voltage_sensor.get_minimum_recorded())
     assert slot_dict['maximum_voltage'] == str(voltage_sensor.get_maximum_recorded())
 
-
 def test_updater_current_sensor_check_modular_chassis():
     chassis = MockChassis()
     assert chassis.is_modular_chassis() == False
@@ -350,7 +401,6 @@ def test_updater_current_sensor_check_modular_chassis():
     assert current_updater.chassis_table != None
     assert current_updater.chassis_table.table_name == '{}_{}'.format(CURRENT_INFO_TABLE_NAME, str(my_slot))
 
-
 def test_updater_current_sensor_check_chassis_table():
     chassis = MockChassis()
 
@@ -368,7 +418,6 @@ def test_updater_current_sensor_check_chassis_table():
     chassis.get_all_current_sensors().append(current_sensor2)
     current_updater.update()
     assert current_updater.chassis_table.get_size() == chassis.get_num_current_sensors()
-
 
 def test_updater_current_sensor_check_min_max():
     chassis = MockChassis()
@@ -448,6 +497,8 @@ def test_daemon_run():
     sonic_platform.platform.Platform = MyPlatform
 
     daemon_sensormond = sensormond.SensorMonitorDaemon()
+    assert daemon.UPDATE_ELAPSED_THRESHOLD == UPDATE_ELAPSED_THRESHOLD
+
     daemon_sensormond.stop_event.wait = mock.MagicMock(return_value=True)
     ret = daemon_sensormond.run()
     assert ret is False
@@ -457,6 +508,70 @@ def test_daemon_run():
     ret = daemon_sensormond.run()
     assert ret is True
 
+builtin_open = open  # save the unpatched version
+def sensor_mock_open(*args, **kwargs):
+    if args and args[0] == sensormond.PLATFORM_ENV_CONF_FILE:
+        return mock.mock_open(read_data="SENSORMOND_WARNING_TIME=45\nOTHER_CONFIG=value\n")(*args, **kwargs)
+    # unpatched version for every other path
+    return builtin_open(*args, **kwargs)
+
+@mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=(tests_path, '')))
+@mock.patch("builtins.open", sensor_mock_open)
+@mock.patch('os.path.isfile', mock.MagicMock(return_value=True))
+def test_daemon_init_with_valid_platform_config():
+    import sonic_platform.platform
+    class MyPlatform():
+        def get_chassis(self):
+            return MockChassis()
+    sonic_platform.platform.Platform = MyPlatform
+
+    daemon = sensormond.SensorMonitorDaemon()
+    assert daemon.UPDATE_ELAPSED_THRESHOLD == 45
+
+def sensor_mock_open_invalid(*args, **kwargs):
+    if args and args[0] == sensormond.PLATFORM_ENV_CONF_FILE:
+        return mock.mock_open(read_data="SENSORMOND_WARNING_TIME=invalid_value\n")(*args, **kwargs)
+    # unpatched version for every other path
+    return builtin_open(*args, **kwargs)
+
+@mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=(tests_path, '')))
+@mock.patch("builtins.open", sensor_mock_open_invalid)
+@mock.patch('os.path.isfile', mock.MagicMock(return_value=True))
+def test_daemon_init_with_invalid_platform_config():
+    import sonic_platform.platform
+    class MyPlatform():
+        def get_chassis(self):
+            return MockChassis()
+    sonic_platform.platform.Platform = MyPlatform
+
+    with mock.patch.object(sensormond.SensorMonitorDaemon, 'log_error') as mock_log_error:
+        daemon = sensormond.SensorMonitorDaemon()
+        # Should fall back to default value and log error
+        assert daemon.UPDATE_ELAPSED_THRESHOLD == UPDATE_ELAPSED_THRESHOLD  # default value
+        mock_log_error.assert_called_once()
+
+@mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=(tests_path, '')))
+def test_daemon_run_with_updater_stop_signal():
+    import sonic_platform.platform
+    class MyPlatform():
+        def get_chassis(self):
+            return MockChassis()
+    sonic_platform.platform.Platform = MyPlatform
+
+    daemon = sensormond.SensorMonitorDaemon()
+    daemon.stop_event.wait = mock.MagicMock(return_value=False)
+
+    daemon.voltage_updater.update = mock.MagicMock(return_value=False)
+    daemon.current_updater.update = mock.MagicMock(return_value=True)
+
+    ret = daemon.run()
+    assert ret is False
+
+    daemon.voltage_updater.update = mock.MagicMock(return_value=True)
+    daemon.current_updater.update = mock.MagicMock(return_value=False)
+
+    ret = daemon.run()
+    assert ret is False
 
 def test_try_get():
     def good_callback():
@@ -474,7 +589,6 @@ def test_try_get():
     ret = sensormond.try_get(unimplemented_callback, 'my default')
     assert ret == 'my default'
 
-
 def test_update_entity_info():
     mock_table = mock.MagicMock()
     mock_voltage_sensor = MockVoltageSensor()
@@ -486,7 +600,6 @@ def test_update_entity_info():
     sensormond.update_entity_info(mock_table, 'Parent Name', 'Key Name', mock_voltage_sensor, 1)
     assert mock_table.set.call_count == 1
     mock_table.set.assert_called_with('Key Name', expected_fvp)
-
 
 @mock.patch('sensormond.SensorMonitorDaemon.run')
 def test_main(mock_run):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
-->
Two quality of life improvements for sensormond:

1. Allow for the user to configure timeout for printing time log warning (keep default at 30), this is set in the the platform_env.conf through the `SENSORMOND_WARNING_TIME` value
2. Cascade stop events (from signal handler) into voltage and current updaters to allow for more graceful checking _during_ the update process, current setup has 10 second timeout and given the updaters can take some time to run can result in SIGKILLs getting sent during operations.

#### Motivation and Context
<!--
-->
With a lot of sensors, the logs can be filled with warnings about exceeding the time to read even if it is expected by the vendor. Additionally, with this longer time, the SIGTERM can not be checked in enough time before supervisorctl falls back to using a SIGKILL

#### How Has This Been Tested?
<!--
-->
Tested on Cisco Smartswitch, time configuration now no longer results in logs being triggered every loop and tested killing w/ `supervisorctl stop sensormond` and no longer see any error logs from system that were being hit when SIGKILL interrupted reads from driver.

#### Additional Information (Optional)
