### PR TITLE
Add Robust Exception Handling to pcied Daemon for Improved Stability

### DIFF
--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -57,6 +57,9 @@ def load_platform_pcieutil():
             _platform_pcieutil = PcieUtil(platform_path)
         except ImportError as e:
             log.log_error("Failed to load default PcieUtil module. Error : {}".format(str(e)), True)
+    if _platform_pcieutil is None:
+        log.log_critical("Failed to load any PCIe utility module. Exiting...", True)
+        raise RuntimeError("Unable to load PCIe utility module.")
     return _platform_pcieutil
 
 def read_id_file(device_name):
@@ -93,72 +96,78 @@ class DaemonPcied(daemon_base.DaemonBase):
             sys.exit(PCIEUTIL_LOAD_ERROR)
 
         # Connect to STATE_DB and create pcie device table
-        self.state_db = daemon_base.db_connect("STATE_DB")
-        self.device_table = swsscommon.Table(self.state_db, PCIE_DEVICE_TABLE_NAME)
-        self.status_table = swsscommon.Table(self.state_db, PCIE_STATUS_TABLE_NAME)
-        self.detach_info = swsscommon.Table(self.state_db, PCIE_DETACH_INFO_TABLE)
+        try:
+            self.state_db = daemon_base.db_connect("STATE_DB")
+            self.device_table = swsscommon.Table(self.state_db, PCIE_DEVICE_TABLE_NAME)
+            self.status_table = swsscommon.Table(self.state_db, PCIE_STATUS_TABLE_NAME)
+            self.detach_info = swsscommon.Table(self.state_db, PCIE_DETACH_INFO_TABLE)
+        except Exception as e:
+            log.log_error("Failed to connect to STATE_DB or create table. Error: {}".format(str(e)), True)
+            sys.exit(PCIEUTIL_CONF_FILE_ERROR)
 
     def __del__(self):
-        if self.device_table:
-            table_keys = self.device_table.getKeys()
-            for tk in table_keys:
-                self.device_table._del(tk)
-        if self.status_table:
-            stable_keys = self.status_table.getKeys()
-            for stk in stable_keys:
-                self.status_table._del(stk)
-        if self.detach_info:
-            detach_info_keys = self.detach_info.getKeys()
-            for dk in detach_info_keys:
-                self.detach_info._del(dk)
+        try:
+            if self.device_table:
+                table_keys = self.device_table.getKeys()
+                for tk in table_keys:
+                    self.device_table._del(tk)
+            if self.status_table:
+                stable_keys = self.status_table.getKeys()
+                for stk in stable_keys:
+                    self.status_table._del(stk)
+            if self.detach_info:
+                detach_info_keys = self.detach_info.getKeys()
+                for dk in detach_info_keys:
+                    self.detach_info._del(dk)
+        except Exception as e:
+            log.log_warning("Exception during cleanup: {}".format(str(e)), True)
 
     # load aer-fields into statedb
     def update_aer_to_statedb(self):
         if self.aer_stats is None:
-            self.log_debug("PCIe device {} has no AER Stats".format(device_name))
+            self.log_debug("PCIe device {} has no AER Stats".format(self.device_name))
             return
 
-        aer_fields = {}
-
-        for key, fv in self.aer_stats.items():
-            for field, value in fv.items():
-                key_field = "{}|{}".format(key,field)
-                aer_fields[key_field] = value
-
-        if aer_fields:
-            formatted_fields = swsscommon.FieldValuePairs(list(aer_fields.items()))
-            self.device_table.set(self.device_name, formatted_fields)
-        else:
-            self.log_debug("PCIe device {} has no AER attriutes".format(self.device_name))
+        try:
+            aer_fields = {
+                f"{key}|{field}": value
+                for key, fv in self.aer_stats.items()
+                for field, value in fv.items()
+            }
+            if aer_fields:
+                self.device_table.set(self.device_name, swsscommon.FieldValuePairs(list(aer_fields.items())))
+            else:
+                self.log_debug("PCIe device {} has no AER attributes".format(self.device_name))
+        except Exception as e:
+            self.log_error("Exception while updating AER attributes to STATE_DB for {}: {}".format(self.device_name, str(e)))
 
 
     # Check the PCIe AER Stats
     def check_n_update_pcie_aer_stats(self, Bus, Dev, Fn):
-        self.device_name = "%02x:%02x.%d" % (Bus, Dev, Fn)
-
-        Id = read_id_file(self.device_name)
-
-        self.aer_stats = {}
-        if Id is not None:
-            fvp = swsscommon.FieldValuePairs([('id', Id)])
-            self.device_table.set(self.device_name, fvp)
-            self.aer_stats = platform_pcieutil.get_pcie_aer_stats(bus=Bus, dev=Dev, func=Fn)
-            self.update_aer_to_statedb()
+        try:
+            self.device_name = "%02x:%02x.%d" % (Bus, Dev, Fn)
+            Id = read_id_file(self.device_name)
+            self.aer_stats = {}
+            if Id is not None:
+                self.device_table.set(self.device_name, swsscommon.FieldValuePairs([('id', Id)]))
+                self.aer_stats = platform_pcieutil.get_pcie_aer_stats(bus=Bus, dev=Dev, func=Fn)
+                self.update_aer_to_statedb()
+        except Exception as e:
+            self.log_error("Exception while checking AER attributes for {}: {}".format(self.device_name, str(e)))
 
 
     # Update the PCIe devices status to DB
     def update_pcie_devices_status_db(self, err):
-        if err:
-            pcie_status = "FAILED"
-            self.log_error("PCIe device status check : {}".format(pcie_status))
-        else:
-            pcie_status = "PASSED"
-            self.log_info("PCIe device status check : {}".format(pcie_status))
-        fvs = swsscommon.FieldValuePairs([
-            ('status', pcie_status)
-        ])
-
-        self.status_table.set("status", fvs)
+        try:
+            if err:
+                pcie_status = "FAILED"
+                self.log_error("PCIe device status check : {}".format(pcie_status))
+            else:
+                pcie_status = "PASSED"
+                self.log_info("PCIe device status check : {}".format(pcie_status))
+            self.status_table.set("status", swsscommon.FieldValuePairs([('status', pcie_status)]))
+        except Exception as e:
+            self.log_error("Exception while updating PCIe device status to STATE_DB: {}".format(str(e)))
 
     # Check if any PCI interface is in detaching mode by querying the state_db
     def is_dpu_in_detaching_mode(self, pcie_dev):
@@ -229,8 +238,12 @@ class DaemonPcied(daemon_base.DaemonBase):
 
     # Main daemon logic
     def run(self):
-        if self.stop_event.wait(self.timeout):
-            # We received a fatal signal
+        try:
+            if self.stop_event.wait(self.timeout):
+                # We received a fatal signal
+                return False
+        except Exception as e:
+            self.log_error("Exception occurred during stop_event wait: {}".format(str(e)))
             return False
 
         self.check_pcie_devices()

--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -102,7 +102,7 @@ class DaemonPcied(daemon_base.DaemonBase):
             self.status_table = swsscommon.Table(self.state_db, PCIE_STATUS_TABLE_NAME)
             self.detach_info = swsscommon.Table(self.state_db, PCIE_DETACH_INFO_TABLE)
         except Exception as e:
-            log.log_error("Failed to connect to STATE_DB or create table. Error: {}".format(str(e)), True)
+            log.log_critical("Failed to connect to STATE_DB or create table. Error: {}".format(str(e)), True)
             sys.exit(PCIEUTIL_CONF_FILE_ERROR)
 
     def __del__(self):
@@ -158,13 +158,14 @@ class DaemonPcied(daemon_base.DaemonBase):
 
     # Update the PCIe devices status to DB
     def update_pcie_devices_status_db(self, err):
+        if err:
+            pcie_status = "FAILED"
+            self.log_error("PCIe device status check : {}".format(pcie_status))
+        else:
+            pcie_status = "PASSED"
+            self.log_info("PCIe device status check : {}".format(pcie_status))
+
         try:
-            if err:
-                pcie_status = "FAILED"
-                self.log_error("PCIe device status check : {}".format(pcie_status))
-            else:
-                pcie_status = "PASSED"
-                self.log_info("PCIe device status check : {}".format(pcie_status))
             self.status_table.set("status", swsscommon.FieldValuePairs([('status', pcie_status)]))
         except Exception as e:
             self.log_error("Exception while updating PCIe device status to STATE_DB: {}".format(str(e)))

--- a/sonic-pcied/tests/mocked_libs/sonic_platform/pcie.py
+++ b/sonic-pcied/tests/mocked_libs/sonic_platform/pcie.py
@@ -2,7 +2,7 @@
     Mock implementation of sonic_platform package for unit testing
 """
 
-from sonic_platform_base.pcie_base import PcieBase
+from sonic_platform_base.sonic_pcie.pcie_base import PcieBase
 
 
 class Pcie(PcieBase):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
This PR introduces comprehensive exception handling throughout the pcied daemon script to enhance reliability and ensure graceful handling of runtime errors. Key improvements include:

- Try-except blocks added around critical operations
- Fix variables during logging.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
These changes make the daemon more resilient during unexpected conditions for REDIS DB disconnection or returning an exception.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
- Replace the daemon in a test-bed
- Inject redis-server crash
- Observe any crashes occurred for PCIe daemon.

- With the changes, only observe following exception but no crashes in PCIe daemon:


2025 Jun 10 22:26:51.529324 XXX ERR pmon#pcied[4197]: Exception while checking AER attributes for ff:13.2: RedisError: Failed to redisGetReply in RedisPipeline::pop, err=3: errstr=Server closed the connection
2025 Jun 10 22:26:51.536091 XXX ERR pmon#pcied[4197]: Exception while checking AER attributes for ff:1f.0: RedisError: Failed to redisGetReply in RedisPipeline::pop, err=3: errstr=Server closed the connection
2025 Jun 10 22:26:51.536280 XXX ERR pmon#pcied[4197]: Exception while checking AER attributes for ff:1f.2: RedisError: Failed to redisGetReply in RedisPipeline::pop, err=3: errstr=Server closed the connection
2025 Jun 10 22:26:51.536471 XXX ERR pmon#pcied[4197]: Exception while updating PCIe device status to STATE_DB: RedisError: Failed to redisGetReply in RedisPipeline::pop, err=3: errstr=Server closed the connection


#### Additional Information (Optional)
