### PR TITLE
Support for syslog alert on temperature change of ZR optics

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -801,7 +801,7 @@ class TestXcvrdScript(object):
         }
         temperature_status={}
 
-        task.update_transceiver_error_status(logical_port_name, port_mapping,dom_info_cache, dom_th_info_cache, temperature_status)
+        task.update_transceiver_temperature_status(logical_port_name, port_mapping,dom_info_cache, dom_th_info_cache, temperature_status)
 
         # Assert that status updated and logger was called with expected message
         assert temperature_status[0] == 1  # TEMP_HIGH_ALARM
@@ -821,7 +821,7 @@ class TestXcvrdScript(object):
         
         temperature_status.clear()
 
-        task.update_transceiver_error_status(logical_port_name, port_mapping,dom_info_cache, dom_th_info_cache, temperature_status)
+        task.update_transceiver_temperature_status(logical_port_name, port_mapping,dom_info_cache, dom_th_info_cache, temperature_status)
 
         # Assert that status updated and logger was called with expected message
         assert temperature_status[0] == 2  # LOW_HIGH_ALARM


### PR DESCRIPTION
#### Description
Provide support for syslog alert to notify user on change of temperature of ZR Optics

#### Why is this change required
No alert shown for temperature of Optics when crosses the threshold

#### How to verify it
syslog updated with alert message with current temperature value which crossed the threshold for optics

2025 Apr 23 09:56:10.997889 qual-7060DX5-64S NOTICE pmon#xcvrd: 80: temperature INFO 75.0 to -5.0
2025 Apr 23 09:56:10.997889 qual-7060DX5-64S NOTICE pmon#xcvrd: Ethernet112: temperature high alarm
2025 Apr 23 09:56:12.044945 qual-7060DX5-64S NOTICE pmon#xcvrd: 80: temperature INFO 15.0 to 0.0
2025 Apr 23 09:56:12.044945 qual-7060DX5-64S NOTICE pmon#xcvrd: Ethernet240: temperature high alarm
2025 Apr 23 09:56:12.405351 qual-7060DX5-64S NOTICE pmon#xcvrd: 80: temperature INFO 75.0 to 0.0
2025 Apr 23 09:56:12.405351 qual-7060DX5-64S NOTICE pmon#xcvrd: Ethernet184: temperature high alarm
2025 Apr 23 09:56:12.865747 qual-7060DX5-64S NOTICE pmon#xcvrd: 80: temperature INFO 75.0 to 0.0
2025 Apr 23 09:56:12.865747 qual-7060DX5-64S NOTICE pmon#xcvrd: Ethernet248: temperature high alarm
2025 Apr 23 09:56:13.223961 qual-7060DX5-64S NOTICE pmon#xcvrd: 80: temperature INFO 75.0 to 0.0
2025 Apr 23 09:56:13.223961 qual-7060DX5-64S NOTICE pmon#xcvrd: Ethernet224: temperature high alarm
2025 Apr 23 09:56:13.543594 qual-7060DX5-64S NOTICE pmon#xcvrd: 80: temperature INFO 80.0 to -10.0
2025 Apr 23 09:56:13.543594 qual-7060DX5-64S NOTICE pmon#xcvrd: Ethernet232: temperature high warning
2025 Apr 23 09:56:13.861593 qual-7060DX5-64S NOTICE pmon#xcvrd: 80: temperature INFO 75.0 to -5.0
2025 Apr 23 09:56:13.861593 qual-7060DX5-64S NOTICE pmon#xcvrd: Ethernet168: temperature high alarm
2025 Apr 23 09:56:14.172986 qual-7060DX5-64S NOTICE pmon#xcvrd: 80: temperature INFO 75.0 to -5.0