### PR TITLE
Chassisd does not wait for the execution to complete for previous admin state change requests. Fixed issue #22138

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -248,7 +248,7 @@ class SmartSwitchModuleConfigUpdater(logger.Logger):
 
         if (admin_state == MODULE_ADMIN_DOWN) or (admin_state == MODULE_ADMIN_UP):
             self.log_info("Changing module {} to admin {} state".format(key, 'DOWN' if admin_state == MODULE_ADMIN_DOWN else 'UP'))
-            t = threading.Thread(target=self.submit_callback, args=(module_index, admin_state, key))
+            t = threading.Thread(target=self.submit_callback, args=(module_index, admin_state))
             t.start()
         else:
             self.log_warning("Invalid admin_state value: {}".format(admin_state))

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -1362,7 +1362,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
         # Update or add transition fields only
         fvs_dict.update({
             'state_transition_in_progress': 'True',
-            'transition_start_time': datetime.utcnow().isoformat()
+            'transition_start_time': get_formatted_time()
         })
 
         # Write merged data back

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -651,6 +651,9 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
 
         self.chassis = chassis
         self.num_modules = self.chassis.get_num_modules()
+        # Connect to CONFIG_DB
+        self.config_db = swsscommon.ConfigDBConnector()
+        self.config_db.connect()
         # Connect to STATE_DB and create chassis info tables
         state_db = daemon_base.db_connect("STATE_DB")
         self.chassis_table = swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
@@ -740,6 +743,11 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
                     # Persist dpu down time
                     self.persist_dpu_reboot_time(key)
 
+                    # Clear transition flag in CONFIG_DB
+                    entry = self.config_db.get_entry('CHASSIS_MODULE', key)
+                    entry['state_transition_in_progress'] = 'False'
+                    self.config_db.set_entry('CHASSIS_MODULE', key, entry)
+
                 elif prev_status == str(ModuleBase.MODULE_STATUS_OFFLINE) and current_status != str(ModuleBase.MODULE_STATUS_OFFLINE):
                     self.log_notice("{} operational status transitioning to online".format(key))
                     reboot_cause = try_get(self.chassis.get_module(module_index).get_reboot_cause)
@@ -749,6 +757,11 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
                         self.persist_dpu_reboot_cause(reboot_cause, key)
                         # publish reboot cause to db
                         self.update_dpu_reboot_cause_to_db(key)
+
+                    # Clear transition flag in CONFIG_DB
+                    entry = self.config_db.get_entry('CHASSIS_MODULE', key)
+                    entry['state_transition_in_progress'] = 'False'
+                    self.config_db.set_entry('CHASSIS_MODULE', key, entry)
 
     def _get_module_info(self, module_index):
         """

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -711,11 +711,13 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
             return 'empty'
 
     def clear_transition_flag(self, key):
-        status, fvs = self.module_table.get(key)
+        config_db = daemon_base.db_connect("CONFIG_DB")
+        chassis_module_table = swsscommon.Table(config_db, CHASSIS_CFG_TABLE)
+        status, fvs = chassis_module_table.get(key)
         if status:
             fvs_dict = dict(fvs)
             fvs_dict['state_transition_in_progress'] = 'False'
-            self.module_table.set(key, list(fvs_dict.items()))
+            chassis_module_table.set(key, list(fvs_dict.items()))
         else:
             self.log_error("Could not clear module admin_status transition flag! {}".format(key))
 

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -197,14 +197,15 @@ class ModuleConfigUpdater(logger.Logger):
 
 class SmartSwitchModuleConfigUpdater(logger.Logger):
 
-    def __init__(self, log_identifier, chassis):
+    def __init__(self, log_identifier, chassis, module_table, set_flag_callback):
         """
         Constructor for SmartSwitchModuleConfigUpdater
         :param chassis: Object representing a platform chassis
         """
         super(SmartSwitchModuleConfigUpdater, self).__init__(log_identifier)
-
         self.chassis = chassis
+        self.module_table = module_table
+        self.set_transition_flag = set_flag_callback
 
     def deinit(self):
         """
@@ -227,12 +228,14 @@ class SmartSwitchModuleConfigUpdater(logger.Logger):
 
         if (admin_state == MODULE_ADMIN_DOWN) or (admin_state == MODULE_ADMIN_UP):
             self.log_info("Changing module {} to admin {} state".format(key, 'DOWN' if admin_state == MODULE_ADMIN_DOWN else 'UP'))
-            t = threading.Thread(target=self.submit_callback, args=(module_index, admin_state))
+            t = threading.Thread(target=self.submit_callback, args=(module_index, admin_state, key))
             t.start()
         else:
             self.log_warning("Invalid admin_state value: {}".format(admin_state))
 
-    def submit_callback(self, module_index, admin_state):
+    def submit_callback(self, module_index, admin_state, module_name):
+        # Set transition flag before starting the admin state change
+        self.set_transition_flag(self.module_table, module_name)
         try_get(self.chassis.get_module(module_index).set_admin_state, admin_state, default=False)
         pass
 
@@ -711,15 +714,26 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
             return 'empty'
 
     def clear_transition_flag(self, key):
-        config_db = daemon_base.db_connect("CONFIG_DB")
-        chassis_module_table = swsscommon.Table(config_db, CHASSIS_CFG_TABLE)
-        status, fvs = chassis_module_table.get(key)
-        if status:
+        status, fvs = self.module_table.get(key)
+        if status and fvs:
             fvs_dict = dict(fvs)
-            fvs_dict['state_transition_in_progress'] = 'False'
-            chassis_module_table.set(key, list(fvs_dict.items()))
+            if 'state_transition_in_progress' in fvs_dict:
+                fvs_dict['state_transition_in_progress'] = 'False'
+            else:
+                self.log_warning(f"Transition flag not found in {key}, adding it as False.")
+                fvs_dict['state_transition_in_progress'] = 'False'
+            self.module_table.set(key, list(fvs_dict.items()))
         else:
-            self.log_error("Could not clear module admin_status transition flag! {}".format(key))
+            self.log_error(f"Could not clear module admin_status transition flag for {key}")
+
+    def clear_all_transition_flags(self):
+        self.log_warning("Clearing all stale state_transition_in_progress flags at startup")
+        keys = self.module_table.getKeys()
+        for key in keys:
+            try:
+                self.clear_transition_flag(key)
+            except Exception as e:
+                self.log_error(f"Failed to clear transition flag for {key}: {e}")
 
     def module_db_update(self):
         for module_index in range(0, self.num_modules):
@@ -1101,15 +1115,23 @@ class ConfigManagerTask(ProcessTaskBase):
 
 
 class SmartSwitchConfigManagerTask(ProcessTaskBase):
-    def __init__(self):
-        ProcessTaskBase.__init__(self)
-
-        # TODO: Refactor to eliminate the need for this Logger instance
+    def __init__(self, set_transition_flag_callback):
+        super(SmartSwitchConfigManagerTask, self).__init__()
         self.logger = logger.Logger(SYSLOG_IDENTIFIER)
+        self.set_transition_flag = set_transition_flag_callback
+        self.config_updater = None
 
     def task_worker(self):
-        self.config_updater = SmartSwitchModuleConfigUpdater(SYSLOG_IDENTIFIER, get_chassis())
         config_db = daemon_base.db_connect("CONFIG_DB")
+        state_db = daemon_base.db_connect("STATE_DB")
+        module_table = swsscommon.Table(state_db, CHASSIS_MODULE_INFO_TABLE)
+
+        self.config_updater = SmartSwitchModuleConfigUpdater(
+            SYSLOG_IDENTIFIER,
+            get_chassis(),
+            module_table,
+            self.set_transition_flag
+        )
 
         # Subscribe to CHASSIS_MODULE table notifications in the Config DB
         sel = swsscommon.Select()
@@ -1278,7 +1300,26 @@ class ChassisdDaemon(daemon_base.DaemonBase):
         else:
             self.log_warning("Caught unhandled signal '{}' - ignoring...".format(SIGNALS_TO_NAMES_DICT[sig]))
 
-    def submit_dpu_callback(self, module_index, admin_state):
+    def set_transition_flag(self, module_table, key):
+        self.log_info(f"set transition flag: key={key}")
+
+        _, fvs = module_table.get(key)
+
+        # Merge existing fields, preserving all others
+        fvs_dict = dict(fvs) if fvs else {}
+
+        # Update or add transition fields only
+        fvs_dict.update({
+            'state_transition_in_progress': 'True',
+            'transition_start_time': datetime.utcnow().isoformat()
+        })
+
+        # Write merged data back
+        module_table.set(key, list(fvs_dict.items()))
+
+    def submit_dpu_callback(self, module_index, admin_state, module_name):
+        # Set admin_state change in progress using the centralized method
+        self.set_transition_flag(self.module_updater.module_table, module_name)
         try_get(self.module_updater.chassis.get_module(module_index).set_admin_state, admin_state, default=False)
         pass
 
@@ -1308,7 +1349,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
 
                 if op is not None:
                     # Create and start a thread for the DPU logic
-                    thread = threading.Thread(target=self.submit_dpu_callback, args=(module_index, op))
+                    thread = threading.Thread(target=self.submit_dpu_callback, args=(module_index, op, module_name))
                     thread.daemon = True  # Set as a daemon thread
                     thread.start()
                     threads.append(thread)
@@ -1344,7 +1385,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
 
         # Start configuration manager task
         if self.smartswitch:
-            config_manager = SmartSwitchConfigManagerTask()
+            config_manager = SmartSwitchConfigManagerTask(self.set_transition_flag)
             config_manager.task_run()
         elif self.module_updater.supervisor_slot == self.module_updater.my_slot:
             config_manager = ConfigManagerTask()
@@ -1357,6 +1398,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
 
         # Set the initial DPU admin state for SmartSwitch
         if self.smartswitch:
+            self.module_updater.clear_all_transition_flags()
             self.set_initial_dpu_admin_state()
 
         while not self.stop.wait(CHASSIS_INFO_UPDATE_PERIOD_SECS):

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -651,9 +651,6 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
 
         self.chassis = chassis
         self.num_modules = self.chassis.get_num_modules()
-        # Connect to CONFIG_DB
-        self.config_db = swsscommon.ConfigDBConnector()
-        self.config_db.connect()
         # Connect to STATE_DB and create chassis info tables
         state_db = daemon_base.db_connect("STATE_DB")
         self.chassis_table = swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
@@ -713,6 +710,15 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
         else:
             return 'empty'
 
+    def clear_transition_flag(self, key):
+        status, fvs = self.module_table.get(key)
+        if status:
+            fvs_dict = dict(fvs)
+            fvs_dict['state_transition_in_progress'] = 'False'
+            self.module_table.set(key, list(fvs_dict.items()))
+        else:
+            self.log_error("Could not clear module admin_status transition flag! {}".format(key))
+
     def module_db_update(self):
         for module_index in range(0, self.num_modules):
             module_info_dict = self._get_module_info(module_index)
@@ -743,10 +749,8 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
                     # Persist dpu down time
                     self.persist_dpu_reboot_time(key)
 
-                    # Clear transition flag in CONFIG_DB
-                    entry = self.config_db.get_entry('CHASSIS_MODULE', key)
-                    entry['state_transition_in_progress'] = 'False'
-                    self.config_db.set_entry('CHASSIS_MODULE', key, entry)
+                    # Clear transition flag in STATE_DB
+                    self.clear_transition_flag(key)
 
                 elif prev_status == str(ModuleBase.MODULE_STATUS_OFFLINE) and current_status != str(ModuleBase.MODULE_STATUS_OFFLINE):
                     self.log_notice("{} operational status transitioning to online".format(key))
@@ -758,10 +762,8 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
                         # publish reboot cause to db
                         self.update_dpu_reboot_cause_to_db(key)
 
-                    # Clear transition flag in CONFIG_DB
-                    entry = self.config_db.get_entry('CHASSIS_MODULE', key)
-                    entry['state_transition_in_progress'] = 'False'
-                    self.config_db.set_entry('CHASSIS_MODULE', key, entry)
+                    # Clear transition flag in STATE_DB
+                    self.clear_transition_flag(key)
 
     def _get_module_info(self, module_index):
         """

--- a/sonic-chassisd/tests/mock_swsscommon.py
+++ b/sonic-chassisd/tests/mock_swsscommon.py
@@ -13,7 +13,12 @@ class Table:
         pass
 
     def set(self, key, fvs):
-        self.mock_dict[key] = dict(fvs)
+        if isinstance(fvs, list):
+            self.mock_dict[key] = dict(fvs)
+        elif hasattr(fvs, 'fv_dict'):
+            self.mock_dict[key] = fvs.fv_dict
+        else:
+            raise ValueError("Unsupported format for field-value pairs.")
 
     def get(self, key):
         if key in self.mock_dict:

--- a/sonic-chassisd/tests/mock_swsscommon.py
+++ b/sonic-chassisd/tests/mock_swsscommon.py
@@ -13,16 +13,18 @@ class Table:
         pass
 
     def set(self, key, fvs):
-        self.mock_dict[key] = fvs.fv_dict
-        pass
+        # Handle both FieldValuePairs objects and lists of tuples
+        if hasattr(fvs, 'fv_dict'):
+            self.mock_dict[key] = fvs.fv_dict
+        elif isinstance(fvs, list):
+            self.mock_dict[key] = dict(fvs)
+        else:
+            raise TypeError("Unsupported type for fvs")
 
     def get(self, key):
         if key in self.mock_dict:
-            rv = []
-            rv.append(True)
-            rv.append(tuple(self.mock_dict[key].items()))
-            return rv
-        return None
+            return True, list(self.mock_dict[key].items())
+        return False, []
 
     def hget(self, key, field):
         if key not in self.mock_dict or field not in self.mock_dict[key]:

--- a/sonic-chassisd/tests/mock_swsscommon.py
+++ b/sonic-chassisd/tests/mock_swsscommon.py
@@ -13,18 +13,12 @@ class Table:
         pass
 
     def set(self, key, fvs):
-        # Handle both FieldValuePairs objects and lists of tuples
-        if hasattr(fvs, 'fv_dict'):
-            self.mock_dict[key] = fvs.fv_dict
-        elif isinstance(fvs, list):
-            self.mock_dict[key] = dict(fvs)
-        else:
-            raise TypeError("Unsupported type for fvs")
+        self.mock_dict[key] = dict(fvs)
 
     def get(self, key):
         if key in self.mock_dict:
-            return True, list(self.mock_dict[key].items())
-        return False, []
+            return [True, tuple(self.mock_dict[key].items())]
+        return None
 
     def hget(self, key, field):
         if key not in self.mock_dict or field not in self.mock_dict[key]:

--- a/sonic-chassisd/tests/test_chassis_db_init.py
+++ b/sonic-chassisd/tests/test_chassis_db_init.py
@@ -32,9 +32,11 @@ def test_provision_db():
 
     chassis_table = provision_db(chassis, log)
 
-    fvs = chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert serial == fvs[CHASSIS_INFO_SERIAL_FIELD]
-    assert model == fvs[CHASSIS_INFO_MODEL_FIELD]
-    assert revision == fvs[CHASSIS_INFO_REV_FIELD]
+    status, fvs = chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+    if status:
+        fvs_dict = dict(fvs)
+        assert serial == fvs[CHASSIS_INFO_SERIAL_FIELD]
+        assert model == fvs[CHASSIS_INFO_MODEL_FIELD]
+        assert revision == fvs[CHASSIS_INFO_REV_FIELD]
+    else:
+        assert False, f"test_provision_db chassis_table not found"

--- a/sonic-chassisd/tests/test_chassis_db_init.py
+++ b/sonic-chassisd/tests/test_chassis_db_init.py
@@ -35,8 +35,8 @@ def test_provision_db():
     status, fvs = chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
     if status:
         fvs_dict = dict(fvs)
-        assert serial == fvs[CHASSIS_INFO_SERIAL_FIELD]
-        assert model == fvs[CHASSIS_INFO_MODEL_FIELD]
-        assert revision == fvs[CHASSIS_INFO_REV_FIELD]
+        assert serial == fvs_dict[CHASSIS_INFO_SERIAL_FIELD]
+        assert model == fvs_dict[CHASSIS_INFO_MODEL_FIELD]
+        assert revision == fvs_dict[CHASSIS_INFO_REV_FIELD]
     else:
         assert False, f"test_provision_db chassis_table not found"

--- a/sonic-chassisd/tests/test_chassis_db_init.py
+++ b/sonic-chassisd/tests/test_chassis_db_init.py
@@ -32,8 +32,8 @@ def test_provision_db():
 
     chassis_table = provision_db(chassis, log)
 
-    status, fvs = chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
-    if status:
+    success, fvs = chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+    if success:
         fvs_dict = dict(fvs)
         assert serial == fvs_dict[CHASSIS_INFO_SERIAL_FIELD]
         assert model == fvs_dict[CHASSIS_INFO_MODEL_FIELD]

--- a/sonic-chassisd/tests/test_chassis_db_init.py
+++ b/sonic-chassisd/tests/test_chassis_db_init.py
@@ -32,11 +32,9 @@ def test_provision_db():
 
     chassis_table = provision_db(chassis, log)
 
-    success, fvs = chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
-    if success:
-        fvs_dict = dict(fvs)
-        assert serial == fvs_dict[CHASSIS_INFO_SERIAL_FIELD]
-        assert model == fvs_dict[CHASSIS_INFO_MODEL_FIELD]
-        assert revision == fvs_dict[CHASSIS_INFO_REV_FIELD]
-    else:
-        assert False, f"test_provision_db chassis_table not found"
+    fvs = chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert serial == fvs[CHASSIS_INFO_SERIAL_FIELD]
+    assert model == fvs[CHASSIS_INFO_MODEL_FIELD]
+    assert revision == fvs[CHASSIS_INFO_REV_FIELD]

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -555,46 +555,46 @@ def test_smartswitch_configupdater_check_admin_state():
         mock_module_post_startup.assert_called_once()
 
 
-    @patch("your_module.glob.glob")
-    @patch("your_module.open", new_callable=mock_open)
-    def test_update_dpu_reboot_cause_to_db(self, mock_open, mock_glob):
-        # Set up the SmartSwitchModuleUpdater and test inputs
-        module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis=MagicMock())
-        module = "dpu0"
-        module_updater.chassis_state_db = MagicMock()
+@patch("your_module.glob.glob")
+@patch("your_module.open", new_callable=mock_open)
+def test_update_dpu_reboot_cause_to_db(self, mock_open, mock_glob):
+    # Set up the SmartSwitchModuleUpdater and test inputs
+    module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis=MagicMock())
+    module = "dpu0"
+    module_updater.chassis_state_db = MagicMock()
 
-        # Case 1: No history files found
-        mock_glob.return_value = []
-        with patch.object(module_updater, "log_warning") as mock_log_warning:
-            module_updater.update_dpu_reboot_cause_to_db(module)
-            mock_log_warning.assert_called_once_with(f"No reboot cause history files found for module: {module}")
+    # Case 1: No history files found
+    mock_glob.return_value = []
+    with patch.object(module_updater, "log_warning") as mock_log_warning:
+        module_updater.update_dpu_reboot_cause_to_db(module)
+        mock_log_warning.assert_called_once_with(f"No reboot cause history files found for module: {module}")
 
-        # Case 2: Valid JSON file with reboot cause
-        mock_glob.return_value = ["/host/reboot-cause/module/dpu0/history/file1.txt"]
-        mock_open().read.return_value = json.dumps({"name": "reboot_2024", "reason": "Power loss"})
-        with patch.object(module_updater, "log_warning") as mock_log_warning:
-            module_updater.update_dpu_reboot_cause_to_db(module)
-            mock_log_warning.assert_not_called()  # No warnings expected
-            module_updater.chassis_state_db.hset.assert_any_call("REBOOT_CAUSE|DPU0|reboot_2024", "name", "reboot_2024")
-            module_updater.chassis_state_db.hset.assert_any_call("REBOOT_CAUSE|DPU0|reboot_2024", "reason", "Power loss")
+    # Case 2: Valid JSON file with reboot cause
+    mock_glob.return_value = ["/host/reboot-cause/module/dpu0/history/file1.txt"]
+    mock_open().read.return_value = json.dumps({"name": "reboot_2024", "reason": "Power loss"})
+    with patch.object(module_updater, "log_warning") as mock_log_warning:
+        module_updater.update_dpu_reboot_cause_to_db(module)
+        mock_log_warning.assert_not_called()  # No warnings expected
+        module_updater.chassis_state_db.hset.assert_any_call("REBOOT_CAUSE|DPU0|reboot_2024", "name", "reboot_2024")
+        module_updater.chassis_state_db.hset.assert_any_call("REBOOT_CAUSE|DPU0|reboot_2024", "reason", "Power loss")
 
-        # Case 3: Empty JSON object in file
-        mock_open().read.return_value = json.dumps({})
-        with patch.object(module_updater, "log_warning") as mock_log_warning:
-            module_updater.update_dpu_reboot_cause_to_db(module)
-            mock_log_warning.assert_any_call(f"{module} reboot_cause_dict is empty")
+    # Case 3: Empty JSON object in file
+    mock_open().read.return_value = json.dumps({})
+    with patch.object(module_updater, "log_warning") as mock_log_warning:
+        module_updater.update_dpu_reboot_cause_to_db(module)
+        mock_log_warning.assert_any_call(f"{module} reboot_cause_dict is empty")
 
-        # Case 4: Invalid JSON in file
-        mock_open().read.side_effect = json.JSONDecodeError("Expecting value", "", 0)
-        with patch.object(module_updater, "log_warning") as mock_log_warning:
-            module_updater.update_dpu_reboot_cause_to_db(module)
-            mock_log_warning.assert_any_call("Failed to decode JSON from file: /host/reboot-cause/module/dpu0/history/file1.txt")
+    # Case 4: Invalid JSON in file
+    mock_open().read.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+    with patch.object(module_updater, "log_warning") as mock_log_warning:
+        module_updater.update_dpu_reboot_cause_to_db(module)
+        mock_log_warning.assert_any_call("Failed to decode JSON from file: /host/reboot-cause/module/dpu0/history/file1.txt")
 
-        # Case 5: General exception handling
-        mock_open.side_effect = IOError("Unable to read file")
-        with patch.object(module_updater, "log_warning") as mock_log_warning:
-            module_updater.update_dpu_reboot_cause_to_db(module)
-            mock_log_warning.assert_any_call("Error processing file /host/reboot-cause/module/dpu0/history/file1.txt: Unable to read file")
+    # Case 5: General exception handling
+    mock_open.side_effect = IOError("Unable to read file")
+    with patch.object(module_updater, "log_warning") as mock_log_warning:
+        module_updater.update_dpu_reboot_cause_to_db(module)
+        mock_log_warning.assert_any_call("Error processing file /host/reboot-cause/module/dpu0/history/file1.txt: Unable to read file")
 
 
 def test_smartswitch_module_db_update():

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -564,7 +564,7 @@ def test_smartswitch_configupdater_check_admin_state():
 
 @patch("scripts.chassisd.glob.glob")
 @patch("scripts.chassisd.open", new_callable=mock_open)
-def test_update_dpu_reboot_cause_to_db(self, mock_open, mock_glob):
+def test_update_dpu_reboot_cause_to_db(self, mock_glob, mock_open):
     # Set up the SmartSwitchModuleUpdater and test inputs
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis=MagicMock())
     module = "dpu0"

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -729,7 +729,7 @@ def test_midplane_presence_modules():
 
     #Check fields in database
     name = "LINE-CARD0"
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -739,7 +739,7 @@ def test_midplane_presence_modules():
     #Set access of line-card to Up (midplane connectivity is down initially)
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -749,7 +749,7 @@ def test_midplane_presence_modules():
     #Set access of line-card to Down (to mock midplane connectivity state change)
     module.set_midplane_reachable(False)
     module_updater.check_midplane_reachability()
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -758,7 +758,7 @@ def test_midplane_presence_modules():
 
     #Deinit
     module_updater.deinit()
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs == None
 
 
@@ -799,7 +799,7 @@ def test_midplane_presence_dpu_modules(mock_open, mock_makedirs):
         assert 1 == midplane_table.size()
 
         #Check fields in database
-        fvs = midplane_table.get(name)
+        status, fvs = midplane_table.get(name)
         assert fvs != None
         if isinstance(fvs, list):
             fvs = dict(fvs[-1])
@@ -809,7 +809,7 @@ def test_midplane_presence_dpu_modules(mock_open, mock_makedirs):
         #Set access of DPU0 to Up (midplane connectivity is down initially)
         module.set_midplane_reachable(True)
         module_updater.check_midplane_reachability()
-        fvs = midplane_table.get(name)
+        status, fvs = midplane_table.get(name)
         assert fvs != None
         if isinstance(fvs, list):
             fvs = dict(fvs[-1])
@@ -819,7 +819,7 @@ def test_midplane_presence_dpu_modules(mock_open, mock_makedirs):
         #Set access of DPU0 to Down (to mock midplane connectivity state change)
         module.set_midplane_reachable(False)
         module_updater.check_midplane_reachability()
-        fvs = midplane_table.get(name)
+        status, fvs = midplane_table.get(name)
         assert fvs != None
         if isinstance(fvs, list):
             fvs = dict(fvs[-1])
@@ -833,7 +833,7 @@ def test_midplane_presence_dpu_modules(mock_open, mock_makedirs):
 
         #Deinit
         module_updater.deinit()
-        fvs = midplane_table.get(name)
+        status, fvs = midplane_table.get(name)
         assert fvs == None
 
 
@@ -932,7 +932,7 @@ def test_midplane_presence_modules_linecard_reboot():
 
     #Check fields in database
     name = "LINE-CARD0"
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -942,7 +942,7 @@ def test_midplane_presence_modules_linecard_reboot():
     #Set access of line-card to Up (midplane connectivity is down initially)
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -957,7 +957,7 @@ def test_midplane_presence_modules_linecard_reboot():
     linecard_fvs = swsscommon.FieldValuePairs([("reboot", "expected")])
     module_reboot_table.set(name,linecard_fvs)
     module_updater.check_midplane_reachability()
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -967,7 +967,7 @@ def test_midplane_presence_modules_linecard_reboot():
     #Set access of line-card to up on time (to mock midplane connectivity state change)
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -984,7 +984,7 @@ def test_midplane_presence_modules_linecard_reboot():
     linecard_fvs = swsscommon.FieldValuePairs([(CHASSIS_MODULE_REBOOT_TIMESTAMP_FIELD, str(time_now))])
     module_reboot_table.set(name,linecard_fvs)
     module_updater.check_midplane_reachability()
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -1042,7 +1042,7 @@ def test_midplane_presence_supervisor():
 
     #Check fields in database
     name = "SUPERVISOR0"
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -1052,7 +1052,7 @@ def test_midplane_presence_supervisor():
     #Set access of line-card to down
     supervisor.set_midplane_reachable(False)
     module_updater.check_midplane_reachability()
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -1061,7 +1061,7 @@ def test_midplane_presence_supervisor():
 
     #Deinit
     module_updater.deinit()
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs == None
 
 def verify_asic(asic_name, asic_pci_address, module_name, asic_id_in_module, asic_table):
@@ -1142,7 +1142,7 @@ def test_asic_presence():
     module_updater.module_db_update()
     module_updater.deinit()
     midplane_table = module_updater.midplane_table
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs == None
     verify_asic("asic4", "0000:04:00.0", name, "0", fabric_asic_table)
     verify_asic("asic5", "0000:05:00.0", name, "1", fabric_asic_table)
@@ -1365,7 +1365,7 @@ def test_set_initial_dpu_admin_state_down():
     midplane_table = module_updater.midplane_table
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -1455,7 +1455,7 @@ def test_set_initial_dpu_admin_state_up():
     midplane_table = module_updater.midplane_table
     module.set_midplane_reachable(False)
     module_updater.check_midplane_reachability()
-    fvs = midplane_table.get(name)
+    status, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -1739,3 +1739,74 @@ def test_smartswitch_time_format():
     if not date_value:
         AssertionError("Date is not set!")
     assert is_valid_date(date_value)
+
+
+def test_clear_transition_flag_sets_false_when_flag_present():
+    module_table = MagicMock()
+    module_table.get.return_value = (True, [('state_transition_in_progress', 'True')])
+
+    module_updater = MagicMock()
+    module_updater.module_table = module_table
+
+    daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER, MagicMock())
+    daemon_chassisd.module_updater = module_updater
+
+    daemon_chassisd.clear_transition_flag("DPU0")
+
+    args = module_table.set.call_args[0][1]
+    assert ('state_transition_in_progress', 'False') in args
+
+
+def test_clear_transition_flag_sets_false_when_flag_missing():
+    module_table = MagicMock()
+    module_table.get.return_value = (True, [('desc', 'test module')])  # no flag present
+
+    module_updater = MagicMock()
+    module_updater.module_table = module_table
+
+    daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER, MagicMock())
+    daemon_chassisd.module_updater = module_updater
+
+    daemon_chassisd.clear_transition_flag("DPU0")
+
+    args = module_table.set.call_args[0][1]
+    assert ('state_transition_in_progress', 'False') in args
+
+
+def test_clear_all_transition_flags_calls_clear_and_handles_exceptions():
+    module_table = MagicMock()
+    module_table.getKeys.return_value = ["DPU0", "DPU1"]
+
+    module_updater = MagicMock()
+    module_updater.module_table = module_table
+
+    daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER, MagicMock())
+    daemon_chassisd.module_updater = module_updater
+    daemon_chassisd.log_error = MagicMock()
+
+    def mock_clear_transition_flag(key):
+        if key == "DPU1":
+            raise Exception("Simulated error")
+
+    daemon_chassisd.clear_transition_flag = MagicMock(side_effect=mock_clear_transition_flag)
+
+    daemon_chassisd.clear_all_transition_flags()
+
+    daemon_chassisd.clear_transition_flag.assert_any_call("DPU0")
+    daemon_chassisd.clear_transition_flag.assert_any_call("DPU1")
+    daemon_chassisd.log_error.assert_called_once_with("Failed to clear transition flag for DPU1: Simulated error")
+
+
+def test_set_transition_flag_creates_entry_if_key_missing():
+    module_table = MagicMock()
+    module_table.get.return_value = None  # Key doesn't exist
+
+    module_updater = MagicMock()
+    daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER, MagicMock())
+    daemon_chassisd.module_updater = module_updater
+
+    daemon_chassisd.set_transition_flag(module_table, "DPU0")
+
+    args = module_table.set.call_args[0][1]
+    assert ('state_transition_in_progress', 'True') in args
+    assert any(k == 'transition_start_time' for k, _ in args)

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -1906,7 +1906,7 @@ def test_submit_dpu_callback():
          patch.object(module, 'module_post_startup') as mock_post_startup:
         daemon_chassisd.submit_dpu_callback(index, MODULE_ADMIN_DOWN, name)
         # Verify correct functions are called for admin down
-        mock_pre_shutdown.assert_called_once()
+        mock_pre_shutdown.assert_not_called()
         mock_set_admin_state.assert_called_once_with(MODULE_ADMIN_DOWN)
         mock_post_startup.assert_not_called()
 

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -81,8 +81,8 @@ def test_moduleupdater_check_valid_fields():
     module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
                                    module.supervisor_slot)
     module_updater.module_db_update()
-    status, fvs = module_updater.module_table.get(name)
-    if status:
+    success, fvs = module_updater.module_table.get(name)
+    if success:
         fvs_dict = dict(fvs)
         assert desc == fvs_dict[CHASSIS_MODULE_INFO_DESC_FIELD]
         assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
@@ -108,8 +108,8 @@ def test_smartswitch_moduleupdater_check_valid_fields():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    status, fvs = module_updater.module_table.get(name)
-    if status:
+    success, fvs = module_updater.module_table.get(name)
+    if success:
         fvs_dict = dict(fvs)
         assert desc == fvs_dict[CHASSIS_MODULE_INFO_DESC_FIELD]
         assert NOT_AVAILABLE == fvs_dict[CHASSIS_MODULE_INFO_SLOT_FIELD]
@@ -188,7 +188,7 @@ def test_smartswitch_moduleupdater_check_invalid_name():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    status, fvs = module_updater.module_table.get(name)
+    success, fvs = module_updater.module_table.get(name)
     assert fvs == None
 
     config_updater = SmartSwitchModuleConfigUpdater(SYSLOG_IDENTIFIER, chassis)
@@ -216,7 +216,7 @@ def test_smartswitch_moduleupdater_check_invalid_admin_state():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    status, fvs = module_updater.module_table.get(name)
+    success, fvs = module_updater.module_table.get(name)
 
     config_updater = SmartSwitchModuleConfigUpdater(SYSLOG_IDENTIFIER, chassis)
     admin_state = 2
@@ -243,7 +243,7 @@ def test_smartswitch_moduleupdater_check_invalid_slot():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    status, fvs = module_updater.module_table.get(name)
+    success, fvs = module_updater.module_table.get(name)
     assert fvs != None
 
 def test_moduleupdater_check_invalid_name():
@@ -265,7 +265,7 @@ def test_moduleupdater_check_invalid_name():
     module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
                                    module.supervisor_slot)
     module_updater.module_db_update()
-    status, fvs = module_updater.module_table.get(name)
+    success, fvs = module_updater.module_table.get(name)
     assert fvs == None
 
 def test_smartswitch_moduleupdater_check_invalid_index():
@@ -286,7 +286,7 @@ def test_smartswitch_moduleupdater_check_invalid_index():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    status, fvs = module_updater.module_table.get(name)
+    success, fvs = module_updater.module_table.get(name)
     assert fvs != None
 
     # Run chassis db clean up
@@ -310,8 +310,8 @@ def test_moduleupdater_check_status_update():
     module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
                                    module.supervisor_slot)
     module_updater.module_db_update()
-    status, fvs = module_updater.module_table.get(name)
-    if status:
+    success, fvs = module_updater.module_table.get(name)
+    if success:
         fvs_dict = dict(fvs)
         print('Initial DB-entry {}'.format(fvs))
         assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
@@ -319,16 +319,16 @@ def test_moduleupdater_check_status_update():
     # Update status
     status = ModuleBase.MODULE_STATUS_OFFLINE
     module.set_oper_status(status)
-    status, fvs = module_updater.module_table.get(name)
-    if status:
+    success, fvs = module_updater.module_table.get(name)
+    if success:
         fvs_dict = dict(fvs)
         print('Not updated DB-entry {}'.format(fvs))
         assert status != fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # Update status and db
     module_updater.module_db_update()
-    status, fvs = module_updater.module_table.get(name)
-    if status:
+    success, fvs = module_updater.module_table.get(name)
+    if success:
         fvs_dict = dict(fvs)
         print('Updated DB-entry {}'.format(fvs))
         assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
@@ -355,14 +355,14 @@ def test_moduleupdater_check_deinit():
                                    module.supervisor_slot)
     module_updater.modules_num_update()
     module_updater.module_db_update()
-    status, fvs = module_updater.module_table.get(name)
-    if status:
+    success, fvs = module_updater.module_table.get(name)
+    if success:
         fvs_dict = dict(fvs)
         assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     module_table = module_updater.module_table
     module_updater.deinit()
-    status, fvs = module_table.get(name)
+    success, fvs = module_table.get(name)
     assert fvs == None
 
 def test_smartswitch_moduleupdater_check_deinit():
@@ -383,11 +383,11 @@ def test_smartswitch_moduleupdater_check_deinit():
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.modules_num_update()
     module_updater.module_db_update()
-    status, fvs = module_updater.module_table.get(name)
+    success, fvs = module_updater.module_table.get(name)
 
     module_table = module_updater.module_table
     module_updater.deinit()
-    status, fvs = module_table.get(name)
+    success, fvs = module_table.get(name)
     assert fvs == None
 
 def test_configupdater_check_valid_names():
@@ -617,19 +617,19 @@ def test_configupdater_check_num_modules():
     module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
                                    module.supervisor_slot)
     module_updater.modules_num_update()
-    status, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+    success, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
     assert fvs == None
 
     # Add a module
     chassis.module_list.append(module)
     module_updater.modules_num_update()
-    status, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
-    if status:
+    success, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+    if success:
         fvs_dict = dict(fvs)
         assert chassis.get_num_modules() == int(fvs_dict[CHASSIS_INFO_CARD_NUM_FIELD])
 
     module_updater.deinit()
-    status, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+    success, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
     assert fvs == None
 
 def test_moduleupdater_check_string_slot():
@@ -730,7 +730,7 @@ def test_midplane_presence_modules():
 
     #Check fields in database
     name = "LINE-CARD0"
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -740,7 +740,7 @@ def test_midplane_presence_modules():
     #Set access of line-card to Up (midplane connectivity is down initially)
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -750,7 +750,7 @@ def test_midplane_presence_modules():
     #Set access of line-card to Down (to mock midplane connectivity state change)
     module.set_midplane_reachable(False)
     module_updater.check_midplane_reachability()
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -759,7 +759,7 @@ def test_midplane_presence_modules():
 
     #Deinit
     module_updater.deinit()
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs == None
 
 
@@ -800,7 +800,7 @@ def test_midplane_presence_dpu_modules(mock_open, mock_makedirs):
         assert 1 == midplane_table.size()
 
         #Check fields in database
-        status, fvs = midplane_table.get(name)
+        success, fvs = midplane_table.get(name)
         assert fvs != None
         if isinstance(fvs, list):
             fvs = dict(fvs[-1])
@@ -810,7 +810,7 @@ def test_midplane_presence_dpu_modules(mock_open, mock_makedirs):
         #Set access of DPU0 to Up (midplane connectivity is down initially)
         module.set_midplane_reachable(True)
         module_updater.check_midplane_reachability()
-        status, fvs = midplane_table.get(name)
+        success, fvs = midplane_table.get(name)
         assert fvs != None
         if isinstance(fvs, list):
             fvs = dict(fvs[-1])
@@ -820,7 +820,7 @@ def test_midplane_presence_dpu_modules(mock_open, mock_makedirs):
         #Set access of DPU0 to Down (to mock midplane connectivity state change)
         module.set_midplane_reachable(False)
         module_updater.check_midplane_reachability()
-        status, fvs = midplane_table.get(name)
+        success, fvs = midplane_table.get(name)
         assert fvs != None
         if isinstance(fvs, list):
             fvs = dict(fvs[-1])
@@ -834,7 +834,7 @@ def test_midplane_presence_dpu_modules(mock_open, mock_makedirs):
 
         #Deinit
         module_updater.deinit()
-        status, fvs = midplane_table.get(name)
+        success, fvs = midplane_table.get(name)
         assert fvs == None
 
 
@@ -933,7 +933,7 @@ def test_midplane_presence_modules_linecard_reboot():
 
     #Check fields in database
     name = "LINE-CARD0"
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -943,7 +943,7 @@ def test_midplane_presence_modules_linecard_reboot():
     #Set access of line-card to Up (midplane connectivity is down initially)
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -958,7 +958,7 @@ def test_midplane_presence_modules_linecard_reboot():
     linecard_fvs = swsscommon.FieldValuePairs([("reboot", "expected")])
     module_reboot_table.set(name,linecard_fvs)
     module_updater.check_midplane_reachability()
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -968,7 +968,7 @@ def test_midplane_presence_modules_linecard_reboot():
     #Set access of line-card to up on time (to mock midplane connectivity state change)
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -985,7 +985,7 @@ def test_midplane_presence_modules_linecard_reboot():
     linecard_fvs = swsscommon.FieldValuePairs([(CHASSIS_MODULE_REBOOT_TIMESTAMP_FIELD, str(time_now))])
     module_reboot_table.set(name,linecard_fvs)
     module_updater.check_midplane_reachability()
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -1043,7 +1043,7 @@ def test_midplane_presence_supervisor():
 
     #Check fields in database
     name = "SUPERVISOR0"
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -1053,7 +1053,7 @@ def test_midplane_presence_supervisor():
     #Set access of line-card to down
     supervisor.set_midplane_reachable(False)
     module_updater.check_midplane_reachability()
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -1062,7 +1062,7 @@ def test_midplane_presence_supervisor():
 
     #Deinit
     module_updater.deinit()
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs == None
 
 def verify_asic(asic_name, asic_pci_address, module_name, asic_id_in_module, asic_table):
@@ -1143,7 +1143,7 @@ def test_asic_presence():
     module_updater.module_db_update()
     module_updater.deinit()
     midplane_table = module_updater.midplane_table
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs == None
     verify_asic("asic4", "0000:04:00.0", name, "0", fabric_asic_table)
     verify_asic("asic5", "0000:05:00.0", name, "1", fabric_asic_table)
@@ -1366,7 +1366,7 @@ def test_set_initial_dpu_admin_state_down():
     midplane_table = module_updater.midplane_table
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
@@ -1456,7 +1456,7 @@ def test_set_initial_dpu_admin_state_up():
     midplane_table = module_updater.midplane_table
     module.set_midplane_reachable(False)
     module_updater.check_midplane_reachability()
-    status, fvs = midplane_table.get(name)
+    success, fvs = midplane_table.get(name)
     assert fvs != None
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -1898,6 +1898,7 @@ def test_submit_dpu_callback():
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER, chassis)
     daemon_chassisd.module_updater = module_updater
+    module_updater.module_table.get = MagicMock(return_value=(True, []))
 
     # Test MODULE_ADMIN_DOWN scenario
     with patch.object(module, 'module_pre_shutdown') as mock_pre_shutdown, \
@@ -1915,6 +1916,7 @@ def test_submit_dpu_callback():
          patch.object(module, 'set_admin_state') as mock_set_admin_state, \
          patch.object(module, 'module_post_startup') as mock_post_startup:
 
+        module_updater.module_table.get = MagicMock(return_value=(True, []))
         daemon_chassisd.submit_dpu_callback(index, MODULE_ADMIN_UP, name)
 
         # Verify correct functions are called for admin up

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -81,7 +81,7 @@ def test_moduleupdater_check_valid_fields():
     module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
                                    module.supervisor_slot)
     module_updater.module_db_update()
-    fvs = module_updater.module_table.get(name)
+    status, fvs = module_updater.module_table.get(name)
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
     assert desc == fvs[CHASSIS_MODULE_INFO_DESC_FIELD]
@@ -106,7 +106,7 @@ def test_smartswitch_moduleupdater_check_valid_fields():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    fvs = module_updater.module_table.get(name)
+    status, fvs = module_updater.module_table.get(name)
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
     assert desc == fvs[CHASSIS_MODULE_INFO_DESC_FIELD]
@@ -184,7 +184,7 @@ def test_smartswitch_moduleupdater_check_invalid_name():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    fvs = module_updater.module_table.get(name)
+    status, fvs = module_updater.module_table.get(name)
     assert fvs == None
 
     config_updater = SmartSwitchModuleConfigUpdater(SYSLOG_IDENTIFIER, chassis)
@@ -212,7 +212,7 @@ def test_smartswitch_moduleupdater_check_invalid_admin_state():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    fvs = module_updater.module_table.get(name)
+    status, fvs = module_updater.module_table.get(name)
 
     config_updater = SmartSwitchModuleConfigUpdater(SYSLOG_IDENTIFIER, chassis)
     admin_state = 2
@@ -239,7 +239,7 @@ def test_smartswitch_moduleupdater_check_invalid_slot():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    fvs = module_updater.module_table.get(name)
+    status, fvs = module_updater.module_table.get(name)
     assert fvs != None
 
 def test_moduleupdater_check_invalid_name():
@@ -261,7 +261,7 @@ def test_moduleupdater_check_invalid_name():
     module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
                                    module.supervisor_slot)
     module_updater.module_db_update()
-    fvs = module_updater.module_table.get(name)
+    status, fvs = module_updater.module_table.get(name)
     assert fvs == None
 
 def test_smartswitch_moduleupdater_check_invalid_index():
@@ -282,7 +282,7 @@ def test_smartswitch_moduleupdater_check_invalid_index():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    fvs = module_updater.module_table.get(name)
+    status, fvs = module_updater.module_table.get(name)
     assert fvs != None
 
     # Run chassis db clean up
@@ -306,7 +306,7 @@ def test_moduleupdater_check_status_update():
     module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
                                    module.supervisor_slot)
     module_updater.module_db_update()
-    fvs = module_updater.module_table.get(name)
+    status, fvs = module_updater.module_table.get(name)
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
     print('Initial DB-entry {}'.format(fvs))
@@ -315,7 +315,7 @@ def test_moduleupdater_check_status_update():
     # Update status
     status = ModuleBase.MODULE_STATUS_OFFLINE
     module.set_oper_status(status)
-    fvs = module_updater.module_table.get(name)
+    status, fvs = module_updater.module_table.get(name)
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
     print('Not updated DB-entry {}'.format(fvs))
@@ -323,7 +323,7 @@ def test_moduleupdater_check_status_update():
 
     # Update status and db
     module_updater.module_db_update()
-    fvs = module_updater.module_table.get(name)
+    status, fvs = module_updater.module_table.get(name)
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
     print('Updated DB-entry {}'.format(fvs))
@@ -351,7 +351,7 @@ def test_moduleupdater_check_deinit():
                                    module.supervisor_slot)
     module_updater.modules_num_update()
     module_updater.module_db_update()
-    fvs = module_updater.module_table.get(name)
+    status, fvs = module_updater.module_table.get(name)
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
     assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
@@ -379,7 +379,7 @@ def test_smartswitch_moduleupdater_check_deinit():
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.modules_num_update()
     module_updater.module_db_update()
-    fvs = module_updater.module_table.get(name)
+    status, fvs = module_updater.module_table.get(name)
     # if isinstance(fvs, list):
     #    fvs = dict(fvs[-1])
     # assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
@@ -616,19 +616,19 @@ def test_configupdater_check_num_modules():
     module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
                                    module.supervisor_slot)
     module_updater.modules_num_update()
-    fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+    status, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
     assert fvs == None
 
     # Add a module
     chassis.module_list.append(module)
     module_updater.modules_num_update()
-    fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+    status, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
     assert chassis.get_num_modules() == int(fvs[CHASSIS_INFO_CARD_NUM_FIELD])
 
     module_updater.deinit()
-    fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+    status, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
     assert fvs == None
 
 def test_moduleupdater_check_string_slot():

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -564,9 +564,8 @@ def test_smartswitch_configupdater_check_admin_state():
 
 @patch("scripts.chassisd.glob.glob")
 @patch("scripts.chassisd.open", new_callable=mock_open)
-def test_update_dpu_reboot_cause_to_db(self, mock_glob, mock_open):
-    # Set up the SmartSwitchModuleUpdater and test inputs
-    module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis=MagicMock())
+def test_update_dpu_reboot_cause_to_db(mock_open, mock_glob):
+    module_updater = SmartSwitchModuleUpdater("TEST_LOG", chassis=MagicMock())
     module = "dpu0"
     module_updater.chassis_state_db = MagicMock()
 
@@ -581,7 +580,7 @@ def test_update_dpu_reboot_cause_to_db(self, mock_glob, mock_open):
     mock_open().read.return_value = json.dumps({"name": "reboot_2024", "reason": "Power loss"})
     with patch.object(module_updater, "log_warning") as mock_log_warning:
         module_updater.update_dpu_reboot_cause_to_db(module)
-        mock_log_warning.assert_not_called()  # No warnings expected
+        mock_log_warning.assert_not_called()
         module_updater.chassis_state_db.hset.assert_any_call("REBOOT_CAUSE|DPU0|reboot_2024", "name", "reboot_2024")
         module_updater.chassis_state_db.hset.assert_any_call("REBOOT_CAUSE|DPU0|reboot_2024", "reason", "Power loss")
 

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -189,7 +189,7 @@ def test_smartswitch_moduleupdater_check_invalid_name():
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
     success, fvs = module_updater.module_table.get(name)
-    assert fvs == None
+    assert fvs == []
 
     config_updater = SmartSwitchModuleConfigUpdater(SYSLOG_IDENTIFIER, chassis)
     admin_state = 0
@@ -266,7 +266,7 @@ def test_moduleupdater_check_invalid_name():
                                    module.supervisor_slot)
     module_updater.module_db_update()
     success, fvs = module_updater.module_table.get(name)
-    assert fvs == None
+    assert fvs == []
 
 def test_smartswitch_moduleupdater_check_invalid_index():
     chassis = MockSmartSwitchChassis()
@@ -363,7 +363,7 @@ def test_moduleupdater_check_deinit():
     module_table = module_updater.module_table
     module_updater.deinit()
     success, fvs = module_table.get(name)
-    assert fvs == None
+    assert fvs == []
 
 def test_smartswitch_moduleupdater_check_deinit():
     chassis = MockSmartSwitchChassis()
@@ -388,7 +388,7 @@ def test_smartswitch_moduleupdater_check_deinit():
     module_table = module_updater.module_table
     module_updater.deinit()
     success, fvs = module_table.get(name)
-    assert fvs == None
+    assert fvs == []
 
 def test_configupdater_check_valid_names():
     chassis = MockChassis()
@@ -618,7 +618,7 @@ def test_configupdater_check_num_modules():
                                    module.supervisor_slot)
     module_updater.modules_num_update()
     success, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
-    assert fvs == None
+    assert fvs == []
 
     # Add a module
     chassis.module_list.append(module)
@@ -630,7 +630,7 @@ def test_configupdater_check_num_modules():
 
     module_updater.deinit()
     success, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
-    assert fvs == None
+    assert fvs == []
 
 def test_moduleupdater_check_string_slot():
     chassis = MockChassis()
@@ -760,7 +760,7 @@ def test_midplane_presence_modules():
     #Deinit
     module_updater.deinit()
     success, fvs = midplane_table.get(name)
-    assert fvs == None
+    assert fvs == []
 
 
 @patch('os.makedirs')
@@ -835,7 +835,7 @@ def test_midplane_presence_dpu_modules(mock_open, mock_makedirs):
         #Deinit
         module_updater.deinit()
         success, fvs = midplane_table.get(name)
-        assert fvs == None
+        assert fvs == []
 
 
 @patch('os.makedirs')
@@ -1063,7 +1063,7 @@ def test_midplane_presence_supervisor():
     #Deinit
     module_updater.deinit()
     success, fvs = midplane_table.get(name)
-    assert fvs == None
+    assert fvs == []
 
 def verify_asic(asic_name, asic_pci_address, module_name, asic_id_in_module, asic_table):
     fvs = asic_table.get(asic_name)
@@ -1144,7 +1144,7 @@ def test_asic_presence():
     module_updater.deinit()
     midplane_table = module_updater.midplane_table
     success, fvs = midplane_table.get(name)
-    assert fvs == None
+    assert fvs == []
     verify_asic("asic4", "0000:04:00.0", name, "0", fabric_asic_table)
     verify_asic("asic5", "0000:05:00.0", name, "1", fabric_asic_table)
 

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -82,11 +82,13 @@ def test_moduleupdater_check_valid_fields():
                                    module.supervisor_slot)
     module_updater.module_db_update()
     status, fvs = module_updater.module_table.get(name)
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert desc == fvs[CHASSIS_MODULE_INFO_DESC_FIELD]
-    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
-    assert serial == fvs[CHASSIS_MODULE_INFO_SERIAL_FIELD]
+    if status:
+        fvs_dict = dict(fvs)
+        assert desc == fvs[CHASSIS_MODULE_INFO_DESC_FIELD]
+        assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+        assert serial == fvs[CHASSIS_MODULE_INFO_SERIAL_FIELD]
+    else:
+        assert False, f"Module {name} not found in module_table"
 
 def test_smartswitch_moduleupdater_check_valid_fields():
     chassis = MockSmartSwitchChassis()

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -81,14 +81,12 @@ def test_moduleupdater_check_valid_fields():
     module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
                                    module.supervisor_slot)
     module_updater.module_db_update()
-    success, fvs = module_updater.module_table.get(name)
-    if success:
-        fvs_dict = dict(fvs)
-        assert desc == fvs_dict[CHASSIS_MODULE_INFO_DESC_FIELD]
-        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
-        assert serial == fvs_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD]
-    else:
-        assert False, f"Module {name} not found in module_table"
+    fvs = module_updater.module_table.get(name)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert desc == fvs[CHASSIS_MODULE_INFO_DESC_FIELD]
+    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    assert serial == fvs[CHASSIS_MODULE_INFO_SERIAL_FIELD]
 
 def test_smartswitch_moduleupdater_check_valid_fields():
     chassis = MockSmartSwitchChassis()
@@ -108,15 +106,13 @@ def test_smartswitch_moduleupdater_check_valid_fields():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    success, fvs = module_updater.module_table.get(name)
-    if success:
-        fvs_dict = dict(fvs)
-        assert desc == fvs_dict[CHASSIS_MODULE_INFO_DESC_FIELD]
-        assert NOT_AVAILABLE == fvs_dict[CHASSIS_MODULE_INFO_SLOT_FIELD]
-        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
-        assert serial == fvs_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD]
-    else:
-        assert False, f"Module {name} not found in module_table"
+    fvs = module_updater.module_table.get(name)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert desc == fvs[CHASSIS_MODULE_INFO_DESC_FIELD]
+    assert NOT_AVAILABLE == fvs[CHASSIS_MODULE_INFO_SLOT_FIELD]
+    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    assert serial == fvs[CHASSIS_MODULE_INFO_SERIAL_FIELD]
 
 def test_smartswitch_moduleupdater_status_transitions():
     # Mock the chassis and module
@@ -188,8 +184,8 @@ def test_smartswitch_moduleupdater_check_invalid_name():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    success, fvs = module_updater.module_table.get(name)
-    assert fvs == []
+    fvs = module_updater.module_table.get(name)
+    assert fvs == None
 
     config_updater = SmartSwitchModuleConfigUpdater(SYSLOG_IDENTIFIER, chassis)
     admin_state = 0
@@ -216,7 +212,7 @@ def test_smartswitch_moduleupdater_check_invalid_admin_state():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    success, fvs = module_updater.module_table.get(name)
+    fvs = module_updater.module_table.get(name)
 
     config_updater = SmartSwitchModuleConfigUpdater(SYSLOG_IDENTIFIER, chassis)
     admin_state = 2
@@ -243,9 +239,8 @@ def test_smartswitch_moduleupdater_check_invalid_slot():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    success, fvs = module_updater.module_table.get(name)
-    fvs_dict = dict(fvs)
-    assert fvs_dict != None
+    fvs = module_updater.module_table.get(name)
+    assert fvs != None
 
 def test_moduleupdater_check_invalid_name():
     chassis = MockChassis()
@@ -266,8 +261,8 @@ def test_moduleupdater_check_invalid_name():
     module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
                                    module.supervisor_slot)
     module_updater.module_db_update()
-    success, fvs = module_updater.module_table.get(name)
-    assert fvs == []
+    fvs = module_updater.module_table.get(name)
+    assert fvs == None
 
 def test_smartswitch_moduleupdater_check_invalid_index():
     chassis = MockSmartSwitchChassis()
@@ -287,9 +282,8 @@ def test_smartswitch_moduleupdater_check_invalid_index():
 
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
-    success, fvs = module_updater.module_table.get(name)
-    fvs_dict = dict(fvs)
-    assert fvs_dict != None
+    fvs = module_updater.module_table.get(name)
+    assert fvs != None
 
     # Run chassis db clean up
     module_updater.module_down_chassis_db_cleanup()
@@ -312,28 +306,28 @@ def test_moduleupdater_check_status_update():
     module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
                                    module.supervisor_slot)
     module_updater.module_db_update()
-    success, fvs = module_updater.module_table.get(name)
-    if success:
-        fvs_dict = dict(fvs)
-        print('Initial DB-entry {}'.format(fvs))
-        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    fvs = module_updater.module_table.get(name)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    print('Initial DB-entry {}'.format(fvs))
+    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # Update status
     status = ModuleBase.MODULE_STATUS_OFFLINE
     module.set_oper_status(status)
-    success, fvs = module_updater.module_table.get(name)
-    if success:
-        fvs_dict = dict(fvs)
-        print('Not updated DB-entry {}'.format(fvs))
-        assert status != fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    fvs = module_updater.module_table.get(name)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    print('Not updated DB-entry {}'.format(fvs))
+    assert status != fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # Update status and db
     module_updater.module_db_update()
-    success, fvs = module_updater.module_table.get(name)
-    if success:
-        fvs_dict = dict(fvs)
-        print('Updated DB-entry {}'.format(fvs))
-        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    fvs = module_updater.module_table.get(name)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    print('Updated DB-entry {}'.format(fvs))
+    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # Run chassis db clean up from LC.
     module_updater.module_down_chassis_db_cleanup()
@@ -357,15 +351,15 @@ def test_moduleupdater_check_deinit():
                                    module.supervisor_slot)
     module_updater.modules_num_update()
     module_updater.module_db_update()
-    success, fvs = module_updater.module_table.get(name)
-    if success:
-        fvs_dict = dict(fvs)
-        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    fvs = module_updater.module_table.get(name)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     module_table = module_updater.module_table
     module_updater.deinit()
-    success, fvs = module_table.get(name)
-    assert fvs == []
+    fvs = module_table.get(name)
+    assert fvs == None
 
 def test_smartswitch_moduleupdater_check_deinit():
     chassis = MockSmartSwitchChassis()
@@ -385,12 +379,15 @@ def test_smartswitch_moduleupdater_check_deinit():
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.modules_num_update()
     module_updater.module_db_update()
-    success, fvs = module_updater.module_table.get(name)
+    fvs = module_updater.module_table.get(name)
+    # if isinstance(fvs, list):
+    #    fvs = dict(fvs[-1])
+    # assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     module_table = module_updater.module_table
     module_updater.deinit()
-    success, fvs = module_table.get(name)
-    assert fvs == []
+    fvs = module_table.get(name)
+    assert fvs == None
 
 def test_configupdater_check_valid_names():
     chassis = MockChassis()
@@ -619,20 +616,20 @@ def test_configupdater_check_num_modules():
     module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
                                    module.supervisor_slot)
     module_updater.modules_num_update()
-    success, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
-    assert fvs == []
+    fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+    assert fvs == None
 
     # Add a module
     chassis.module_list.append(module)
     module_updater.modules_num_update()
-    success, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
-    if success:
-        fvs_dict = dict(fvs)
-        assert chassis.get_num_modules() == int(fvs_dict[CHASSIS_INFO_CARD_NUM_FIELD])
+    fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert chassis.get_num_modules() == int(fvs[CHASSIS_INFO_CARD_NUM_FIELD])
 
     module_updater.deinit()
-    success, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
-    assert fvs == []
+    fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+    assert fvs == None
 
 def test_moduleupdater_check_string_slot():
     chassis = MockChassis()
@@ -732,40 +729,37 @@ def test_midplane_presence_modules():
 
     #Check fields in database
     name = "LINE-CARD0"
-    success, fvs = midplane_table.get(name)
-    fvs_dict = dict(fvs)
-    assert fvs_dict != None
-    if success:
-        fvs_dict = dict(fvs)
-        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs = midplane_table.get(name)
+    assert fvs != None
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     #Set access of line-card to Up (midplane connectivity is down initially)
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
-    success, fvs = midplane_table.get(name)
-    fvs_dict = dict(fvs)
-    assert fvs_dict != None
-    if success:
-        fvs_dict = dict(fvs)
-        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs = midplane_table.get(name)
+    assert fvs != None
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     #Set access of line-card to Down (to mock midplane connectivity state change)
     module.set_midplane_reachable(False)
     module_updater.check_midplane_reachability()
-    success, fvs = midplane_table.get(name)
-    fvs_dict = dict(fvs)
-    assert fvs_dict != None
-    if success:
-        fvs_dict = dict(fvs)
-        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs = midplane_table.get(name)
+    assert fvs != None
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     #Deinit
     module_updater.deinit()
-    success, fvs = midplane_table.get(name)
-    assert fvs == []
+    fvs = midplane_table.get(name)
+    assert fvs == None
 
 
 @patch('os.makedirs')
@@ -805,35 +799,32 @@ def test_midplane_presence_dpu_modules(mock_open, mock_makedirs):
         assert 1 == midplane_table.size()
 
         #Check fields in database
-        success, fvs = midplane_table.get(name)
-        fvs_dict = dict(fvs)
-        assert fvs_dict != None
-        if success:
-            fvs_dict = dict(fvs)
-            assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-            assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+        fvs = midplane_table.get(name)
+        assert fvs != None
+        if isinstance(fvs, list):
+            fvs = dict(fvs[-1])
+        assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
         #Set access of DPU0 to Up (midplane connectivity is down initially)
         module.set_midplane_reachable(True)
         module_updater.check_midplane_reachability()
-        success, fvs = midplane_table.get(name)
-        fvs_dict = dict(fvs)
-        assert fvs_dict != None
-        if success:
-            fvs_dict = dict(fvs)
-            assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-            assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+        fvs = midplane_table.get(name)
+        assert fvs != None
+        if isinstance(fvs, list):
+            fvs = dict(fvs[-1])
+        assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
         #Set access of DPU0 to Down (to mock midplane connectivity state change)
         module.set_midplane_reachable(False)
         module_updater.check_midplane_reachability()
-        success, fvs = midplane_table.get(name)
-        fvs_dict = dict(fvs)
-        assert fvs_dict != None
-        if success:
-            fvs_dict = dict(fvs)
-            assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-            assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+        fvs = midplane_table.get(name)
+        assert fvs != None
+        if isinstance(fvs, list):
+            fvs = dict(fvs[-1])
+        assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
         # Run chassis db clean up
         module_updater.module_down_chassis_db_cleanup()
@@ -842,8 +833,8 @@ def test_midplane_presence_dpu_modules(mock_open, mock_makedirs):
 
         #Deinit
         module_updater.deinit()
-        success, fvs = midplane_table.get(name)
-        assert fvs == []
+        fvs = midplane_table.get(name)
+        assert fvs == None
 
 
 @patch('os.makedirs')
@@ -941,24 +932,22 @@ def test_midplane_presence_modules_linecard_reboot():
 
     #Check fields in database
     name = "LINE-CARD0"
-    success, fvs = midplane_table.get(name)
-    fvs_dict = dict(fvs)
-    assert fvs_dict != None
-    if success:
-        fvs_dict = dict(fvs)
-        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs = midplane_table.get(name)
+    assert fvs != None
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     #Set access of line-card to Up (midplane connectivity is down initially)
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
-    success, fvs = midplane_table.get(name)
-    fvs_dict = dict(fvs)
-    assert fvs_dict != None
-    if success:
-        fvs_dict = dict(fvs)
-        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs = midplane_table.get(name)
+    assert fvs != None
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     
     #Set access of line-card to Down (to mock midplane connectivity state change)
@@ -968,23 +957,22 @@ def test_midplane_presence_modules_linecard_reboot():
     linecard_fvs = swsscommon.FieldValuePairs([("reboot", "expected")])
     module_reboot_table.set(name,linecard_fvs)
     module_updater.check_midplane_reachability()
-    success, fvs = midplane_table.get(name)
-    fvs_dict = dict(fvs)
-    assert fvs_dict != None
-    if success:
-        fvs_dict = dict(fvs)
-        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs = midplane_table.get(name)
+    assert fvs != None
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     #Set access of line-card to up on time (to mock midplane connectivity state change)
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
-    fvs_dict = dict(fvs)
-    assert fvs_dict != None
-    if success:
-        fvs_dict = dict(fvs)
-        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs = midplane_table.get(name)
+    assert fvs != None
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     # test linecard reboot midplane connectivity restored timeout
     # Set access of line-card to Down (to mock midplane connectivity state change)
@@ -996,14 +984,13 @@ def test_midplane_presence_modules_linecard_reboot():
     linecard_fvs = swsscommon.FieldValuePairs([(CHASSIS_MODULE_REBOOT_TIMESTAMP_FIELD, str(time_now))])
     module_reboot_table.set(name,linecard_fvs)
     module_updater.check_midplane_reachability()
-    success, fvs = midplane_table.get(name)
-    fvs_dict = dict(fvs)
-    assert fvs_dict != None
-    if success:
-        fvs_dict = dict(fvs)
-        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]   
-        assert module_updater.linecard_reboot_timeout == 240    
+    fvs = midplane_table.get(name)
+    assert fvs != None
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]   
+    assert module_updater.linecard_reboot_timeout == 240    
     
 def test_midplane_presence_supervisor():
     chassis = MockChassis()
@@ -1055,44 +1042,42 @@ def test_midplane_presence_supervisor():
 
     #Check fields in database
     name = "SUPERVISOR0"
-    success, fvs = midplane_table.get(name)
-    fvs_dict = dict(fvs)
-    assert fvs_dict != None
-    if success:
-        fvs_dict = dict(fvs)
-        assert supervisor.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(supervisor.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs = midplane_table.get(name)
+    assert fvs != None
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert supervisor.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+    assert str(supervisor.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     #Set access of line-card to down
     supervisor.set_midplane_reachable(False)
     module_updater.check_midplane_reachability()
-    success, fvs = midplane_table.get(name)
-    fvs_dict = dict(fvs)
-    assert fvs_dict != None
-    if success:
-        fvs_dict = dict(fvs)
-        assert supervisor.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(supervisor.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs = midplane_table.get(name)
+    assert fvs != None
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert supervisor.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+    assert str(supervisor.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     #Deinit
     module_updater.deinit()
-    success, fvs = midplane_table.get(name)
-    assert fvs == []
+    fvs = midplane_table.get(name)
+    assert fvs == None
 
 def verify_asic(asic_name, asic_pci_address, module_name, asic_id_in_module, asic_table):
-    success, fvs =  asic_table.get(asic_name)
-    if success:
-        fvs_dict = dict(fvs)
-        assert fvs_dict[CHASSIS_ASIC_PCI_ADDRESS_FIELD] == asic_pci_address
-        assert fvs_dict[CHASSIS_MODULE_INFO_NAME_FIELD] == module_name
-        assert fvs_dict[CHASSIS_ASIC_ID_IN_MODULE_FIELD] == asic_id_in_module
+    fvs = asic_table.get(asic_name)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert fvs[CHASSIS_ASIC_PCI_ADDRESS_FIELD] == asic_pci_address
+    assert fvs[CHASSIS_MODULE_INFO_NAME_FIELD] == module_name
+    assert fvs[CHASSIS_ASIC_ID_IN_MODULE_FIELD] == asic_id_in_module
 
 def verify_asic_in_module_table(lc, slot, num_asics, chassis_module_table):
-    success, fvs = chassis_module_table.get(lc)
-    if success:
-        fvs_dict = dict(fvs)
-        assert fvs_dict['slot'] == str(slot)
-        assert fvs_dict['num_asics'] == str(num_asics)
+    fvs = chassis_module_table.get(lc)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert fvs['slot'] == str(slot)
+    assert fvs['num_asics'] == str(num_asics)
 
 def test_asic_presence():
     chassis = MockChassis()
@@ -1157,8 +1142,8 @@ def test_asic_presence():
     module_updater.module_db_update()
     module_updater.deinit()
     midplane_table = module_updater.midplane_table
-    success, fvs = midplane_table.get(name)
-    assert fvs == []
+    fvs = midplane_table.get(name)
+    assert fvs == None
     verify_asic("asic4", "0000:04:00.0", name, "0", fabric_asic_table)
     verify_asic("asic5", "0000:05:00.0", name, "1", fabric_asic_table)
 
@@ -1380,13 +1365,12 @@ def test_set_initial_dpu_admin_state_down():
     midplane_table = module_updater.midplane_table
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
-    success, fvs = midplane_table.get(name)
-    fvs_dict = dict(fvs)
-    assert fvs_dict != None
-    if success:
-        fvs_dict = dict(fvs)
-        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs = midplane_table.get(name)
+    assert fvs != None
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     # Patching platform's Chassis object to return the mocked module
     with patch.object(sonic_platform.platform.Chassis, 'is_smartswitch') as mock_is_smartswitch, \
@@ -1471,13 +1455,12 @@ def test_set_initial_dpu_admin_state_up():
     midplane_table = module_updater.midplane_table
     module.set_midplane_reachable(False)
     module_updater.check_midplane_reachability()
-    success, fvs = midplane_table.get(name)
-    fvs_dict = dict(fvs)
-    assert fvs_dict != None
-    if success:
-        fvs_dict = dict(fvs)
-        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(module.is_midplane_reachable()) == fv_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs = midplane_table.get(name)
+    assert fvs != None
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     # Patching platform's Chassis object to return the mocked module
     with patch.object(sonic_platform.platform.Chassis, 'is_smartswitch') as mock_is_smartswitch, \
@@ -1609,20 +1592,20 @@ def test_chassis_db_cleanup():
     module.set_oper_status(status)
     sup_module_updater.module_db_update()
 
-    success, fvs = sup_module_updater.module_table.get(lc_name)
-    if success:
-        fvs_dict = dict(fvs)
-        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    fvs = sup_module_updater.module_table.get(lc_name)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # Change linecard module status to OFFLINE
     status = ModuleBase.MODULE_STATUS_OFFLINE
     module.set_oper_status(status)
     sup_module_updater.module_db_update()
 
-    success, fvs = sup_module_updater.module_table.get(lc_name)
-    if success:
-        fvs_dict = dict(fvs)
-        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    fvs = sup_module_updater.module_table.get(lc_name)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # Mock >= CHASSIS_DB_CLEANUP_MODULE_DOWN_PERIOD module down period for LINE-CARD0
     down_module_key = lc_name+"|"+hostname
@@ -1682,16 +1665,16 @@ def test_chassis_db_bootup_with_empty_slot():
     sup_module_updater.module_db_update()
 
     # check LC1 STATUS ONLINE in module table
-    success, fvs = sup_module_updater.module_table.get(lc_name)
-    if success:
-        fvs_dict = dict(fvs)
-        assert ModuleBase.MODULE_STATUS_ONLINE == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    fvs = sup_module_updater.module_table.get(lc_name)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert ModuleBase.MODULE_STATUS_ONLINE == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # check LC2 STATUS EMPTY in module table 
-    success, fvs = sup_module_updater.module_table.get(lc2_name)
-    if success:
-        fvs_dict = dict(fvs)
-        assert ModuleBase.MODULE_STATUS_EMPTY == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    fvs = sup_module_updater.module_table.get(lc2_name)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert ModuleBase.MODULE_STATUS_EMPTY == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # Both should no tbe in down_module keys.
     
@@ -1705,10 +1688,10 @@ def test_chassis_db_bootup_with_empty_slot():
     module.set_oper_status(status)
     sup_module_updater.module_db_update()
 
-    success, fvs = sup_module_updater.module_table.get(lc_name)
-    if success:
-        fvs_dict = dict(fvs)
-        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    fvs = sup_module_updater.module_table.get(lc_name)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
     assert down_module_lc1_key in sup_module_updater.down_modules.keys()
 
 

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -1538,7 +1538,7 @@ def test_task_worker_loop():
 
     # Patch the swsscommon.Select to use this mock
     with patch('tests.mock_swsscommon.Select', return_value=mock_select):
-        config_manager = SmartSwitchConfigManagerTask()
+        config_manager = SmartSwitchConfigManagerTask(set_transition_flag_callback=MagicMock())
 
         config_manager.config_updater = MagicMock()
 

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -187,7 +187,14 @@ def test_smartswitch_moduleupdater_check_invalid_name():
     fvs = module_updater.module_table.get(name)
     assert fvs == None
 
-    config_updater = SmartSwitchModuleConfigUpdater(SYSLOG_IDENTIFIER, chassis)
+    mock_module_table = MagicMock()
+    mock_set_flag_callback = MagicMock()
+    config_updater = SmartSwitchModuleConfigUpdater(
+        SYSLOG_IDENTIFIER,
+        chassis,
+        mock_module_table,
+        mock_set_flag_callback
+    )
     admin_state = 0
     config_updater.module_config_update(name, admin_state)
 
@@ -214,7 +221,14 @@ def test_smartswitch_moduleupdater_check_invalid_admin_state():
     module_updater.module_db_update()
     fvs = module_updater.module_table.get(name)
 
-    config_updater = SmartSwitchModuleConfigUpdater(SYSLOG_IDENTIFIER, chassis)
+    mock_module_table = MagicMock()
+    mock_set_flag_callback = MagicMock()
+    config_updater = SmartSwitchModuleConfigUpdater(
+        SYSLOG_IDENTIFIER,
+        chassis,
+        mock_module_table,
+        mock_set_flag_callback
+    )
     admin_state = 2
     config_updater.module_config_update(name, admin_state)
 
@@ -475,7 +489,14 @@ def test_smartswitch_configupdater_check_admin_state():
     module.set_oper_status(status)
     chassis.module_list.append(module)
 
-    config_updater = SmartSwitchModuleConfigUpdater(SYSLOG_IDENTIFIER, chassis)
+    mock_module_table = MagicMock()
+    mock_set_flag_callback = MagicMock()
+    config_updater = SmartSwitchModuleConfigUpdater(
+        SYSLOG_IDENTIFIER,
+        chassis,
+        mock_module_table,
+        mock_set_flag_callback
+    )
     admin_state = 0
     config_updater.module_config_update(name, admin_state)
     assert module.get_admin_state() == admin_state

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -358,7 +358,7 @@ def test_moduleupdater_check_deinit():
 
     module_table = module_updater.module_table
     module_updater.deinit()
-    fvs = module_table.get(name)
+    status, fvs = module_table.get(name)
     assert fvs == None
 
 def test_smartswitch_moduleupdater_check_deinit():
@@ -386,7 +386,7 @@ def test_smartswitch_moduleupdater_check_deinit():
 
     module_table = module_updater.module_table
     module_updater.deinit()
-    fvs = module_table.get(name)
+    status, fvs = module_table.get(name)
     assert fvs == None
 
 def test_configupdater_check_valid_names():

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -536,7 +536,14 @@ def test_smartswitch_configupdater_check_admin_state():
     module.set_oper_status(status)
     chassis.module_list.append(module)
 
-    config_updater = SmartSwitchModuleConfigUpdater(SYSLOG_IDENTIFIER, chassis)
+    mock_module_table = MagicMock()
+    mock_set_flag_callback = MagicMock()
+    config_updater = SmartSwitchModuleConfigUpdater(
+        SYSLOG_IDENTIFIER,
+        chassis,
+        mock_module_table,
+        mock_set_flag_callback
+    )
 
     # Test setting admin state to down
     admin_state = 0

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -244,7 +244,8 @@ def test_smartswitch_moduleupdater_check_invalid_slot():
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
     success, fvs = module_updater.module_table.get(name)
-    assert fvs != None
+    fvs_dict = dict(fvs)
+    assert fvs_dict != None
 
 def test_moduleupdater_check_invalid_name():
     chassis = MockChassis()
@@ -287,7 +288,8 @@ def test_smartswitch_moduleupdater_check_invalid_index():
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
     success, fvs = module_updater.module_table.get(name)
-    assert fvs != None
+    fvs_dict = dict(fvs)
+    assert fvs_dict != None
 
     # Run chassis db clean up
     module_updater.module_down_chassis_db_cleanup()
@@ -731,31 +733,34 @@ def test_midplane_presence_modules():
     #Check fields in database
     name = "LINE-CARD0"
     success, fvs = midplane_table.get(name)
-    assert fvs != None
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs_dict = dict(fvs)
+    assert fvs_dict != None
+    if success:
+        fvs_dict = dict(fvs)
+        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     #Set access of line-card to Up (midplane connectivity is down initially)
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
     success, fvs = midplane_table.get(name)
-    assert fvs != None
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs_dict = dict(fvs)
+    assert fvs_dict != None
+    if success:
+        fvs_dict = dict(fvs)
+        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     #Set access of line-card to Down (to mock midplane connectivity state change)
     module.set_midplane_reachable(False)
     module_updater.check_midplane_reachability()
     success, fvs = midplane_table.get(name)
-    assert fvs != None
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs_dict = dict(fvs)
+    assert fvs_dict != None
+    if success:
+        fvs_dict = dict(fvs)
+        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     #Deinit
     module_updater.deinit()
@@ -801,31 +806,34 @@ def test_midplane_presence_dpu_modules(mock_open, mock_makedirs):
 
         #Check fields in database
         success, fvs = midplane_table.get(name)
-        assert fvs != None
-        if isinstance(fvs, list):
-            fvs = dict(fvs[-1])
-        assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+        fvs_dict = dict(fvs)
+        assert fvs_dict != None
+        if success:
+            fvs_dict = dict(fvs)
+            assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+            assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
         #Set access of DPU0 to Up (midplane connectivity is down initially)
         module.set_midplane_reachable(True)
         module_updater.check_midplane_reachability()
         success, fvs = midplane_table.get(name)
-        assert fvs != None
-        if isinstance(fvs, list):
-            fvs = dict(fvs[-1])
-        assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+        fvs_dict = dict(fvs)
+        assert fvs_dict != None
+        if success:
+            fvs_dict = dict(fvs)
+            assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+            assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
         #Set access of DPU0 to Down (to mock midplane connectivity state change)
         module.set_midplane_reachable(False)
         module_updater.check_midplane_reachability()
         success, fvs = midplane_table.get(name)
-        assert fvs != None
-        if isinstance(fvs, list):
-            fvs = dict(fvs[-1])
-        assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-        assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+        fvs_dict = dict(fvs)
+        assert fvs_dict != None
+        if success:
+            fvs_dict = dict(fvs)
+            assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+            assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
         # Run chassis db clean up
         module_updater.module_down_chassis_db_cleanup()
@@ -934,21 +942,23 @@ def test_midplane_presence_modules_linecard_reboot():
     #Check fields in database
     name = "LINE-CARD0"
     success, fvs = midplane_table.get(name)
-    assert fvs != None
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs_dict = dict(fvs)
+    assert fvs_dict != None
+    if success:
+        fvs_dict = dict(fvs)
+        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     #Set access of line-card to Up (midplane connectivity is down initially)
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
     success, fvs = midplane_table.get(name)
-    assert fvs != None
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs_dict = dict(fvs)
+    assert fvs_dict != None
+    if success:
+        fvs_dict = dict(fvs)
+        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     
     #Set access of line-card to Down (to mock midplane connectivity state change)
@@ -959,21 +969,22 @@ def test_midplane_presence_modules_linecard_reboot():
     module_reboot_table.set(name,linecard_fvs)
     module_updater.check_midplane_reachability()
     success, fvs = midplane_table.get(name)
-    assert fvs != None
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs_dict = dict(fvs)
+    assert fvs_dict != None
+    if success:
+        fvs_dict = dict(fvs)
+        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     #Set access of line-card to up on time (to mock midplane connectivity state change)
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
-    success, fvs = midplane_table.get(name)
-    assert fvs != None
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs_dict = dict(fvs)
+    assert fvs_dict != None
+    if success:
+        fvs_dict = dict(fvs)
+        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     # test linecard reboot midplane connectivity restored timeout
     # Set access of line-card to Down (to mock midplane connectivity state change)
@@ -986,12 +997,13 @@ def test_midplane_presence_modules_linecard_reboot():
     module_reboot_table.set(name,linecard_fvs)
     module_updater.check_midplane_reachability()
     success, fvs = midplane_table.get(name)
-    assert fvs != None
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]   
-    assert module_updater.linecard_reboot_timeout == 240    
+    fvs_dict = dict(fvs)
+    assert fvs_dict != None
+    if success:
+        fvs_dict = dict(fvs)
+        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]   
+        assert module_updater.linecard_reboot_timeout == 240    
     
 def test_midplane_presence_supervisor():
     chassis = MockChassis()
@@ -1044,21 +1056,23 @@ def test_midplane_presence_supervisor():
     #Check fields in database
     name = "SUPERVISOR0"
     success, fvs = midplane_table.get(name)
-    assert fvs != None
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert supervisor.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-    assert str(supervisor.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs_dict = dict(fvs)
+    assert fvs_dict != None
+    if success:
+        fvs_dict = dict(fvs)
+        assert supervisor.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(supervisor.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     #Set access of line-card to down
     supervisor.set_midplane_reachable(False)
     module_updater.check_midplane_reachability()
     success, fvs = midplane_table.get(name)
-    assert fvs != None
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert supervisor.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-    assert str(supervisor.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs_dict = dict(fvs)
+    assert fvs_dict != None
+    if success:
+        fvs_dict = dict(fvs)
+        assert supervisor.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(supervisor.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     #Deinit
     module_updater.deinit()
@@ -1066,19 +1080,19 @@ def test_midplane_presence_supervisor():
     assert fvs == []
 
 def verify_asic(asic_name, asic_pci_address, module_name, asic_id_in_module, asic_table):
-    fvs = asic_table.get(asic_name)
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert fvs[CHASSIS_ASIC_PCI_ADDRESS_FIELD] == asic_pci_address
-    assert fvs[CHASSIS_MODULE_INFO_NAME_FIELD] == module_name
-    assert fvs[CHASSIS_ASIC_ID_IN_MODULE_FIELD] == asic_id_in_module
+    success, fvs =  asic_table.get(asic_name)
+    if success:
+        fvs_dict = dict(fvs)
+        assert fvs_dict[CHASSIS_ASIC_PCI_ADDRESS_FIELD] == asic_pci_address
+        assert fvs_dict[CHASSIS_MODULE_INFO_NAME_FIELD] == module_name
+        assert fvs_dict[CHASSIS_ASIC_ID_IN_MODULE_FIELD] == asic_id_in_module
 
 def verify_asic_in_module_table(lc, slot, num_asics, chassis_module_table):
-    fvs = chassis_module_table.get(lc)
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert fvs['slot'] == str(slot)
-    assert fvs['num_asics'] == str(num_asics)
+    success, fvs = chassis_module_table.get(lc)
+    if success:
+        fvs_dict = dict(fvs)
+        assert fvs_dict['slot'] == str(slot)
+        assert fvs_dict['num_asics'] == str(num_asics)
 
 def test_asic_presence():
     chassis = MockChassis()
@@ -1367,11 +1381,12 @@ def test_set_initial_dpu_admin_state_down():
     module.set_midplane_reachable(True)
     module_updater.check_midplane_reachability()
     success, fvs = midplane_table.get(name)
-    assert fvs != None
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs_dict = dict(fvs)
+    assert fvs_dict != None
+    if success:
+        fvs_dict = dict(fvs)
+        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(module.is_midplane_reachable()) == fvs_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     # Patching platform's Chassis object to return the mocked module
     with patch.object(sonic_platform.platform.Chassis, 'is_smartswitch') as mock_is_smartswitch, \
@@ -1457,11 +1472,12 @@ def test_set_initial_dpu_admin_state_up():
     module.set_midplane_reachable(False)
     module_updater.check_midplane_reachability()
     success, fvs = midplane_table.get(name)
-    assert fvs != None
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert module.get_midplane_ip() == fvs[CHASSIS_MIDPLANE_INFO_IP_FIELD]
-    assert str(module.is_midplane_reachable()) == fvs[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
+    fvs_dict = dict(fvs)
+    assert fvs_dict != None
+    if success:
+        fvs_dict = dict(fvs)
+        assert module.get_midplane_ip() == fvs_dict[CHASSIS_MIDPLANE_INFO_IP_FIELD]
+        assert str(module.is_midplane_reachable()) == fv_dict[CHASSIS_MIDPLANE_INFO_ACCESS_FIELD]
 
     # Patching platform's Chassis object to return the mocked module
     with patch.object(sonic_platform.platform.Chassis, 'is_smartswitch') as mock_is_smartswitch, \
@@ -1593,20 +1609,20 @@ def test_chassis_db_cleanup():
     module.set_oper_status(status)
     sup_module_updater.module_db_update()
 
-    fvs = sup_module_updater.module_table.get(lc_name)
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    success, fvs = sup_module_updater.module_table.get(lc_name)
+    if success:
+        fvs_dict = dict(fvs)
+        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # Change linecard module status to OFFLINE
     status = ModuleBase.MODULE_STATUS_OFFLINE
     module.set_oper_status(status)
     sup_module_updater.module_db_update()
 
-    fvs = sup_module_updater.module_table.get(lc_name)
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    success, fvs = sup_module_updater.module_table.get(lc_name)
+    if success:
+        fvs_dict = dict(fvs)
+        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # Mock >= CHASSIS_DB_CLEANUP_MODULE_DOWN_PERIOD module down period for LINE-CARD0
     down_module_key = lc_name+"|"+hostname
@@ -1666,16 +1682,16 @@ def test_chassis_db_bootup_with_empty_slot():
     sup_module_updater.module_db_update()
 
     # check LC1 STATUS ONLINE in module table
-    fvs = sup_module_updater.module_table.get(lc_name)
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert ModuleBase.MODULE_STATUS_ONLINE == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    success, fvs = sup_module_updater.module_table.get(lc_name)
+    if success:
+        fvs_dict = dict(fvs)
+        assert ModuleBase.MODULE_STATUS_ONLINE == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # check LC2 STATUS EMPTY in module table 
-    fvs = sup_module_updater.module_table.get(lc2_name)
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert ModuleBase.MODULE_STATUS_EMPTY == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    success, fvs = sup_module_updater.module_table.get(lc2_name)
+    if success:
+        fvs_dict = dict(fvs)
+        assert ModuleBase.MODULE_STATUS_EMPTY == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # Both should no tbe in down_module keys.
     
@@ -1689,10 +1705,10 @@ def test_chassis_db_bootup_with_empty_slot():
     module.set_oper_status(status)
     sup_module_updater.module_db_update()
 
-    fvs = sup_module_updater.module_table.get(lc_name)
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    success, fvs = sup_module_updater.module_table.get(lc_name)
+    if success:
+        fvs_dict = dict(fvs)
+        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
     assert down_module_lc1_key in sup_module_updater.down_modules.keys()
 
 

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -84,9 +84,9 @@ def test_moduleupdater_check_valid_fields():
     status, fvs = module_updater.module_table.get(name)
     if status:
         fvs_dict = dict(fvs)
-        assert desc == fvs[CHASSIS_MODULE_INFO_DESC_FIELD]
-        assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
-        assert serial == fvs[CHASSIS_MODULE_INFO_SERIAL_FIELD]
+        assert desc == fvs_dict[CHASSIS_MODULE_INFO_DESC_FIELD]
+        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+        assert serial == fvs_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD]
     else:
         assert False, f"Module {name} not found in module_table"
 
@@ -109,12 +109,14 @@ def test_smartswitch_moduleupdater_check_valid_fields():
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
     module_updater.module_db_update()
     status, fvs = module_updater.module_table.get(name)
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert desc == fvs[CHASSIS_MODULE_INFO_DESC_FIELD]
-    assert NOT_AVAILABLE == fvs[CHASSIS_MODULE_INFO_SLOT_FIELD]
-    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
-    assert serial == fvs[CHASSIS_MODULE_INFO_SERIAL_FIELD]
+    if status:
+        fvs_dict = dict(fvs)
+        assert desc == fvs_dict[CHASSIS_MODULE_INFO_DESC_FIELD]
+        assert NOT_AVAILABLE == fvs_dict[CHASSIS_MODULE_INFO_SLOT_FIELD]
+        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+        assert serial == fvs_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD]
+    else:
+        assert False, f"Module {name} not found in module_table"
 
 def test_smartswitch_moduleupdater_status_transitions():
     # Mock the chassis and module
@@ -309,27 +311,27 @@ def test_moduleupdater_check_status_update():
                                    module.supervisor_slot)
     module_updater.module_db_update()
     status, fvs = module_updater.module_table.get(name)
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    print('Initial DB-entry {}'.format(fvs))
-    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    if status:
+        fvs_dict = dict(fvs)
+        print('Initial DB-entry {}'.format(fvs))
+        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # Update status
     status = ModuleBase.MODULE_STATUS_OFFLINE
     module.set_oper_status(status)
     status, fvs = module_updater.module_table.get(name)
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    print('Not updated DB-entry {}'.format(fvs))
-    assert status != fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    if status:
+        fvs_dict = dict(fvs)
+        print('Not updated DB-entry {}'.format(fvs))
+        assert status != fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # Update status and db
     module_updater.module_db_update()
     status, fvs = module_updater.module_table.get(name)
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    print('Updated DB-entry {}'.format(fvs))
-    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    if status:
+        fvs_dict = dict(fvs)
+        print('Updated DB-entry {}'.format(fvs))
+        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     # Run chassis db clean up from LC.
     module_updater.module_down_chassis_db_cleanup()
@@ -354,9 +356,9 @@ def test_moduleupdater_check_deinit():
     module_updater.modules_num_update()
     module_updater.module_db_update()
     status, fvs = module_updater.module_table.get(name)
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+    if status:
+        fvs_dict = dict(fvs)
+        assert status == fvs_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     module_table = module_updater.module_table
     module_updater.deinit()
@@ -382,9 +384,6 @@ def test_smartswitch_moduleupdater_check_deinit():
     module_updater.modules_num_update()
     module_updater.module_db_update()
     status, fvs = module_updater.module_table.get(name)
-    # if isinstance(fvs, list):
-    #    fvs = dict(fvs[-1])
-    # assert status == fvs[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
     module_table = module_updater.module_table
     module_updater.deinit()
@@ -625,9 +624,9 @@ def test_configupdater_check_num_modules():
     chassis.module_list.append(module)
     module_updater.modules_num_update()
     status, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
-    if isinstance(fvs, list):
-        fvs = dict(fvs[-1])
-    assert chassis.get_num_modules() == int(fvs[CHASSIS_INFO_CARD_NUM_FIELD])
+    if status:
+        fvs_dict = dict(fvs)
+        assert chassis.get_num_modules() == int(fvs_dict[CHASSIS_INFO_CARD_NUM_FIELD])
 
     module_updater.deinit()
     status, fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -1903,7 +1903,7 @@ def test_submit_dpu_callback():
     with patch.object(module, 'module_pre_shutdown') as mock_pre_shutdown, \
          patch.object(module, 'set_admin_state') as mock_set_admin_state, \
          patch.object(module, 'module_post_startup') as mock_post_startup:
-        daemon_chassisd.submit_dpu_callback(index, MODULE_ADMIN_DOWN)
+        daemon_chassisd.submit_dpu_callback(index, MODULE_ADMIN_DOWN, name)
         # Verify correct functions are called for admin down
         mock_pre_shutdown.assert_called_once()
         mock_set_admin_state.assert_called_once_with(MODULE_ADMIN_DOWN)
@@ -1915,7 +1915,7 @@ def test_submit_dpu_callback():
          patch.object(module, 'set_admin_state') as mock_set_admin_state, \
          patch.object(module, 'module_post_startup') as mock_post_startup:
 
-        daemon_chassisd.submit_dpu_callback(index, MODULE_ADMIN_UP)
+        daemon_chassisd.submit_dpu_callback(index, MODULE_ADMIN_UP, name)
 
         # Verify correct functions are called for admin up
         mock_pre_shutdown.assert_not_called()

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -562,8 +562,8 @@ def test_smartswitch_configupdater_check_admin_state():
         mock_module_post_startup.assert_called_once()
 
 
-@patch("your_module.glob.glob")
-@patch("your_module.open", new_callable=mock_open)
+@patch("scripts.chassisd.glob.glob")
+@patch("scripts.chassisd.open", new_callable=mock_open)
 def test_update_dpu_reboot_cause_to_db(self, mock_open, mock_glob):
     # Set up the SmartSwitchModuleUpdater and test inputs
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis=MagicMock())

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -10,6 +10,7 @@ from sonic_py_common import daemon_base
 
 from .mock_platform import MockChassis, MockSmartSwitchChassis, MockModule
 from .mock_module_base import ModuleBase
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../scripts"))
 
 # Assuming OBJECT should be a specific value, define it manually
 SELECT_OBJECT = 1  # Replace with the actual value for OBJECT if know
@@ -562,8 +563,8 @@ def test_smartswitch_configupdater_check_admin_state():
         mock_module_post_startup.assert_called_once()
 
 
-@patch("scripts.chassisd.glob.glob")
-@patch("scripts.chassisd.open", new_callable=mock_open)
+@patch("chassisd.glob.glob")
+@patch("chassisd.open", new_callable=mock_open)
 def test_update_dpu_reboot_cause_to_db(mock_open, mock_glob):
     module_updater = SmartSwitchModuleUpdater("TEST_LOG", chassis=MagicMock())
     module = "dpu0"


### PR DESCRIPTION
Chassisd does not wait for the execution to complete for previous admin state change requests. Fixed issue #22138

#### Description
Fixed issue #22138
Chassisd does not wait for the execution to complete for previous admin state change requests. Added support to solve this.

The corresponding sonic-utilities PR is: https://github.com/sonic-net/sonic-utilities/pull/3937

#### Motivation and Context
Added a state to indicate the progress of an admin_state transition period (window) of every module in config_db.
When in progress do not allow another admin_state change for that module.
Mark the beginning of state transition in the CLI itself. Added a timeout also for error cases.
Mark the end of state transition in chassisd

#### How Has This Been Tested?
ssue "config chassis module startup DPU0". This takes around 3 mins. Check the config_db and verify the new variable is set to True.
Issue another "config chassis module startup DPU0" and also ""config chassis module shutdown DPU0".
See both are blocked.
Once the DPU operational state is the admin_sate check if a new config is accepted.

#### Request for 202505
- [x] 202505

#### Additional Information (Optional)
Goes with PR: https://github.com/sonic-net/sonic-utilities/pull/3845