### PR TITLE
xcvrd: sff_mgr missing log_info leading to crashes

### DIFF
--- a/sonic-xcvrd/xcvrd/sff_mgr.py
+++ b/sonic-xcvrd/xcvrd/sff_mgr.py
@@ -25,6 +25,9 @@ class SffLoggerForPortUpdateEvent:
     def __init__(self, logger):
         self.logger = logger
 
+    def log_info(self, message):
+        self.logger.log_info("{}{}".format(self.SFF_LOGGER_PREFIX, message))
+
     def log_notice(self, message):
         self.logger.log_notice("{}{}".format(self.SFF_LOGGER_PREFIX, message))
 


### PR DESCRIPTION
#### Description
The logger object may be different based on subsystem but not all have the same log callbacks leading to errors in SffLogger:
```
2025 Jun 26 10:25:14.640757 dvc140 ERR pmon#xcvrd[120]:     self.logger.log_info("subscribing to port_tbl {} - {} DB of namespace {} ".format(
2025 Jun 26 10:25:14.640793 dvc140 ERR pmon#xcvrd[120]:     ^^^^^^^^^^^^^^^^^^^^
2025 Jun 26 10:25:14.640793 dvc140 ERR pmon#xcvrd[120]: AttributeError: 'SffLoggerForPortUpdateEvent' object has no attribute 'log_info'
```

This patch adds log_info to Sff.
#### Motivation and Context

Fix crash after #567 was merged

#### How Has This Been Tested?

Reproduced on physical hardware

#### Additional Information (Optional)
