### PR TITLE
Store reboot_cause history files with json extension. Fix for #22072 

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -876,7 +876,7 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
         if prev_reboot_time is None:
             prev_reboot_time = self._get_current_time_str()
 
-        file_name = f"{prev_reboot_time}_reboot_cause.txt"
+        file_name = f"{prev_reboot_time}_reboot_cause.json"
         prev_reboot_path = self._get_history_path(module, "prev_reboot_time.txt")
 
         if os.path.exists(prev_reboot_path):
@@ -946,7 +946,7 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
                 self.chassis_state_db.delete(key)
 
         # Fetch the list of reboot cause history files
-        history_path = f"/host/reboot-cause/module/{module.lower()}/history/*_reboot_cause.txt"
+        history_path = f"/host/reboot-cause/module/{module.lower()}/history/*_reboot_cause.json"
         reboot_cause_files = glob.glob(history_path)
 
         if not reboot_cause_files:

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -842,7 +842,7 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
     def persist_dpu_reboot_time(self, module):
         """Persist the current reboot time to a file."""
         time_str = self._get_current_time_str()
-        path = self._get_history_path(module, "prev_reboot_time.txt")
+        path = os.path.join(MODULE_REBOOT_CAUSE_DIR, module.lower(), "prev_reboot_time.txt")
 
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, 'w') as f:
@@ -850,7 +850,7 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
 
     def retrieve_dpu_reboot_time(self, module):
         """Retrieve the persisted reboot time from a file."""
-        path = self._get_history_path(module, "prev_reboot_time.txt")
+        path = os.path.join(MODULE_REBOOT_CAUSE_DIR, module.lower(), "prev_reboot_time.txt")
 
         try:
             with open(path, 'r') as f:
@@ -877,7 +877,7 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
             prev_reboot_time = self._get_current_time_str()
 
         file_name = f"{prev_reboot_time}_reboot_cause.json"
-        prev_reboot_path = self._get_history_path(module, "prev_reboot_time.txt")
+        prev_reboot_path = os.path.join(MODULE_REBOOT_CAUSE_DIR, module.lower(), "prev_reboot_time.txt")
 
         if os.path.exists(prev_reboot_path):
             os.remove(prev_reboot_path)


### PR DESCRIPTION
#### Description
For SmartSwitch platform the module history files were getting stored with txt extension, where as they should have been stored with json extension.  Now storing the history files with json extension.

Fixed issue: #22072
#### Motivation and Context
The process-reboot-cause expects the reboot_cause history files to be stored with json extension.

#### How Has This Been Tested?
Unit Test on a SmartSwitch:
root@MtFuji:/home/cisco# cd /host/reboot-cause/module/dpu6
root@MtFuji:/host/reboot-cause/module/dpu6# ls -lrt
total 12
-rw-r--r-- 1 root root   40 Apr  4 07:56 reboot-cause.txt
lrwxrwxrwx 1 root root   76 Apr  4 07:56 previous-reboot-cause.json -> /host/reboot-cause/module/dpu6/history/2025_04_04_07_56_45_reboot_cause.json
drwxr-xr-x 2 root root 4096 Apr  4 07:56 history
root@MtFuji:/host/reboot-cause/module/dpu6# cd history/
root@MtFuji:/host/reboot-cause/module/dpu6/history# ls -lrt
total 12
-rw-r--r-- 1 root root 151 Apr  4 07:43 2025_04_04_07_43_03_reboot_cause.json
-rw-r--r-- 1 root root 160 Apr  4 07:52 2025_04_04_07_52_05_reboot_cause.json
-rw-r--r-- 1 root root 151 Apr  4 07:56 2025_04_04_07_56_45_reboot_cause.json
root@MtFuji:/host/reboot-cause/module/dpu6/history# cd ..
root@MtFuji:/host/reboot-cause/module/dpu6# show reboot-cause history DPU6
Device    Name                 Cause                Time                             User    Comment
--------  -------------------  -------------------  -------------------------------  ------  ------------
DPU6      2025_04_04_07_56_45  Switch rebooted DPU  Fri Apr 04 07:56:45 AM UTC 2025          Non-Hardware
DPU6      2025_04_04_07_52_05  Reboot               Fri Apr 04 07:52:05 AM UTC 2025          Non-Hardware
DPU6      2025_04_04_07_43_03  Switch rebooted DPU  Fri Apr 04 07:43:03 AM UTC 2025          Non-Hardware
