### PR TITLE
[xcvrd] Add wait based on MaxDurationDPTxTurnOff after disabling Tx

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2264,6 +2264,27 @@ class TestXcvrdScript(object):
         ret = task.post_port_active_apsel_to_db(mock_xcvr_api, lport, host_lanes_mask)
         assert int_tbl.getKeys() == []
 
+    @pytest.mark.parametrize(
+        "expired_time, current_time, expected_result",
+        [
+            (None, datetime.datetime(2025, 3, 26, 12, 0, 0), False),  # Case 1: expired_time is None
+            (datetime.datetime(2025, 3, 26, 12, 10, 0), datetime.datetime(2025, 3, 26, 12, 0, 0), False),  # Case 2: expired_time is in the future
+            (datetime.datetime(2025, 3, 26, 11, 50, 0), datetime.datetime(2025, 3, 26, 12, 0, 0), True),  # Case 3: expired_time is in the past
+            (datetime.datetime(2025, 3, 26, 12, 0, 0), datetime.datetime(2025, 3, 26, 12, 0, 0), True),  # Case 4: expired_time is exactly now
+            (datetime.datetime(2025, 2, 26, 12, 0, 0), None, True),  # Case 5: current_time is None
+        ],
+    )
+    def test_CmisManagerTask_test_is_timer_expired(self, expired_time, current_time, expected_result):
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
+
+        # Call the is_timer_expired function
+        result = task.is_timer_expired(expired_time, current_time)
+
+        # Assert the result matches the expected output
+        assert result == expected_result
+
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_status_tbl')
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd.is_fast_reboot_enabled', MagicMock(return_value=(False)))
@@ -2370,6 +2391,16 @@ class TestXcvrdScript(object):
                 'DP8State': 'DataPathDeactivated'
             },
             {
+                'DP1State': 'DataPathDeactivated',
+                'DP2State': 'DataPathDeactivated',
+                'DP3State': 'DataPathDeactivated',
+                'DP4State': 'DataPathDeactivated',
+                'DP5State': 'DataPathDeactivated',
+                'DP6State': 'DataPathDeactivated',
+                'DP7State': 'DataPathDeactivated',
+                'DP8State': 'DataPathDeactivated'
+            },
+            {
                 'DP1State': 'DataPathInitialized',
                 'DP2State': 'DataPathInitialized',
                 'DP3State': 'DataPathInitialized',
@@ -2462,10 +2493,14 @@ class TestXcvrdScript(object):
         task.get_port_admin_status = MagicMock(return_value='up')
         task.get_configured_tx_power_from_db = MagicMock(return_value=-13)
         task.get_configured_laser_freq_from_db = MagicMock(return_value=193100)
+        task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
+        task.task_worker()
+
+        assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_DP_PRE_INIT_CHECK
         task.configure_tx_output_power = MagicMock(return_value=1)
         task.configure_laser_frequency = MagicMock(return_value=1)
 
-        # Case 1: Module Inserted --> DP_DEINIT
+        # Case 1: CMIS_STATE_DP_PRE_INIT_CHECK --> DP_DEINIT
         task.is_appl_reconfigure_required = MagicMock(return_value=True)
         mock_xcvr_api.decommission_all_datapaths = MagicMock(return_value=True)
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
@@ -2559,6 +2594,7 @@ class TestXcvrdScript(object):
         mock_xcvr_api.get_tx_config_power = MagicMock(return_value=0)
         mock_xcvr_api.get_laser_config_freq = MagicMock(return_value=0)
         mock_xcvr_api.get_module_type_abbreviation = MagicMock(return_value='QSFP-DD')
+        mock_xcvr_api.get_datapath_tx_turnoff_duration = MagicMock(return_value=500.0)
         mock_xcvr_api.get_datapath_init_duration = MagicMock(return_value=60000.0)
         mock_xcvr_api.get_module_pwr_up_duration = MagicMock(return_value=70000.0)
         mock_xcvr_api.get_datapath_deinit_duration = MagicMock(return_value=600000.0)
@@ -2684,7 +2720,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd._wrapper_get_sfp_type', MagicMock(return_value='QSFP_DD'))
     @patch('xcvrd.xcvrd.CmisManagerTask.wait_for_port_config_done', MagicMock())
     @patch('xcvrd.xcvrd.is_cmis_api', MagicMock(return_value=True))
-    def test_CmisManagerTask_task_worker_host_tx_ready_false(self, mock_chassis, mock_get_status_tbl):
+    def test_CmisManagerTask_task_worker_host_tx_ready_false_to_true(self, mock_chassis, mock_get_status_tbl):
         mock_get_status_tbl = Table("STATE_DB", TRANSCEIVER_STATUS_TABLE)
         mock_xcvr_api = MagicMock()
         mock_xcvr_api.set_datapath_deinit = MagicMock(return_value=True)
@@ -2697,6 +2733,7 @@ class TestXcvrdScript(object):
         mock_xcvr_api.get_tx_config_power = MagicMock(return_value=0)
         mock_xcvr_api.get_laser_config_freq = MagicMock(return_value=0)
         mock_xcvr_api.get_module_type_abbreviation = MagicMock(return_value='QSFP-DD')
+        mock_xcvr_api.get_datapath_tx_turnoff_duration = MagicMock(return_value=500.0)
         mock_xcvr_api.get_datapath_init_duration = MagicMock(return_value=60000.0)
         mock_xcvr_api.get_module_pwr_up_duration = MagicMock(return_value=70000.0)
         mock_xcvr_api.get_datapath_deinit_duration = MagicMock(return_value=600000.0)
@@ -2770,7 +2807,47 @@ class TestXcvrdScript(object):
                 'DP6State': 'DataPathActivated',
                 'DP7State': 'DataPathActivated',
                 'DP8State': 'DataPathActivated'
-            }
+            },
+            {
+                'DP1State': 'DataPathActivated',
+                'DP2State': 'DataPathActivated',
+                'DP3State': 'DataPathActivated',
+                'DP4State': 'DataPathActivated',
+                'DP5State': 'DataPathActivated',
+                'DP6State': 'DataPathActivated',
+                'DP7State': 'DataPathActivated',
+                'DP8State': 'DataPathActivated'
+            },
+            {
+                'DP1State': 'DataPathInitialized',
+                'DP2State': 'DataPathInitialized',
+                'DP3State': 'DataPathInitialized',
+                'DP4State': 'DataPathInitialized',
+                'DP5State': 'DataPathInitialized',
+                'DP6State': 'DataPathInitialized',
+                'DP7State': 'DataPathInitialized',
+                'DP8State': 'DataPathInitialized'
+            },
+            {
+                'DP1State': 'DataPathInitialized',
+                'DP2State': 'DataPathInitialized',
+                'DP3State': 'DataPathInitialized',
+                'DP4State': 'DataPathInitialized',
+                'DP5State': 'DataPathInitialized',
+                'DP6State': 'DataPathInitialized',
+                'DP7State': 'DataPathInitialized',
+                'DP8State': 'DataPathInitialized'
+            },
+            {
+                'DP1State': 'DataPathInitialized',
+                'DP2State': 'DataPathInitialized',
+                'DP3State': 'DataPathInitialized',
+                'DP4State': 'DataPathInitialized',
+                'DP5State': 'DataPathInitialized',
+                'DP6State': 'DataPathInitialized',
+                'DP7State': 'DataPathInitialized',
+                'DP8State': 'DataPathInitialized'
+            },
         ])
         mock_sfp = MagicMock()
         mock_sfp.get_presence = MagicMock(return_value=True)
@@ -2814,6 +2891,33 @@ class TestXcvrdScript(object):
         assert task.post_port_active_apsel_to_db.call_count == 1
         assert mock_xcvr_api.tx_disable_channel.call_count == 1
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_READY
+        assert task.port_dict['Ethernet0']['forced_tx_disabled'] == True
+
+        task.port_dict['Ethernet0']['host_tx_ready'] = 'true'
+        task.force_cmis_reinit('Ethernet0', 0)
+        task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
+        task.task_worker()
+        assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_DP_PRE_INIT_CHECK
+
+        # Failure scenario wherein DP state is still DataPathActivated in the first attempt post enabling host_tx_ready
+        # This doesn't allow the CMIS state to proceed to DP_DEINIT
+        task.is_timer_expired = MagicMock(return_value=(True))
+        task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, False, False, True])
+        task.task_worker()
+        assert task.port_dict['Ethernet0']['cmis_retries'] == 1
+        assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_DP_PRE_INIT_CHECK
+
+        # Ensures that CMIS state is set to DP_DEINIT in the second attempt
+        mock_sfp = MagicMock()
+        mock_sfp.get_xcvr_api = MagicMock(return_value=mock_xcvr_api)
+        mock_xcvr_api.is_coherent_module = MagicMock(return_value=False)
+        task.is_appl_reconfigure_required = MagicMock(return_value=False)
+        task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
+        task.task_worker()
+
+        assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_DP_DEINIT
+        assert task.port_dict['Ethernet0']['forced_tx_disabled'] == False
+        assert task.port_dict['Ethernet0']['cmis_retries'] == 1
 
     @pytest.mark.parametrize("lport, expected_dom_polling", [
         ('Ethernet0', 'disabled'),

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -55,6 +55,7 @@ TRANSCEIVER_STATUS_TABLE_SW_FIELDS = ["status", "error", "cmis_state"]
 
 CMIS_STATE_UNKNOWN   = 'UNKNOWN'
 CMIS_STATE_INSERTED  = 'INSERTED'
+CMIS_STATE_DP_PRE_INIT_CHECK = 'DP_PRE_INIT_CHECK'
 CMIS_STATE_DP_DEINIT = 'DP_DEINIT'
 CMIS_STATE_AP_CONF   = 'AP_CONFIGURED'
 CMIS_STATE_DP_ACTIVATE = 'DP_ACTIVATION'
@@ -597,6 +598,7 @@ class CmisManagerTask(threading.Thread):
     CMIS_DEF_EXPIRED     = 60 # seconds, default expiration time
     CMIS_MODULE_TYPES    = ['QSFP-DD', 'QSFP_DD', 'OSFP', 'OSFP-8X', 'QSFP+C']
     CMIS_MAX_HOST_LANES    = 8
+    CMIS_EXPIRATION_BUFFER_MS = 2
 
     def __init__(self, namespaces, port_mapping, main_thread_stop_event, skip_cmis_mgr=False):
         threading.Thread.__init__(self)
@@ -658,6 +660,7 @@ class CmisManagerTask(threading.Thread):
         # 'index' can be -1 if STATE_DB|PORT_TABLE
         if lport not in self.port_dict:
             self.port_dict[lport] = {}
+            self.port_dict[lport]['forced_tx_disabled'] = False
 
         if port_change_event.port_dict is None:
             return
@@ -689,6 +692,9 @@ class CmisManagerTask(threading.Thread):
 
     def get_cmis_dp_deinit_duration_secs(self, api):
         return api.get_datapath_deinit_duration()/1000
+
+    def get_cmis_dp_tx_turnoff_duration_secs(self, api):
+        return api.get_datapath_tx_turnoff_duration()/1000
 
     def get_cmis_module_power_up_duration_secs(self, api):
         return api.get_module_pwr_up_duration()/1000
@@ -1094,6 +1100,37 @@ class CmisManagerTask(threading.Thread):
             if key in ["PortConfigDone", "PortInitDone"]:
                 break
 
+    def update_cmis_state_expiration_time(self, lport, duration_seconds):
+        """
+        Set the CMIS expiration time for the given logical port
+        in the port dictionary.
+        Args:
+            lport: Logical port name
+            duration_seconds: Duration in seconds for the expiration
+        """
+        self.port_dict[lport]['cmis_expired'] = datetime.datetime.now() + \
+                                                datetime.timedelta(seconds=duration_seconds) + \
+                                                datetime.timedelta(milliseconds=self.CMIS_EXPIRATION_BUFFER_MS)
+
+    def is_timer_expired(self, expired_time, current_time=None):
+        """
+        Check if the given expiration time has passed.
+
+        Args:
+            expired_time (datetime): The expiration time to check.
+            current_time (datetime, optional): The current time. Defaults to now.
+
+        Returns:
+            bool: True if expired_time is not None and has passed, False otherwise.
+        """
+        if expired_time is None:
+            return False
+
+        if current_time is None:
+            current_time = datetime.datetime.now()
+
+        return expired_time <= current_time
+
     def task_worker(self):
         self.xcvr_table_helper = XcvrTableHelper(self.namespaces)
 
@@ -1196,7 +1233,6 @@ class CmisManagerTask(threading.Thread):
                 # A retry should always start over at INSETRTED state, while the
                 # expiration will reset the state to INSETRTED and advance the
                 # retry counter
-                now = datetime.datetime.now()
                 expired = self.port_dict[lport].get('cmis_expired')
                 retries = self.port_dict[lport].get('cmis_retries', 0)
                 host_lanes_mask = self.port_dict[lport].get('host_lanes_mask', 0)
@@ -1260,10 +1296,28 @@ class CmisManagerTask(threading.Thread):
                                self.log_notice("{} Forcing Tx laser OFF".format(lport))
                                # Force DataPath re-init
                                api.tx_disable_channel(media_lanes_mask, True)
+                               self.port_dict[lport]['forced_tx_disabled'] = True
+                               txoff_duration = self.get_cmis_dp_tx_turnoff_duration_secs(api)
+                               self.log_notice("{}: Tx turn off duration {} secs".format(lport, txoff_duration))
+                               self.update_cmis_state_expiration_time(lport, txoff_duration)
                                self.post_port_active_apsel_to_db(api, lport, host_lanes_mask, reset_apsel=True)
                            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
                            continue
-                    # Configure the target output power if ZR module
+                        self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_PRE_INIT_CHECK)
+                    if state == CMIS_STATE_DP_PRE_INIT_CHECK:
+                        if self.port_dict[lport].get('forced_tx_disabled', False):
+                            # Ensure that Tx is OFF
+                            # Transceiver will remain in DataPathDeactivated state while it is in Low Power Mode (even if Tx is disabled)
+                            # Transceiver will enter DataPathInitialized state if Tx was disabled after CMIS initialization was completed
+                            if not self.check_datapath_state(api, host_lanes_mask, ['DataPathDeactivated', 'DataPathInitialized']):
+                                if self.is_timer_expired(expired):
+                                    self.log_notice("{}: timeout for 'DataPathDeactivated/DataPathInitialized'".format(lport))
+                                    self.force_cmis_reinit(lport, retries + 1)
+                                continue
+                            self.port_dict[lport]['forced_tx_disabled'] = False
+                            self.log_notice("{}: Tx laser is successfully turned OFF".format(lport))
+
+                        # Configure the target output power if ZR module
                         if api.is_coherent_module():
                            tx_power = self.port_dict[lport]['tx_power']
                            # Prevent configuring same tx power multiple times
@@ -1325,7 +1379,7 @@ class CmisManagerTask(threading.Thread):
                         dpDeinitDuration = self.get_cmis_dp_deinit_duration_secs(api)
                         modulePwrUpDuration = self.get_cmis_module_power_up_duration_secs(api)
                         self.log_notice("{}: DpDeinit duration {} secs, modulePwrUp duration {} secs".format(lport, dpDeinitDuration, modulePwrUpDuration))
-                        self.port_dict[lport]['cmis_expired'] = now + datetime.timedelta(seconds = max(modulePwrUpDuration, dpDeinitDuration))
+                        self.update_cmis_state_expiration_time(lport, max(modulePwrUpDuration, dpDeinitDuration))
 
                     elif state == CMIS_STATE_AP_CONF:
                         # Explicit control bit to apply custom Host SI settings. 
@@ -1335,13 +1389,13 @@ class CmisManagerTask(threading.Thread):
 
                         # TODO: Use fine grained time when the CMIS memory map is available
                         if not self.check_module_state(api, ['ModuleReady']):
-                            if (expired is not None) and (expired <= now):
+                            if self.is_timer_expired(expired):
                                 self.log_notice("{}: timeout for 'ModuleReady'".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
                             continue
 
                         if not self.check_datapath_state(api, host_lanes_mask, ['DataPathDeactivated']):
-                            if (expired is not None) and (expired <= now):
+                            if self.is_timer_expired(expired):
                                 self.log_notice("{}: timeout for 'DataPathDeactivated state'".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
                             continue
@@ -1389,7 +1443,7 @@ class CmisManagerTask(threading.Thread):
                         self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_INIT)
                     elif state == CMIS_STATE_DP_INIT:
                         if not self.check_config_error(api, host_lanes_mask, ['ConfigSuccess']):
-                            if (expired is not None) and (expired <= now):
+                            if self.is_timer_expired(expired):
                                 self.log_notice("{}: timeout for 'ConfigSuccess'".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
                             continue
@@ -1415,11 +1469,11 @@ class CmisManagerTask(threading.Thread):
                         api.set_datapath_init(host_lanes_mask)
                         dpInitDuration = self.get_cmis_dp_init_duration_secs(api)
                         self.log_notice("{}: DpInit duration {} secs".format(lport, dpInitDuration))
-                        self.port_dict[lport]['cmis_expired'] = now + datetime.timedelta(seconds=dpInitDuration)
+                        self.update_cmis_state_expiration_time(lport, dpInitDuration)
                         self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_TXON)
                     elif state == CMIS_STATE_DP_TXON:
                         if not self.check_datapath_state(api, host_lanes_mask, ['DataPathInitialized']):
-                            if (expired is not None) and (expired <= now):
+                            if self.is_timer_expired(expired):
                                 self.log_notice("{}: timeout for 'DataPathInitialized'".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
                             continue
@@ -1430,8 +1484,12 @@ class CmisManagerTask(threading.Thread):
                         self.log_notice("{}: Turning ON tx power".format(lport))
                         self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_ACTIVATE)
                     elif state == CMIS_STATE_DP_ACTIVATE:
+                        # Use dpInitDuration instead of MaxDurationDPTxTurnOn because
+                        # some modules rely on dpInitDuration to turn on the Tx signal.
+                        # This behavior deviates from the CMIS spec but is honored since
+                        # such modules are already in production.
                         if not self.check_datapath_state(api, host_lanes_mask, ['DataPathActivated']):
-                            if (expired is not None) and (expired <= now):
+                            if self.is_timer_expired(expired):
                                 self.log_notice("{}: timeout for 'DataPathActivated'".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
                             continue

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1486,8 +1486,8 @@ class CmisManagerTask(threading.Thread):
                     elif state == CMIS_STATE_DP_ACTIVATE:
                         # Use dpInitDuration instead of MaxDurationDPTxTurnOn because
                         # some modules rely on dpInitDuration to turn on the Tx signal.
-                        # This behavior deviates from the CMIS spec but is honored since
-                        # such modules are already in production.
+                        # This behavior deviates from the CMIS spec but is honored
+                        # to prevent old modules from breaking with new sonic
                         if not self.check_datapath_state(api, host_lanes_mask, ['DataPathActivated']):
                             if self.is_timer_expired(expired):
                                 self.log_notice("{}: timeout for 'DataPathActivated'".format(lport))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
XCVRD needs to wait for the MaxDurationDPTxTurnOff time after disabling Tx via the following API call:
https://github.com/sonic-net/sonic-platform-daemons/blob/f581c06cd8adeb4b82816ee0fc38fd07b3f9e692/sonic-xcvrd/xcvrd/xcvrd.py#L1468
This waiting period is essential to allow the module to transition to the DataPathInitialized state after disabling Tx. Failing to wait for the DataPathInitialized state may cause the module to behave unexpectedly, especially if Tx is disabled during CMIS initialization.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
One possible way to run into port permanently having Tx disabled is during boot-up
In one case, following steps led to the Tx being disabled permanently on a module during switch boot-up

- OA sets host_tx_ready to False (06:48:48.670346)
- CMIS SM transitions to DP_TXON state (06:48:48.844797)
- xcvrd updates port_dict with host_tx_ready as False (06:48:48.876416)
- OA sets host_tx_ready to True (06:48:48.922804)
- xcvrd hasn't updated port_dict yet and it disables the Tx now (06:48:49.103428)
- xcvrd updates port_dict with host_tx_ready as True (06:48:49.128350)
- xcvrd upon performing CMIS initialization finds that the port is already CMIS READY (06:48:49.468976)
    - 264ms ago, 'DP6State': 'DataPathTxTurnOn' (06:48:49.204792)

Fix
1. Added `DP_PRE_INIT_CHECK` state to allow the CMIS state machine to wait for the module to handle the Tx disabled event. The wait time for the module to handle the Tx disabled event can be read through the MaxDurationDPTxTurnOff register.
2. The CMIS state machine does not wait for MaxDurationDPTxTurnOn after enabling Tx, as some modules do not honor this time, which can cause the link to remain down for those modules.
3. Added the `update_cmis_state_expiration_time` function to update the expiration time based on the current time. Previously, the CMIS SM was reading the current time and then performing multiple accesses to the EEPROM, adding unaccounted time to the expiration time. A buffer time of 2ms is now added to the expiration time.
https://github.com/sonic-net/sonic-platform-daemons/blob/ba47670352b1778ad3732d27c646e9a1f4b9c49b/sonic-xcvrd/xcvrd/xcvrd.py#L1199
4. Added the `is_timer_expired` function to calculate the expiration time by comparing real-time rather than using the time stored in the `now` variable.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
DR8 CMIS module test
1. Issue shut and no shut on a port
2. Reset port followed by shut and no shut on all subports
4. shutdown port followed by sfputil reset followed no shutdown on 1 subport
5. Change host_tx_ready to false followed by true while port is undergoing CMIS initialization
6. Reboot the device
7. xcvrd restart

400ZR module test
1. shut and no shut on a port
2. Reset port followed by shut and no shut
4. Reboot the device

#### Additional Information (Optional)
Fixes https://github.com/sonic-net/sonic-buildimage/issues/22071