### PR TITLE
[xcvrd] Optimize module initialization performance

### DIFF
--- a/sonic-xcvrd/tests/mock_swsscommon.py
+++ b/sonic-xcvrd/tests/mock_swsscommon.py
@@ -36,6 +36,13 @@ class Table:
         if key in self.mock_dict:
             return True, self.mock_dict[key]
         return False, None
+    
+    def hget(self, key, field):
+        if key in self.mock_dict:
+            for fv in self.mock_dict[key]:
+                if fv[0] == field:
+                    return True, fv[1]
+        return False, None
 
     def get_size(self):
         return (len(self.mock_dict))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
1. Use hget instead of hgetall to gain better performance
2. Optimize `SfpStateUpdateTask.init`:
  - Use cache in this function for different logical ports with the same physical module. 
  - Handles transceiver info table and media settings before any other table.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Improve module initialization performance. Due my test:
1. `hget` is 7 times faster than `hgetall` when getting cmis module state
2. Before optimizing `SfpStateUpdateTask.init`, the last module takes about 5 minutes to finish `notify_media_settings` call; after the optimization, the last module takes about 1 minutes to finish notify_media_settings` call.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Manual test

#### Additional Information (Optional)
