### PR TITLE
[Smartswitch][Chassisd] Fix for initialization DPU admin state post startup and pre shutdown

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -1306,7 +1306,15 @@ class ChassisdDaemon(daemon_base.DaemonBase):
             self.log_warning("Caught unhandled signal '{}' - ignoring...".format(SIGNALS_TO_NAMES_DICT[sig]))
 
     def submit_dpu_callback(self, module_index, admin_state):
+        if admin_state == MODULE_ADMIN_DOWN:
+            # This is only valid on platforms which have pci_detach and sensord changes required. If it is not implemented,
+            # there are no actions taken during this function execution.
+            try_get(self.module_updater.chassis.get_module(module_index).module_pre_shutdown, default=False)
         try_get(self.module_updater.chassis.get_module(module_index).set_admin_state, admin_state, default=False)
+        if admin_state == MODULE_ADMIN_UP:
+            # This is only valid on platforms which have pci_rescan sensord changes required. If it is not implemented,
+            # there are no actions taken during this function execution.
+            try_get(self.module_updater.chassis.get_module(module_index).module_post_startup, default=False)
         pass
 
     def set_initial_dpu_admin_state(self):

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -1775,7 +1775,6 @@ def test_smartswitch_time_format():
         AssertionError("Date is not set!")
     assert is_valid_date(date_value)
 
-
 def test_smartswitch_moduleupdater_midplane_state_change():
     """Test that when midplane goes down, control plane and data plane states are set to down"""
     chassis = MockSmartSwitchChassis()
@@ -1840,7 +1839,7 @@ def test_smartswitch_moduleupdater_midplane_state_change():
 
         assert is_valid_date(chassis_state_db[key]["dpu_midplane_link_time"])
 
-        def test_submit_dpu_callback():
+def test_submit_dpu_callback():
     """Test that submit_dpu_callback calls the right functions in the correct order"""
     chassis = MockSmartSwitchChassis()
 

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -1807,9 +1807,7 @@ def test_submit_dpu_callback():
         mock_pre_shutdown.assert_called_once()
         mock_set_admin_state.assert_called_once_with(MODULE_ADMIN_DOWN)
         mock_post_startup.assert_not_called()
-        # Verify call order: pre_shutdown should be called before set_admin_state
-        calls = [call[0][0] for call in [mock_pre_shutdown.call_args, mock_set_admin_state.call_args]]
-        assert len(calls) == 2
+
 
     # Reset mocks for next test
     with patch.object(module, 'module_pre_shutdown') as mock_pre_shutdown, \
@@ -1823,6 +1821,3 @@ def test_submit_dpu_callback():
         mock_set_admin_state.assert_called_once_with(MODULE_ADMIN_UP)
         mock_post_startup.assert_called_once()
 
-        # Verify call order: set_admin_state should be called before post_startup
-        calls = [call[0][0] for call in [mock_set_admin_state.call_args, mock_post_startup.call_args]]
-        assert len(calls) == 2

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -1774,3 +1774,55 @@ def test_smartswitch_time_format():
     if not date_value:
         AssertionError("Date is not set!")
     assert is_valid_date(date_value)
+
+def test_submit_dpu_callback():
+    """Test that submit_dpu_callback calls the right functions in the correct order"""
+    chassis = MockSmartSwitchChassis()
+
+    # DPU0 details
+    index = 0
+    name = "DPU0"
+    desc = "DPU Module 0"
+    slot = 0
+    serial = "DPU0-0000"
+    module_type = ModuleBase.MODULE_TYPE_DPU
+    module = MockModule(index, name, desc, module_type, slot, serial)
+
+    # Set initial state
+    status = ModuleBase.MODULE_STATUS_PRESENT
+    module.set_oper_status(status)
+    chassis.module_list.append(module)
+
+    # Create module updater and daemon
+    module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
+    daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER, chassis)
+    daemon_chassisd.module_updater = module_updater
+
+    # Test MODULE_ADMIN_DOWN scenario
+    with patch.object(module, 'module_pre_shutdown') as mock_pre_shutdown, \
+         patch.object(module, 'set_admin_state') as mock_set_admin_state, \
+         patch.object(module, 'module_post_startup') as mock_post_startup:
+        daemon_chassisd.submit_dpu_callback(index, MODULE_ADMIN_DOWN)
+        # Verify correct functions are called for admin down
+        mock_pre_shutdown.assert_called_once()
+        mock_set_admin_state.assert_called_once_with(MODULE_ADMIN_DOWN)
+        mock_post_startup.assert_not_called()
+        # Verify call order: pre_shutdown should be called before set_admin_state
+        calls = [call[0][0] for call in [mock_pre_shutdown.call_args, mock_set_admin_state.call_args]]
+        assert len(calls) == 2
+
+    # Reset mocks for next test
+    with patch.object(module, 'module_pre_shutdown') as mock_pre_shutdown, \
+         patch.object(module, 'set_admin_state') as mock_set_admin_state, \
+         patch.object(module, 'module_post_startup') as mock_post_startup:
+
+        daemon_chassisd.submit_dpu_callback(index, MODULE_ADMIN_UP)
+
+        # Verify correct functions are called for admin up
+        mock_pre_shutdown.assert_not_called()
+        mock_set_admin_state.assert_called_once_with(MODULE_ADMIN_UP)
+        mock_post_startup.assert_called_once()
+
+        # Verify call order: set_admin_state should be called before post_startup
+        calls = [call[0][0] for call in [mock_set_admin_state.call_args, mock_post_startup.call_args]]
+        assert len(calls) == 2


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

This change is so that the pre shutdown and post startup are handled even during the dark mode initialization for the DPUs.
Initial DPU state changes are handled by submit_dpu_callback so we need the pre/post execution for initialization


#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
During initialization, the admin state change for the DPU is handled by `submit_dpu_callback` function, so we need the `module_pre_shutdown` and `module_post_startup` calls in `submit_dpu_callback` as well. 

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Unit test and manual tests 

#### Additional Information (Optional)
