### PR TITLE
chassisd: add fabric module information to STATE_DB

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -56,6 +56,9 @@ CHASSIS_MODULE_INFO_OPERSTATUS_FIELD = 'oper_status'
 CHASSIS_MODULE_INFO_NUM_ASICS_FIELD = 'num_asics'
 CHASSIS_MODULE_INFO_ASICS = 'asics'
 CHASSIS_MODULE_INFO_SERIAL_FIELD = 'serial'
+CHASSIS_MODULE_INFO_PRESENCE_FIELD = 'presence'
+CHASSIS_MODULE_INFO_MODEL_FIELD = 'model'
+CHASSIS_MODULE_INFO_REPLACEABLE_FIELD = 'is_replaceable'
 
 CHASSIS_ASIC_INFO_TABLE = 'CHASSIS_ASIC_TABLE'
 CHASSIS_FABRIC_ASIC_INFO_TABLE = 'CHASSIS_FABRIC_ASIC_TABLE'
@@ -79,6 +82,8 @@ DEFAULT_LINECARD_REBOOT_TIMEOUT = 180
 DEFAULT_DPU_REBOOT_TIMEOUT = 360
 PLATFORM_ENV_CONF_FILE = "/usr/share/sonic/platform/platform_env.conf"
 PLATFORM_JSON_FILE = "/usr/share/sonic/platform/platform.json"
+
+PHYSICAL_ENTITY_INFO_TABLE = 'PHYSICAL_ENTITY_INFO'
 
 CHASSIS_INFO_UPDATE_PERIOD_SECS = 10
 CHASSIS_DB_CLEANUP_MODULE_DOWN_PERIOD = 30 # Minutes
@@ -145,6 +150,15 @@ def get_formatted_time(datetimeobj=None, op_format=None):
     """
     date_obj = datetimeobj if datetimeobj else datetime.now(timezone.utc)
     return date_obj.strftime(op_format if op_format else "%a %b %d %I:%M:%S %p UTC %Y")
+
+def update_entity_info(table, parent_name, key, index, serial, model, is_replaceable):
+    fvs = swsscommon.FieldValuePairs(
+        [('position_in_parent', str(index)),
+         ('parent_name', parent_name),
+         ('serial', serial),
+         ('model', model),
+         ('is_replaceable', is_replaceable)])
+    table.set(key, fvs)
 
 #
 # Module Config Updater ========================================================
@@ -259,6 +273,7 @@ class ModuleUpdater(logger.Logger):
         self.chassis_table = swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
         self.module_table = swsscommon.Table(state_db, CHASSIS_MODULE_INFO_TABLE)
         self.midplane_table = swsscommon.Table(state_db, CHASSIS_MIDPLANE_INFO_TABLE)
+        self.phy_entity_table = swsscommon.Table(state_db, PHYSICAL_ENTITY_INFO_TABLE)
         self.info_dict_keys = [CHASSIS_MODULE_INFO_NAME_FIELD,
                                CHASSIS_MODULE_INFO_DESC_FIELD,
                                CHASSIS_MODULE_INFO_SLOT_FIELD,
@@ -301,6 +316,8 @@ class ModuleUpdater(logger.Logger):
             self.module_table._del(name)
             if self.midplane_table.get(name) is not None:
                 self.midplane_table._del(name)
+            if self.phy_entity_table.get(name) is not None:
+                self.phy_entity_table._del(name)
 
         if self.chassis_table is not None:
             self.chassis_table._del(CHASSIS_INFO_KEY_TEMPLATE.format(1))
@@ -365,9 +382,22 @@ class ModuleUpdater(logger.Logger):
                                                    str(module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD])),
                                                   (CHASSIS_MODULE_INFO_OPERSTATUS_FIELD, module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]),
                                                   (CHASSIS_MODULE_INFO_NUM_ASICS_FIELD, str(len(module_info_dict[CHASSIS_MODULE_INFO_ASICS]))),
-                                                  (CHASSIS_MODULE_INFO_SERIAL_FIELD, module_info_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD])])
+                                                  (CHASSIS_MODULE_INFO_SERIAL_FIELD, module_info_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD]),
+                                                  (CHASSIS_MODULE_INFO_PRESENCE_FIELD, module_info_dict[CHASSIS_MODULE_INFO_PRESENCE_FIELD]),
+                                                  (CHASSIS_MODULE_INFO_REPLACEABLE_FIELD, module_info_dict[CHASSIS_MODULE_INFO_REPLACEABLE_FIELD]),
+                                                  (CHASSIS_MODULE_INFO_MODEL_FIELD, module_info_dict[CHASSIS_MODULE_INFO_MODEL_FIELD])])
+
+
                 prev_status = self.get_module_current_status(key)
                 self.module_table.set(key, fvs)
+
+                update_entity_info(self.phy_entity_table,
+                                   "chassis {}".format(1),
+                                   key,
+                                   module_index,
+                                   module_info_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD],
+                                   module_info_dict[CHASSIS_MODULE_INFO_MODEL_FIELD],
+                                   module_info_dict[CHASSIS_MODULE_INFO_REPLACEABLE_FIELD])
 
                 # Construct key for down_modules dict. Example down_modules key format: LINE-CARD0|<hostname>
                 fvs = self.hostname_table.get(key)
@@ -452,6 +482,9 @@ class ModuleUpdater(logger.Logger):
         asics = try_get(self.chassis.get_module(module_index).get_all_asics,
                         default=[])
         serial = try_get(self.chassis.get_module(module_index).get_serial)
+        presence = try_get(self.chassis.get_module(module_index).get_presence)
+        replaceable = try_get(self.chassis.get_module(module_index).is_replaceable)
+        model = try_get(self.chassis.get_module(module_index).get_model)
 
         module_info_dict[CHASSIS_MODULE_INFO_NAME_FIELD] = name
         module_info_dict[CHASSIS_MODULE_INFO_DESC_FIELD] = str(desc)
@@ -459,6 +492,9 @@ class ModuleUpdater(logger.Logger):
         module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD] = str(status)
         module_info_dict[CHASSIS_MODULE_INFO_ASICS] = asics
         module_info_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD] = str(serial)
+        module_info_dict[CHASSIS_MODULE_INFO_PRESENCE_FIELD] = str(presence)
+        module_info_dict[CHASSIS_MODULE_INFO_REPLACEABLE_FIELD] = str(replaceable)
+        module_info_dict[CHASSIS_MODULE_INFO_MODEL_FIELD] = str(model)
 
         return module_info_dict
 

--- a/sonic-chassisd/tests/mock_platform.py
+++ b/sonic-chassisd/tests/mock_platform.py
@@ -4,6 +4,7 @@ class MockDevice:
         self.presence = True
         self.model = 'Module Model'
         self.serial = 'Module Serial'
+        self.replaceable = True
 
     def get_name(self):
         return self.name
@@ -17,10 +18,13 @@ class MockDevice:
     def get_serial(self):
         return self.serial
 
+    def is_replaceable(self):
+        return self.replaceable
 
 class MockModule(MockDevice):
     def __init__(self, module_index, module_name, module_desc, module_type, module_slot,
                  module_serial, asic_list=[]):
+        super(MockModule, self).__init__()
         self.module_index = module_index
         self.module_name = module_name
         self.module_desc = module_desc
@@ -32,7 +36,7 @@ class MockModule(MockDevice):
         self.midplane_access = False
         self.asic_list = asic_list
         self.module_serial = module_serial
- 
+
     def get_name(self):
         return self.module_name
 
@@ -82,6 +86,18 @@ class MockModule(MockDevice):
 
     def get_serial(self):
         return self.module_serial
+
+    def set_serial(self, serial):
+        self.serial = serial
+
+    def set_replaceable(self, replaceable):
+        self.replaceable = replaceable
+
+    def set_model(self, model):
+        self.model = model
+
+    def set_presence(self, presence):
+        self.presence = presence
 
 class MockChassis:
     def __init__(self):

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -39,6 +39,9 @@ CHASSIS_MODULE_INFO_DESC_FIELD = 'desc'
 CHASSIS_MODULE_INFO_SLOT_FIELD = 'slot'
 CHASSIS_MODULE_INFO_OPERSTATUS_FIELD = 'oper_status'
 CHASSIS_MODULE_INFO_SERIAL_FIELD = 'serial'
+CHASSIS_MODULE_INFO_PRESENCE_FIELD = 'presence'
+CHASSIS_MODULE_INFO_MODEL_FIELD = 'model'
+CHASSIS_MODULE_INFO_REPLACEABLE_FIELD = 'is_replaceable'
 
 CHASSIS_INFO_KEY_TEMPLATE = 'CHASSIS {}'
 CHASSIS_INFO_CARD_NUM_FIELD = 'module_num'
@@ -71,10 +74,16 @@ def test_moduleupdater_check_valid_fields():
     serial = "FC1000101"
     module_type = ModuleBase.MODULE_TYPE_FABRIC
     module = MockModule(index, name, desc, module_type, slot, serial)
+    replaceable = True
+    presence = True
+    model = 'N/A'
 
     # Set initial state
     status = ModuleBase.MODULE_STATUS_ONLINE
     module.set_oper_status(status)
+    module.set_replaceable(replaceable)
+    module.set_presence(presence)
+    module.set_model(model)
 
     chassis.module_list.append(module)
 
@@ -87,6 +96,44 @@ def test_moduleupdater_check_valid_fields():
     assert desc == fvs[CHASSIS_MODULE_INFO_DESC_FIELD]
     assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
     assert serial == fvs[CHASSIS_MODULE_INFO_SERIAL_FIELD]
+    assert model == fvs[CHASSIS_MODULE_INFO_MODEL_FIELD]
+    assert str(replaceable) == fvs[CHASSIS_MODULE_INFO_REPLACEABLE_FIELD]
+    assert str(presence) == fvs[CHASSIS_MODULE_INFO_PRESENCE_FIELD]
+
+def test_moduleupdater_check_phyentity_fields():
+    chassis = MockChassis()
+    index = 0
+    name = "FABRIC-CARD0"
+    desc = "Switch Fabric Module"
+    slot = 10
+    serial = "FC1000101"
+    module_type = ModuleBase.MODULE_TYPE_FABRIC
+    module = MockModule(index, name, desc, module_type, slot, serial)
+    replaceable = True
+    presence = True
+    model = 'N/A'
+    parent_name = 'chassis 1'
+
+    # Set initial state
+    status = ModuleBase.MODULE_STATUS_ONLINE
+    module.set_oper_status(status)
+    module.set_replaceable(replaceable)
+    module.set_presence(presence)
+    module.set_model(model)
+
+    chassis.module_list.append(module)
+
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
+                                   module.supervisor_slot)
+    module_updater.module_db_update()
+    fvs = module_updater.phy_entity_table.get(name)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert str(index) == fvs['position_in_parent']
+    assert parent_name == fvs['parent_name']
+    assert serial == fvs[CHASSIS_MODULE_INFO_SERIAL_FIELD]
+    assert model == fvs[CHASSIS_MODULE_INFO_MODEL_FIELD]
+    assert str(replaceable) == fvs[CHASSIS_MODULE_INFO_REPLACEABLE_FIELD]
 
 def test_smartswitch_moduleupdater_check_valid_fields():
     chassis = MockSmartSwitchChassis()

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -299,7 +299,7 @@ class FanUpdater(logger.Logger):
         if fan_type == FanType.PSU:
             parent_name = 'PSU {}'.format(parent_index + 1)
         elif fan_type == FanType.MODULE:
-            parent_name = 'Module {}'.format(parent_index + 1)
+            parent_name = try_get(parent.get_name, default='Module {}'.format(parent_index + 1))
         else:
             parent_name = drawer_name if drawer_name != NOT_AVAILABLE else CHASSIS_INFO_KEY
         fan_name = try_get(fan.get_name, '{} fan {}'.format(parent_name, fan_index + 1))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

1. Add Fabric Card Module information to STATE_DB. This information
is necessary as in the tests we expect for fans under fabric cards,
their parent information (i.e fabric cards) is also present in the
`PHYSICAL_ENTITY_INFO` of `STATE_DB`.

2. Rather than storing a module by its index, store it by its name.
This makes it easier to refer to modules as sometimes index/position
of module may change, but it's name remains consistent.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

This was done as part of changes to fix https://github.com/sonic-net/sonic-mgmt/issues/16189,
where the test was failing as we expect parent of fan to be present, but
for fans under fabric modules, fabric modules were not present in `STATE_DB`.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Added a unit-test which tests whether `PHYSICAL_ENTITY_INFO` is updated
when a fabric module is inserted.

Also, tested manually by checking `STATE_DB` on internal machines.

#### Additional Information (Optional)

Other PR's of interest for this change: https://github.com/sonic-net/sonic-snmpagent/pull/349, https://github.com/sonic-net/sonic-mgmt/pull/17686
