### PR TITLE
Add CMIS FSM for DP decomission

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -3329,7 +3329,7 @@ class TestXcvrdScript(object):
         # 2nd subport should not start decommission state machine as 1st subport already started decommission for the entire physical port
         assert get_cmis_state_from_state_db('Ethernet2', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet2'))) == CMIS_STATE_INSERTED
         assert task.is_decomm_pending('Ethernet0')
-        assert not task.is_decomm_failed_for_pport('Ethernet0')
+        assert not task.is_decomm_failed('Ethernet0')
 
         task.task_stopping_event.is_set = MagicMock(side_effect=[False]*3 + [True])
         task.task_worker()
@@ -3345,7 +3345,7 @@ class TestXcvrdScript(object):
         # 2nd subport is unblocked from decommission and continue on normal state machine
         assert get_cmis_state_from_state_db('Ethernet2', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet2'))) == CMIS_STATE_DP_PRE_INIT_CHECK
         assert not task.is_decomm_lead_lport('Ethernet0')
-        assert not task.is_decomm_failed_for_pport('Ethernet0')
+        assert not task.is_decomm_failed('Ethernet0')
         assert not task.is_decomm_pending('Ethernet0')
 
         # Delete the config for all subports
@@ -3371,7 +3371,7 @@ class TestXcvrdScript(object):
         # Set CMIS_STATE_FAILED to 1st subport to force decommission fail on the entire physical port
         task.update_port_transceiver_status_table_sw_cmis_state('Ethernet0', CMIS_STATE_FAILED)
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_FAILED
-        assert task.is_decomm_failed_for_pport('Ethernet0')
+        assert task.is_decomm_failed('Ethernet0')
 
         # Insert 2nd subport event
         port_change_event = PortChangeEvent('Ethernet2', physical_port_idx, 0, PortChangeEvent.PORT_SET, {'speed':'100000', 'lanes':'3,4', 'subport': '2'})
@@ -3380,12 +3380,12 @@ class TestXcvrdScript(object):
         task.task_worker()
         # 1st subport should stay in failed state
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_FAILED
-        assert task.is_decomm_failed_for_pport('Ethernet0')
+        assert task.is_decomm_failed('Ethernet0')
         assert task.is_decomm_lead_lport('Ethernet0')
         # 2nd subport is waiting for decommission to complete, and should also fall into failed state
         assert get_cmis_state_from_state_db('Ethernet2', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet2'))) == CMIS_STATE_FAILED
         assert task.is_decomm_pending('Ethernet2')
-        assert task.is_decomm_failed_for_pport('Ethernet2')
+        assert task.is_decomm_failed('Ethernet2')
 
         # Delete the config for 1st subport
         port_change_event = PortChangeEvent('Ethernet0', physical_port_idx, 0, PortChangeEvent.PORT_DEL, {}, db_name='CONFIG_DB', table_name='PORT')

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -211,14 +211,11 @@ def gen_cmis_lanes_dict(key_format_str, value, one_based=True):
         lanes_dict[key_format_str.format(lane_idx)] = value
     return lanes_dict
 
-
 def gen_cmis_dp_state_dict(value):
     return gen_cmis_lanes_dict('DP{}State', value)
 
-
 def gen_cmis_config_status_dict(value):
     return gen_cmis_lanes_dict('ConfigStatusLane{}', value)
-
 
 def gen_cmis_dpinit_pending_dict(value):
     return gen_cmis_lanes_dict('DPInitPending{}', value)
@@ -2641,6 +2638,8 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.CmisManagerTask.wait_for_port_config_done', MagicMock())
     @patch('xcvrd.xcvrd.CmisManagerTask.is_decommission_required', MagicMock(return_value=False))
     @patch('xcvrd.xcvrd.is_cmis_api', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.optics_si_parser.optics_si_present', MagicMock(return_value=(True)))
+    @patch('xcvrd.xcvrd_utilities.optics_si_parser.fetch_optics_si_setting', MagicMock())
     def test_CmisManagerTask_task_worker(self, mock_chassis, mock_get_status_sw_tbl):
         mock_get_status_sw_tbl = Table("STATE_DB", TRANSCEIVER_STATUS_SW_TABLE)
         mock_xcvr_api = MagicMock()

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -3380,6 +3380,8 @@ class TestXcvrdScript(object):
 
         # ===== Test failed decommission case =====
 
+        # Force config status check to failed
+        mock_xcvr_api.get_config_datapath_hostlane_status.return_value = gen_cmis_config_status_dict('ConfigRejected')
         mock_xcvr_api.get_datapath_state = MagicMock(return_value=gen_cmis_dp_state_dict('DataPathDeactivated'))
         mock_xcvr_api.get_datapath_init_duration = MagicMock(return_value=0)
         mock_xcvr_api.get_module_pwr_up_duration = MagicMock(return_value=0)
@@ -3388,16 +3390,8 @@ class TestXcvrdScript(object):
         # Insert 1st subport event
         port_change_event = PortChangeEvent('Ethernet0', physical_port_idx, 0, PortChangeEvent.PORT_SET, {'speed':'100000', 'lanes':'1,2', 'subport': '1'})
         task.on_port_update_event(port_change_event)
-        # Force DPInitPending check to fail
-        task.check_datapath_init_pending = MagicMock(return_value=False)
-        task.task_stopping_event.is_set = MagicMock(side_effect=[False]*10 + [True]*2)
-        task.task_worker()
-        # Unblock from DPInitPending check
-        task.check_datapath_init_pending = MagicMock(return_value=True)
-        # Force config status check to fail
-        mock_xcvr_api.get_config_datapath_hostlane_status.return_value = gen_cmis_config_status_dict('ConfigRejected')
         # Make sure to give enough iterations so that task worker runs to the end
-        task.task_stopping_event.is_set = MagicMock(side_effect=[False]*30 + [True]*2)
+        task.task_stopping_event.is_set = MagicMock(side_effect=[False]*50 + [True]*2)
         task.task_worker()
         assert task.is_decomm_lead_lport('Ethernet0')
         # 1st subport should fail on 'ConfigSuccess' check and fall into failed state after retries

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2115,6 +2115,15 @@ class TestXcvrdScript(object):
         task.xcvr_table_helper.get_status_tbl.return_value = mock_status_tbl
         task.update_port_xcvr_status_tbl_decommission_state(port_mapping, lport, decommission_state)
 
+    @pytest.mark.parametrize("mock_found, mock_status_dict, expected_decom_state", [
+        (True, {'decommission_state': True}, True),
+        (False, {}, False),
+        (True, {'other_key': 'some_value'}, False)
+    ])
+    def test_get_decommission_state_from_state_db(self, mock_found, mock_status_dict, expected_decom_state):
+        status_tbl = MagicMock()
+        status_tbl.get.return_value = (mock_found, mock_status_dict)
+        assert get_decommission_state_from_state_db("Ethernet0", status_tbl) == expected_decom_state
 
     DEFAULT_DP_STATE = {
         'DP1State': 'DataPathActivated',

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -3256,7 +3256,7 @@ class TestXcvrdScript(object):
         assert task.port_dict['Ethernet0']['forced_tx_disabled'] == False
         assert task.port_dict['Ethernet0']['cmis_retries'] == 1
 
-@patch('xcvrd.xcvrd.XcvrTableHelper.get_status_sw_tbl')
+    @patch('xcvrd.xcvrd.XcvrTableHelper.get_status_sw_tbl')
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd.is_fast_reboot_enabled', MagicMock(return_value=(False)))
     @patch('xcvrd.xcvrd.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2682,7 +2682,7 @@ class TestXcvrdScript(object):
         # Shouldn't proceed to DP_DEINIT on error
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
-        assert not get_cmis_state_from_state_db('Ethernet1', task.xcvr_table_helper.get_status_tbl(task.get_asic_id('Ethernet1'))) == CMIS_STATE_DP_PRE_INIT_CHECK
+        assert not get_cmis_state_from_state_db('Ethernet1', task.xcvr_table_helper.get_status_tbl(task.get_asic_id('Ethernet1'))) == CMIS_STATE_DP_DEINIT
 
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_status_tbl')
     @patch('xcvrd.xcvrd.platform_chassis')

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2298,95 +2298,20 @@ class TestXcvrdScript(object):
         cmis_manager.join()
         assert not cmis_manager.is_alive()
 
-    @patch('xcvrd.xcvrd.get_decommission_state_from_state_db')
     @pytest.mark.parametrize("app_new, lane_appl_code, expected", [
         (2, {0 : 1, 1 : 1, 2 : 1, 3 : 1, 4 : 2, 5 : 2, 6 : 2, 7 : 2}, True),
         (0, {0 : 1, 1 : 1, 2 : 1, 3 : 1}, True),
         (1, {0 : 0, 1 : 0, 2 : 0, 3 : 0, 4 : 0, 5 : 0, 6 : 0, 7 : 0}, False)
      ])
-    def test_CmisManagerTask_is_appl_reconfigure_required(self, mock_get_decomm, app_new, lane_appl_code, expected):
-        mock_get_status_tbl = Table("STATE_DB", TRANSCEIVER_STATUS_TABLE)
+    def test_CmisManagerTask_is_appl_reconfigure_required(self, app_new, lane_appl_code, expected):
         mock_xcvr_api = MagicMock()
-        port_mapping = PortMapping()
-        stop_event = threading.Event()
-        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
-        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
-        mock_get_status_tbl = MagicMock()
-        mock_get_status_tbl.set = MagicMock()
-        task.xcvr_table_helper.get_status_tbl = mock_get_status_tbl
         def get_application(lane):
             return lane_appl_code.get(lane, 0)
         mock_xcvr_api.get_application = MagicMock(side_effect=get_application)
-        mock_get_decomm.return_value = False
-        assert task.is_appl_reconfigure_required(mock_xcvr_api, app_new, "Ethernet0") == expected
-
-    def test_CmisManagerTask_decomission_all_datapaths(self):
-        SUCCESS = 0
-        RETRY = 1
-        CONTINUE = 2
-        mock_xcvr_api = MagicMock()
         port_mapping = PortMapping()
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
-        task.port_dict["Ethernet0"] = {}
-        mock_xcvr_api.get_datapath_deinit_duration = MagicMock(return_value=600000.0)
-        assert task.decomission_all_datapaths("Ethernet0", mock_xcvr_api) == CONTINUE
-
-        task.port_dict['Ethernet0']['cmis_decom_state'] = CMIS_DECOM_APCONFIG
-        assert task.decomission_all_datapaths("Ethernet0", mock_xcvr_api) == CONTINUE
-
-        task.is_timer_expired = MagicMock(return_value=(True))
-        assert task.decomission_all_datapaths("Ethernet0", mock_xcvr_api) == RETRY
-
-        task.check_datapath_state = MagicMock(return_value=(True))
-        mock_xcvr_api.scs_apply_datapath_init = MagicMock(return_value=(True))
-        assert task.decomission_all_datapaths("Ethernet0", mock_xcvr_api) == CONTINUE
-
-        mock_xcvr_api.scs_apply_datapath_init = MagicMock(return_value=(False))
-        assert task.decomission_all_datapaths("Ethernet0", mock_xcvr_api) == RETRY
-
-        task.port_dict['Ethernet0']['cmis_decom_state'] = CMIS_DECOM_DPINIT
-        task.is_timer_expired = MagicMock(return_value=(True))
-        task.check_config_error = MagicMock(return_value=(False))
-        assert task.decomission_all_datapaths("Ethernet0", mock_xcvr_api) == RETRY
-
-        task.is_timer_expired = MagicMock(return_value=(False))
-        assert task.decomission_all_datapaths("Ethernet0", mock_xcvr_api) == CONTINUE
-
-        task.check_config_error = MagicMock(return_value=(True))
-        assert task.decomission_all_datapaths("Ethernet0", mock_xcvr_api) == SUCCESS
-
-    def test_update_port_xcvr_status_tbl_decommission_state(self):
-        mock_status_tbl = MagicMock()
-        port_mapping = PortMapping()
-        stop_event = threading.Event()
-        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
-        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
-        mock_get_status_tbl = MagicMock()
-        mock_get_status_tbl.set = MagicMock()
-        task.xcvr_table_helper.get_status_tbl = mock_get_status_tbl
-        port_mapping.logical_port_list.count('Ethernet0')
-        lport = 'Ethernet0'
-        physical_port = [0]
-        logical_ports = ['Ethernet0', 'Ethernet4']
-        asic_id = 'asic0'
-        decommission_state = "True"
-
-        port_mapping.get_logical_to_physical = MagicMock(return_value=physical_port)
-        port_mapping.get_physical_to_logical = MagicMock(return_value=logical_ports)
-        task.get_asic_id = MagicMock(return_value=asic_id)
-        task.xcvr_table_helper.get_status_tbl.return_value = mock_status_tbl
-        task.update_port_xcvr_status_tbl_decommission_state(port_mapping, lport, decommission_state)
-
-    @pytest.mark.parametrize("mock_found, mock_status_dict, expected_decom_state", [
-        (True, {'decommission_state': True}, True),
-        (False, {}, False),
-        (True, {'other_key': 'some_value'}, False)
-    ])
-    def test_get_decommission_state_from_state_db(self, mock_found, mock_status_dict, expected_decom_state):
-        status_tbl = MagicMock()
-        status_tbl.get.return_value = (mock_found, mock_status_dict)
-        assert get_decommission_state_from_state_db("Ethernet0", status_tbl) == expected_decom_state
+        assert task.is_appl_reconfigure_required(mock_xcvr_api, app_new) == expected
 
     DEFAULT_DP_STATE = {
         'DP1State': 'DataPathActivated',
@@ -2905,7 +2830,8 @@ class TestXcvrdScript(object):
         task.configure_laser_frequency = MagicMock(return_value=1)
 
         # Case 1: CMIS_STATE_DP_PRE_INIT_CHECK --> DP_DEINIT
-        task.is_appl_reconfigure_required = MagicMock(return_value=False)
+        task.is_appl_reconfigure_required = MagicMock(return_value=True)
+        mock_xcvr_api.decommission_all_datapaths = MagicMock(return_value=True)
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_DEINIT
@@ -2970,6 +2896,8 @@ class TestXcvrdScript(object):
         task.configure_laser_frequency = MagicMock(return_value=1)
 
         # Shouldn't proceed to DP_DEINIT on error
+        task.is_appl_reconfigure_required = MagicMock(return_value=True)
+        mock_xcvr_api.decommission_all_datapaths = MagicMock(return_value=False)
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
         assert not get_cmis_state_from_state_db('Ethernet1', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet1'))) == CMIS_STATE_DP_DEINIT

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -622,6 +622,7 @@ class CmisManagerTask(threading.Thread):
         self.task_stopping_event = threading.Event()
         self.main_thread_stop_event = main_thread_stop_event
         self.port_dict = {k: {"asic_id": v} for k, v in port_mapping.logical_to_asic.items()}
+        self.port_mapping = copy.deepcopy(port_mapping)
         self.isPortInitDone = False
         self.isPortConfigDone = False
         self.skip_cmis_mgr = skip_cmis_mgr

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -904,9 +904,9 @@ class CmisManagerTask(threading.Thread):
         Try to force the restart of CMIS state machine
         """
         self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_INSERTED)
-	self.port_dict[lport]['cmis_decom_state'] =  CMIS_DECOM_DEINIT
+        self.port_dict[lport]['cmis_decom_state'] =  CMIS_DECOM_DEINIT
         self.port_dict[lport]['cmis_retries'] = retries
-	self.port_dict[lport]['cmis_decom_expired'] = None
+        self.port_dict[lport]['cmis_decom_expired'] = None
         self.port_dict[lport]['cmis_expired'] = None # No expiration
 
     def check_module_state(self, api, states):
@@ -1453,7 +1453,7 @@ class CmisManagerTask(threading.Thread):
                                  self.log_notice("{} Successfully configured Tx power = {}".format(lport, tx_power))
 
                         # Set all the DP lanes AppSel to unused(0) when non default app code needs to be configured
-			if self.is_appl_reconfigure_required(api, appl, lport):
+                        if self.is_appl_reconfigure_required(api, appl, lport):
                             self.log_notice(f"{lport}: Decommissioning all lanes/datapaths to default AppSel=0")
                             decom_state = self.decomission_all_datapaths(lport, api)
                             if decom_state == RETRY:

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1266,15 +1266,15 @@ class CmisManagerTask(threading.Thread):
                             self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_DEINIT)
                             continue
                         elif self.is_decomm_pending_for_pport(lport):
-                            failed = self.is_decomm_failed_for_pport(lport)
-                            failed_str = "failed" if failed else "waiting"
-                            self.log_notice("{}: DECOMMISSION: another lport is doing decommission for this pport, {}"
-                                                                    .format(lport, failed_str))
-                            if failed:
-                                # Fail the CMIS state machine for this lport
-                                self.force_cmis_reinit(lport, self.CMIS_MAX_RETRIES + 1)
+                            if self.is_decomm_failed_for_pport(lport):
+                                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
+                                decomm_status_str = "failed"
+                            else:
+                                decomm_status_str = "waiting for completion"
+                            self.log_notice("{}: DECOMMISSION: decommission has already started for this physical port, "
+                                            "{}".format(lport, decomm_status_str))
                             continue
-                    
+
                         if self.port_dict[lport]['host_tx_ready'] != 'true' or \
                                 self.port_dict[lport]['admin_status'] != 'up':
                            if is_fast_reboot and self.check_datapath_state(api, host_lanes_mask, ['DataPathActivated']):

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -699,12 +699,12 @@ class CmisManagerTask(threading.Thread):
                 Boolean, True, if decommission pending is set, False otherwise
                          False, it means the datapath is ready to be reinitialized.
         """
-        target_index = self.port_dict[lport]['index']
-        for port, pdata in self.port_dict.items():
-            if pdata['index'] == target_index:
+        physical_port = self.port_dict[lport]['index']
+        for logical_port, pdata in self.port_dict.items():
+            if pdata['index'] == physical_port:
                 pdata['is_decomm_pending'] = decomm_pending
                 if not decomm_pending:
-                    self.force_cmis_reinit(port, 0)
+                    self.force_cmis_reinit(logical_port, 0)
 
     def is_decommission_required(self, lport, api):
         """
@@ -1168,7 +1168,7 @@ class CmisManagerTask(threading.Thread):
                 try:
                     # CMIS state transitions
                     if state == CMIS_STATE_INSERTED:
-                        f self.is_decommission_required(lport, api):
+                        if self.is_decommission_required(lport, api):
                             self.port_dict[lport]['appl'] = appl = 0
                             self.port_dict[lport]['host_lanes_mask'] = host_lanes_mask = 0xff
                             self.port_dict[lport]['media_lane_mask'] = 0xff

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1402,6 +1402,7 @@ class CmisManagerTask(threading.Thread):
                                 # Apply module SI settings if applicable
                                 lane_speed = int(speed/1000)//host_lane_count
                                 optics_si_dict = optics_si_parser.fetch_optics_si_setting(pport, lane_speed, sfp)
+
                                 self.log_debug("Read SI parameters for port {} from optics_si_settings.json vendor file:".format(lport))
                                 for key, sub_dict in optics_si_dict.items():
                                     self.log_debug("{}".format(key))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1386,7 +1386,7 @@ class CmisManagerTask(threading.Thread):
                             continue
 
                         # Skip rest if it's in decommission state machine
-                        if not self.is_decomm_lead_lport(lport):
+                        if not self.is_decomm_pending(lport):
                             if api.is_coherent_module():
                             # For ZR module, configure the laser frequency when Datapath is in Deactivated state
                                 freq = self.port_dict[lport]['laser_freq']
@@ -1431,13 +1431,13 @@ class CmisManagerTask(threading.Thread):
                     elif state == CMIS_STATE_DP_INIT:
                         if not self.check_config_error(api, host_lanes_mask, ['ConfigSuccess']):
                             if self.is_timer_expired(expired):
-                                self.log_notice("{}: timeout for 'ConfigSuccess'".format(lport))
+                                self.log_notice("{}: timeout for 'ConfigSuccess', current ConfigStatus: "
+                                                "{}".format(lport, list(api.get_config_datapath_hostlane_status().values())))
                                 self.force_cmis_reinit(lport, retries + 1)
                             continue
 
-                        # Set the decommission pending flag to False and invoke CMIS reinit
-                        # so that normal CMIS initialization can begin
-                        if self.is_decomm_lead_lport(lport):
+                        # Clear decommission status and invoke CMIS reinit so that normal CMIS initialization can begin
+                        if self.is_decomm_pending(lport):
                             self.log_notice("{}: DECOMMISSION: done for physical port {}".format(lport, self.port_dict[lport]['index']))
                             self.clear_decomm_pending(lport)
                             self.force_cmis_reinit(lport)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -952,23 +952,6 @@ class CmisManagerTask(threading.Thread):
 
         return done
 
-    def update_port_xcvr_status_tbl_decommission_state(self, lport, decommission_state):
-        """
-        Update decommission state for all logical ports in physical port
-        """
-        physical_port = self.port_mapping.get_logical_to_physical(lport)
-        logical_ports = self.port_mapping.get_physical_to_logical(int(physical_port[0]))
-        for port in logical_ports:
-            asic_index = self.port_mapping.get_asic_id_for_logical_port(port)
-            status_table = self.xcvr_table_helper.get_status_tbl(asic_index)
-            if status_table is None:
-                self.log_error("status_table is None while updating "
-                                    "sw DECOMMISSION state for lport {}".format(port))
-                return
-
-            fvs = swsscommon.FieldValuePairs([('decommission_state', decommission_state)])
-            status_table.set(port, fvs)
-
     def check_datapath_init_pending(self, api, host_lanes_mask):
         """
         Check if the CMIS datapath init is pending

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -111,10 +111,6 @@ VOLT_UNIT = 'Volts'
 POWER_UNIT = 'dBm'
 BIAS_UNIT = 'mA'
 
-SUCCESS = 0
-RETRY = 1
-CONTINUE = 2
-
 g_dict = {}
 # Global platform specific sfputil class instance
 platform_sfputil = None
@@ -612,7 +608,6 @@ class CmisManagerTask(threading.Thread):
         self.task_stopping_event = threading.Event()
         self.main_thread_stop_event = main_thread_stop_event
         self.port_dict = {k: {"asic_id": v} for k, v in port_mapping.logical_to_asic.items()}
-        self.port_mapping = copy.deepcopy(port_mapping)
         self.isPortInitDone = False
         self.isPortConfigDone = False
         self.skip_cmis_mgr = skip_cmis_mgr
@@ -1181,21 +1176,6 @@ class CmisManagerTask(threading.Thread):
             current_time = datetime.datetime.now()
 
         return expired_time <= current_time
-
-    def update_port_xcvr_status_tbl_decommission_state(self, port_mapping, lport, decommission_state):
-        """
-        Update decommission state for all logical ports in physical port
-        """
-        physical_port = port_mapping.get_logical_to_physical(lport)
-        logical_ports = port_mapping.get_physical_to_logical(int(physical_port[0]))
-        for port in logical_ports:
-            status_tbl = self.xcvr_table_helper.get_status_tbl(self.get_asic_id(port))
-            if status_tbl is None:
-                self.log_error("status_table is None while updating "
-                                       "sw DECOMMISSION state for lport {}".format(port))
-                return
-            fvs = swsscommon.FieldValuePairs([('decommission_state', decommission_state)])
-            status_tbl.set(port, fvs)
 
     def task_worker(self):
         is_fast_reboot = is_fast_reboot_enabled()

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1273,11 +1273,6 @@ class CmisManagerTask(threading.Thread):
                             self.port_dict[lport]['forced_tx_disabled'] = False
                             self.log_notice("{}: Tx laser is successfully turned OFF".format(lport))
 
-                        # Skip rest of the pre-init when decommission is required
-                        if not self.is_decomm_pending_for_lport(lport):
-                            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_DEINIT)
-                            continue
-
                         # Configure the target output power if ZR module
                         if api.is_coherent_module():
                            tx_power = self.port_dict[lport]['tx_power']

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -566,7 +566,7 @@ def get_decommission_state_from_state_db(lport, status_tbl):
     if found and 'decommission_state' in dict(xcvr_status_dict):
         return dict(xcvr_status_dict)['decommission_state']
     else:
-        return CMIS_STATE_UNKNOWN
+        return False
 
 # Delete port from SFP status table
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -114,6 +114,10 @@ VOLT_UNIT = 'Volts'
 POWER_UNIT = 'dBm'
 BIAS_UNIT = 'mA'
 
+SUCCESS = 0
+RETRY = 1
+CONTINUE = 2
+
 g_dict = {}
 # Global platform specific sfputil class instance
 platform_sfputil = None
@@ -826,11 +830,13 @@ class CmisManagerTask(threading.Thread):
 
         return media_lanes_mask
 
-    def is_appl_reconfigure_required(self, api, app_new, lport, status_tbl):
+    def is_appl_reconfigure_required(self, api, app_new, lport):
         """
-	Reset app code if non default app code needs to configured 
+        Reset app code if non default app code needs to configured
         """
+	status_tbl = self.xcvr_table_helper.get_status_tbl(self.get_asic_id(lport))
 	is_decomm = get_decommission_state_from_state_db(lport, status_tbl)
+
         if is_decomm == True:
             return False
 
@@ -900,6 +906,7 @@ class CmisManagerTask(threading.Thread):
         self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_INSERTED)
 	self.port_dict[lport]['cmis_decom_state'] =  CMIS_DECOM_DEINIT
         self.port_dict[lport]['cmis_retries'] = retries
+	self.port_dict[lport]['cmis_decom_expired'] = None
         self.port_dict[lport]['cmis_expired'] = None # No expiration
 
     def check_module_state(self, api, states):
@@ -1164,44 +1171,6 @@ class CmisManagerTask(threading.Thread):
             if key in ["PortConfigDone", "PortInitDone"]:
                 break
 
-    def decomission_all_datapaths(self, lport, api):
-	"""
-        Decomission all DPs using a sub CMIS FSM which will 
-	DEINIT -> APCONIFG -> DPINIT the DPs with non blocking advertised wait
-        """
-        now = datetime.datetime.now()
-        expired = self.port_dict[lport].get('cmis_decom_expired')
-        state = self.port_dict[lport].get('cmis_decom_state', CMIS_DECOM_DEINIT)
-
-        # De-init all datpaths
-        api.set_datapath_deinit((1 << api.NUM_CHANNELS) - 1)
-        if 'cmis_decom_state' not in self.port_dict[lport]:
-            self.port_dict[lport]['cmis_decom_state'] =  CMIS_DECOM_DEINIT
-
-        if state == CMIS_DECOM_DEINIT:
-            dpDeinitDuration = self.get_cmis_dp_deinit_duration_secs(api)
-            self.log_notice("{}: Decomission DpDeinit duration {} secs".format(lport, dpDeinitDuration))
-            self.port_dict[lport]['cmis_decom_expired'] = now + datetime.timedelta(dpDeinitDuration)
-            self.port_dict[lport]['cmis_decom_state'] =  CMIS_DECOM_APCONFIG
-            return "continue"
-        elif state == CMIS_DECOM_APCONFIG:
-            if not self.check_datapath_state(api, api.NUM_CHANNELS, ['DataPathDeactivated']):
-                if (expired is not None) and (expired <= now):
-                    self.log_notice("{}: timeout for 'DataPathDeactivated state' while decomission".format(lport))
-                    return "retry"
-                return "continue"
-            api.set_application(api.NUM_CHANNELS, 0, 0)
-            if not api.scs_apply_datapath_init(api.NUM_CHANNELS):
-                self.log_notice("{}: unable to set application and stage DP init while decomission".format(lport))
-                return "retry"
-            self.port_dict[lport]['cmis_decom_state'] =  CMIS_DECOM_DPINIT
-        elif state == CMIS_DECOM_DPINIT:
-            if (expired is not None) and (expired <= now):
-                if not self.check_config_error(api, api.NUM_CHANNELS, ['ConfigSuccess']):
-                    self.log_notice("{}: timeout for 'Config success' while decomission".format(lport))
-                    return "retry"
-        return "done"
-
     def update_cmis_state_expiration_time(self, lport, duration_seconds):
         """
         Set the CMIS expiration time for the given logical port
@@ -1213,6 +1182,18 @@ class CmisManagerTask(threading.Thread):
         self.port_dict[lport]['cmis_expired'] = datetime.datetime.now() + \
                                                 datetime.timedelta(seconds=duration_seconds) + \
                                                 datetime.timedelta(milliseconds=self.CMIS_EXPIRATION_BUFFER_MS)
+
+    def update_cmis_decom_state_expiration_time(self, lport, duration_seconds):
+        """
+        Set the CMIS decomission expiration time for the given logical port
+        in the port dictionary.
+        Args:
+            lport: Logical port name
+            duration_seconds: Duration in seconds for the expiration
+        """
+        self.port_dict[lport]['cmis_decom_expired'] = datetime.datetime.now() + \
+                                                      datetime.timedelta(seconds=duration_seconds) + \
+                                                      datetime.timedelta(milliseconds=self.CMIS_EXPIRATION_BUFFER_MS)
 
     def is_timer_expired(self, expired_time, current_time=None):
         """
@@ -1232,6 +1213,58 @@ class CmisManagerTask(threading.Thread):
             current_time = datetime.datetime.now()
 
         return expired_time <= current_time
+
+    def update_port_xcvr_status_tbl_decommission_state(self, port_mapping, lport, decommission_state):
+        """
+        Update decommission state for all logical ports in physical port
+        """
+        physical_port = port_mapping.get_logical_to_physical(lport)
+        logical_ports = port_mapping.get_physical_to_logical(int(physical_port[0]))
+        for port in logical_ports:
+            status_tbl = self.xcvr_table_helper.get_status_tbl(self.get_asic_id(port))
+            if status_tbl is None:
+                self.log_error("status_table is None while updating "
+                                       "sw DECOMMISSION state for lport {}".format(port))
+                return
+            fvs = swsscommon.FieldValuePairs([('decommission_state', decommission_state)])
+            status_tbl.set(port, fvs)
+
+    def decomission_all_datapaths(self, lport, api):
+        now = datetime.datetime.now()
+        expired = self.port_dict[lport].get('cmis_decom_expired')
+
+        # De-init all datpaths
+        api.set_datapath_deinit((1 << api.NUM_CHANNELS) - 1)
+        if 'cmis_decom_state' not in self.port_dict[lport]:
+            self.port_dict[lport]['cmis_decom_state'] =  CMIS_DECOM_DEINIT
+
+        state = self.port_dict[lport].get('cmis_decom_state')
+
+        if state == CMIS_DECOM_DEINIT:
+            dpDeinitDuration = self.get_cmis_dp_deinit_duration_secs(api)
+            self.log_notice("{}: Decomission DpDeinit duration {} secs".format(lport, dpDeinitDuration))
+            self.update_cmis_decom_state_expiration_time(lport, dpDeinitDuration)
+            self.port_dict[lport]['cmis_decom_state'] =  CMIS_DECOM_APCONFIG
+            return CONTINUE
+        elif state == CMIS_DECOM_APCONFIG:
+            if not self.check_datapath_state(api, api.NUM_CHANNELS, ['DataPathDeactivated']):
+                if self.is_timer_expired(expired):
+                    self.log_notice("{}: timeout for 'DataPathDeactivated state' while decomission".format(lport))
+                    return RETRY
+                return CONTINUE
+            api.set_application(api.NUM_CHANNELS, 0, 0)
+            if not api.scs_apply_datapath_init(api.NUM_CHANNELS):
+                self.log_notice("{}: unable to set application and stage DP init while decomission".format(lport))
+                return RETRY
+            self.port_dict[lport]['cmis_decom_state'] =  CMIS_DECOM_DPINIT
+            return CONTINUE
+        elif state == CMIS_DECOM_DPINIT:
+            if not self.check_config_error(api, api.NUM_CHANNELS, ['ConfigSuccess']):
+                if self.is_timer_expired(expired):
+                    self.log_notice("{}: timeout for 'Config success' while decomission".format(lport))
+                    return RETRY
+                return CONTINUE
+        return SUCCESS
 
     def task_worker(self):
         is_fast_reboot = is_fast_reboot_enabled()
@@ -1420,18 +1453,18 @@ class CmisManagerTask(threading.Thread):
                                  self.log_notice("{} Successfully configured Tx power = {}".format(lport, tx_power))
 
                         # Set all the DP lanes AppSel to unused(0) when non default app code needs to be configured
-			status_tbl = self.xcvr_table_helper.get_status_tbl(self.port_mapping.get_asic_id_for_logical_port(lport))
-                        if True == self.is_appl_reconfigure_required(api, appl, lport, status_tbl):
-                            self.log_notice("{}: Decommissioning all lanes/datapaths to default AppSel=0".format(lport))
+			if self.is_appl_reconfigure_required(api, appl, lport):
+                            self.log_notice(f"{lport}: Decommissioning all lanes/datapaths to default AppSel=0")
                             decom_state = self.decomission_all_datapaths(lport, api)
-                            if decom_state == "retry":
+                            if decom_state == RETRY:
                                 self.force_cmis_reinit(lport, retries + 1)
                                 continue
-                            elif decom_state == "continue":
+                            if decom_state == CONTINUE:
                                 continue
-                            else:
-                                self.log_notice("{}: Decomissioned physical port {}".format(lport, self.port_mapping.get_logical_to_physical(lport)))
-				self.update_port_xcvr_status_tbl_decommission_state(lport, "True")
+
+                            # SUCCESS
+                            self.log_notice(f"{lport}: Decommissioned physical port {self.port_mapping.get_logical_to_physical(lport)}")
+                            self.update_port_xcvr_status_tbl_decommission_state(self.port_mapping, lport, "True")
 
                         need_update = self.is_cmis_application_update_required(api, appl, host_lanes_mask)
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -834,8 +834,8 @@ class CmisManagerTask(threading.Thread):
         """
         Reset app code if non default app code needs to configured
         """
-	status_tbl = self.xcvr_table_helper.get_status_tbl(self.get_asic_id(lport))
-	is_decomm = get_decommission_state_from_state_db(lport, status_tbl)
+        status_tbl = self.xcvr_table_helper.get_status_tbl(self.get_asic_id(lport))
+        is_decomm = get_decommission_state_from_state_db(lport, status_tbl)
 
         if is_decomm == True:
             return False

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -687,7 +687,7 @@ class CmisManagerTask(threading.Thread):
 
         return media_lanes_mask
 
-     def is_decomm_pending_for_lport(self, lport):
+    def is_decomm_pending_for_lport(self, lport):
         """
         Get the decommission pending status for the given logical port.
         Args:
@@ -747,7 +747,7 @@ class CmisManagerTask(threading.Thread):
             if app_cur != 0 and app_cur != app_new:
                 return True
         return False
-    
+
     def is_cmis_application_update_required(self, api, app_new, host_lanes_mask):
         """
         Check if the CMIS application update is required
@@ -1185,11 +1185,11 @@ class CmisManagerTask(threading.Thread):
 
                 try:
                     # CMIS state transitions
-                    if state == CMIS_STATE_INSERTED: 
+                    if state == CMIS_STATE_INSERTED:
                         self.port_dict[lport]['appl'] = get_cmis_application_desired(api, host_lane_count, host_speed)
                         if self.port_dict[lport]['appl'] is None:
                             self.log_error("{}: no suitable app for the port appl {} host_lane_count {} "
-                                           "host_speed {}".format(lport, appl, host_lane_count, host_speed))
+                                            "host_speed {}".format(lport, appl, host_lane_count, host_speed))
                             self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
                             continue
                         appl = self.port_dict[lport]['appl']
@@ -1199,7 +1199,7 @@ class CmisManagerTask(threading.Thread):
                                                                         appl, host_lane_count, subport)
                         if self.port_dict[lport]['host_lanes_mask'] <= 0:
                             self.log_error("{}: Invalid lane mask received - host_lane_count {} subport {} "
-                                           "appl {}!".format(lport, host_lane_count, subport, appl))
+                                            "appl {}!".format(lport, host_lane_count, subport, appl))
                             self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
                             continue
                         host_lanes_mask = self.port_dict[lport]['host_lanes_mask']
@@ -1213,8 +1213,8 @@ class CmisManagerTask(threading.Thread):
                                                                         appl, lport, subport)
                         if self.port_dict[lport]['media_lanes_mask'] <= 0:
                             self.log_error("{}: Invalid media lane mask received - media_lane_count {} "
-                                           "media_lane_assignment_options {} subport {}"
-                                           " appl {}!".format(lport, media_lane_count, media_lane_assignment_options, subport, appl))
+                                            "media_lane_assignment_options {} subport {}"
+                                            " appl {}!".format(lport, media_lane_count, media_lane_assignment_options, subport, appl))
                             self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
                             continue
                         media_lanes_mask = self.port_dict[lport]['media_lanes_mask']

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1429,16 +1429,6 @@ class CmisManagerTask(threading.Thread):
 
                         self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_INIT)
                     elif state == CMIS_STATE_DP_INIT:
-                        if hasattr(api, 'get_cmis_rev'):
-                            # Check datapath init pending on module that supports CMIS 5.x
-                            # According to CMIS spec Table 6-3 and 6-4, result status gets reported in ConfigStatus after DPInitPending is set
-                            majorRev = int(api.get_cmis_rev().split('.')[0])
-                            if majorRev >= 5 and not self.check_datapath_init_pending(api, host_lanes_mask):
-                                if self.is_timer_expired(expired):
-                                    self.log_notice("{}: timeout for 'DPInitPending'".format(lport))
-                                    self.force_cmis_reinit(lport, retries + 1)
-                                continue
-
                         if not self.check_config_error(api, host_lanes_mask, ['ConfigSuccess']):
                             if self.is_timer_expired(expired):
                                 self.log_notice("{}: timeout for 'ConfigSuccess', current ConfigStatus: "
@@ -1452,6 +1442,14 @@ class CmisManagerTask(threading.Thread):
                             self.clear_decomm_pending(lport)
                             self.force_cmis_reinit(lport)
                             continue
+
+                        if hasattr(api, 'get_cmis_rev'):
+                            # Check datapath init pending on module that supports CMIS 5.x
+                            majorRev = int(api.get_cmis_rev().split('.')[0])
+                            if majorRev >= 5 and not self.check_datapath_init_pending(api, host_lanes_mask):
+                                self.log_notice("{}: datapath init not pending".format(lport))
+                                self.force_cmis_reinit(lport, retries + 1)
+                                continue
 
                         # Ensure the Datapath is NOT Activated unless the host Tx siganl is good.
                         # NOTE: Some CMIS compliant modules may have 'auto-squelch' feature where

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -725,7 +725,7 @@ class CmisManagerTask(threading.Thread):
         for logical_port, pdata in self.port_dict.items():
             if pdata.get('index') == self.port_dict[lport]['index']:
                 if pdata.get('is_decomm_pending', False) and \
-                    get_cmis_state_from_state_db(logical_port, self.xcvr_table_helper.get_status_tbl(self.get_asic_id(logical_port))) == CMIS_STATE_FAILED:
+                    get_cmis_state_from_state_db(logical_port, self.xcvr_table_helper.get_status_sw_tbl(self.get_asic_id(logical_port))) == CMIS_STATE_FAILED:
                     return True
         return False
 
@@ -1219,7 +1219,7 @@ class CmisManagerTask(threading.Thread):
                             continue
                         media_lanes_mask = self.port_dict[lport]['media_lanes_mask']
                         self.log_notice("{}: Setting media_lanemask=0x{:x}".format(lport, media_lanes_mask))
-    
+
                         if (not self.is_decomm_pending_for_pport(lport) and self.is_decommission_required(api, appl)):
                             self.port_dict[lport]['is_decomm_pending'] = True
                             self.log_notice(f"{lport}: DECOMMISSION: setting is_decomm_pending=True")
@@ -1370,13 +1370,12 @@ class CmisManagerTask(threading.Thread):
                                 # Apply module SI settings if applicable
                                 lane_speed = int(speed/1000)//host_lane_count
                                 optics_si_dict = optics_si_parser.fetch_optics_si_setting(pport, lane_speed, sfp)
-                            
                                 self.log_debug("Read SI parameters for port {} from optics_si_settings.json vendor file:".format(lport))
                                 for key, sub_dict in optics_si_dict.items():
                                     self.log_debug("{}".format(key))
                                     for sub_key, value in sub_dict.items():
                                         self.log_debug("{}: {}".format(sub_key, str(value)))
-                            
+
                                 if optics_si_dict:
                                     self.log_notice("{}: Apply Optics SI found for Vendor: {}  PN: {} lane speed: {}G".
                                                     format(lport, api.get_manufacturer(), api.get_model(), lane_speed))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -741,7 +741,7 @@ class CmisManagerTask(threading.Thread):
         """
         return self.port_dict[lport]['index'] in self.decomm_pending_dict
 
-    def is_decomm_failed_for_pport(self, lport):
+    def is_decomm_failed(self, lport):
         """
         Get the decommission failed status for the physical port the given logical port belongs to.
 
@@ -1272,7 +1272,7 @@ class CmisManagerTask(threading.Thread):
                             self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_DEINIT)
                             continue
                         elif self.is_decomm_pending(lport):
-                            if self.is_decomm_failed_for_pport(lport):
+                            if self.is_decomm_failed(lport):
                                 self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
                                 decomm_status_str = "failed"
                             else:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Fix for : https://github.com/sonic-net/sonic-buildimage/issues/21603

Add a logic to decommission data path by setting Appl Sel 0 using the existing CMIS SM. 
When there are multiple subports/logical ports under the same physical port:
1. For lead logical port of decommission (whoever is the first one calling is_decomm_required()==True), it will conduct the actual decommission state machine.
2. For non-lead logical port(s), it will wait until the decommission state machine is done by the lead logical port.
The non-lead port will remain in the CMIS inserted state until the lead port completes the decommissioning or it transitions to Failed state.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Decommission lanes of the port which doesn't has required AppCode set to default

```
2025 Apr 30 23:16:01.293831 sonic NOTICE pmon#xcvrd[27]: CMIS: Ethernet268: Decommissioned Successfully physical port [33]
2025 Apr 30 23:16:01.293899 sonic INFO pmon#supervisord: xcvrd NOTICE:xcvrd:CMIS: Ethernet268: Decommissioned Successfully physical port [33]
2025 Apr 30 23:16:01.451007 sonic NOTICE pmon#xcvrd[27]: CMIS: Ethernet280: Decommissioned Successfully physical port [35]
2025 Apr 30 23:16:01.451088 sonic INFO pmon#supervisord: xcvrd NOTICE:xcvrd:CMIS: Ethernet280: Decommissioned Successfully physical port [35]
2025 Apr 30 23:16:01.492465 sonic NOTICE pmon#xcvrd[27]: CMIS: Ethernet244: Decommissioned Successfully physical port [30]
2025 Apr 30 23:16:01.492547 sonic INFO pmon#supervisord: xcvrd NOTICE:xcvrd:CMIS: Ethernet244: Decommissioned Successfully physical port [30]
2025 Apr 30 23:16:01.563489 sonic NOTICE pmon#xcvrd[27]: CMIS: Ethernet264: Decommissioned Successfully physical port [33]
2025 Apr 30 23:16:01.563636 sonic INFO pmon#supervisord: xcvrd NOTICE:xcvrd:CMIS: Ethernet264: Decommissioned Successfully physical port [33]
2025 Apr 30 23:16:01.660994 sonic NOTICE pmon#xcvrd[27]: CMIS: Ethernet164: Decommissioned Successfully physical port [20]
2025 Apr 30 23:16:01.661135 sonic INFO pmon#supervisord: xcvrd NOTICE:xcvrd:CMIS: Ethernet164: Decommissioned Successfully physical port [20]
2025 Apr 30 23:16:15.646395 sonic NOTICE pmon#xcvrd[27]: CMIS: Ethernet284: Decommissioned Successfully physical port [35]
2025 Apr 30 23:16:15.646519 sonic INFO pmon#supervisord: xcvrd NOTICE:xcvrd:CMIS: Ethernet284: Decommissioned Successfully physical port [35]
2025 Apr 30 23:16:15.847901 sonic NOTICE pmon#xcvrd[27]: CMIS: Ethernet324: Decommissioned Successfully physical port [40]
2025 Apr 30 23:16:15.848038 sonic INFO pmon#supervisord: xcvrd NOTICE:xcvrd:CMIS: Ethernet324: Decommissioned Successfully physical port [40]
2025 Apr 30 23:16:16.022971 sonic NOTICE pmon#xcvrd[27]: CMIS: Ethernet240: Decommissioned Successfully physical port [30]
2025 Apr 30 23:16:16.023098 sonic INFO pmon#supervisord: xcvrd NOTICE:xcvrd:CMIS: Ethernet240: Decommissioned Successfully physical port [30]
2025 Apr 30 23:16:16.331959 sonic NOTICE pmon#xcvrd[27]: CMIS: Ethernet160: Decommissioned Successfully physical port [20]
2025 Apr 30 23:16:16.332114 sonic INFO pmon#supervisord: xcvrd NOTICE:xcvrd:CMIS: Ethernet160: Decommissioned Successfully physical port [20]
2025 Apr 30 23:16:16.403968 sonic NOTICE pmon#xcvrd[27]: CMIS: Ethernet320: Decommissioned Successfully physical port [40]
2025 Apr 30 23:16:16.404111 sonic INFO pmon#supervisord: xcvrd NOTICE:xcvrd:CMIS: Ethernet320: Decommissioned Successfully physical port [40]
2025 Apr 30 23:16:36.476933 sonic NOTICE pmon#xcvrd[27]: CMIS: Ethernet268: Decommissioned Successfully physical port [33]
2025 Apr 30 23:16:36.476933 sonic INFO pmon#supervisord: xcvrd NOTICE:xcvrd:CMIS: Ethernet268: Decommissioned Successfully physical port [33]
```


#### Additional Information (Optional)
