### PR TITLE
Fix for 22430 - SmartSwitch - Reboot cause for DPUs not updated on complete system reboot

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -829,7 +829,6 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
                     is_reboot = False
                     if current_cause and stored_cause and stored_time_str:
                         try:
-                            from datetime import datetime, timezone
                             stored_dt = datetime.strptime(stored_time_str, "%Y_%m_%d_%H_%M_%S").replace(tzinfo=timezone.utc)
                             now = datetime.now(timezone.utc)
                             delta_sec = (now - stored_dt).total_seconds()

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -80,6 +80,7 @@ CHASSIS_MODULE_REBOOT_TIMESTAMP_FIELD = 'timestamp'
 CHASSIS_MODULE_REBOOT_REBOOT_FIELD = 'reboot'
 DEFAULT_LINECARD_REBOOT_TIMEOUT = 180
 DEFAULT_DPU_REBOOT_TIMEOUT = 360
+MAX_DPU_REBOOT_DURATION = 800
 PLATFORM_ENV_CONF_FILE = "/usr/share/sonic/platform/platform_env.conf"
 PLATFORM_JSON_FILE = "/usr/share/sonic/platform/platform.json"
 
@@ -760,6 +761,25 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
         else:
             return 'empty'
 
+    def retrieve_dpu_reboot_info(self, module):
+        """
+        Retrieve the most recent reboot cause and time from previous-reboot-cause.json.
+        Returns (cause_string, time_string), or (None, None) if unavailable.
+        """
+        try:
+            path = os.path.join(MODULE_REBOOT_CAUSE_DIR, module.lower(), "previous-reboot-cause.json")
+            if os.path.exists(path):
+                with open(path, 'r') as f:
+                    data = json.load(f)
+                    cause = data.get("cause")
+                    time_str = data.get("name")  # Format: "YYYY_MM_DD_HH_MM_SS"
+                    return cause, time_str
+            else:
+                self.log_debug(f"{module}: previous-reboot-cause.json not found")
+        except Exception as e:
+            self.log_error(f"{module}: Failed to read previous-reboot-cause.json: {e}")
+        return None, None
+
     def module_db_update(self):
         for module_index in range(0, self.num_modules):
             module_info_dict = self._get_module_info(module_index)
@@ -784,20 +804,45 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
                 current_status = module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
                 # Operational status transitioning to offline
-                if prev_status != str(ModuleBase.MODULE_STATUS_OFFLINE) and current_status == str(ModuleBase.MODULE_STATUS_OFFLINE):
+                if prev_status != "Empty" and prev_status != str(ModuleBase.MODULE_STATUS_OFFLINE) and current_status == str(ModuleBase.MODULE_STATUS_OFFLINE):
                     self.log_notice("{} operational status transitioning to offline".format(key))
 
                     # Persist dpu down time
                     self.persist_dpu_reboot_time(key)
-
-                elif prev_status == str(ModuleBase.MODULE_STATUS_OFFLINE) and current_status != str(ModuleBase.MODULE_STATUS_OFFLINE):
-                    self.log_notice("{} operational status transitioning to online".format(key))
+                    # persist reboot cause
                     reboot_cause = try_get(self.chassis.get_module(module_index).get_reboot_cause)
+                    self.persist_dpu_reboot_cause(reboot_cause, key)
+                    # publish reboot cause to db
+                    self.update_dpu_reboot_cause_to_db(key)
 
-                    if not self.retrieve_dpu_reboot_time(key) is None or self._is_first_boot(key):
-                        # persist reboot cause
+                elif (prev_status == "Empty" or prev_status == str(ModuleBase.MODULE_STATUS_OFFLINE)) and current_status != str(ModuleBase.MODULE_STATUS_OFFLINE):
+                    self.log_notice(f"{key} operational status transitioning to online")
+
+                    reboot_cause = try_get(self.chassis.get_module(module_index).get_reboot_cause)
+                    if isinstance(reboot_cause, (tuple, list)):
+                        current_cause = reboot_cause[0]
+                    else:
+                        current_cause = reboot_cause
+
+                    stored_cause, stored_time_str = self.retrieve_dpu_reboot_info(key)
+
+                    is_reboot = False
+                    if current_cause and stored_cause and stored_time_str:
+                        try:
+                            from datetime import datetime, timezone
+                            stored_dt = datetime.strptime(stored_time_str, "%Y_%m_%d_%H_%M_%S").replace(tzinfo=timezone.utc)
+                            now = datetime.now(timezone.utc)
+                            delta_sec = (now - stored_dt).total_seconds()
+
+                            if current_cause == stored_cause and delta_sec <  MAX_DPU_REBOOT_DURATION:
+                                self.log_info(f"{key}: is_reboot=True — same reboot cause within {int(delta_sec)}s")
+                                is_reboot = True
+                        except Exception as e:
+                            self.log_error(f"{key}: Reboot cause/time comparison failed: {e}")
+
+                    if not is_reboot and (stored_time_str is not None or self._is_first_boot(key)):
+                        # persist reboot cause and publish to db
                         self.persist_dpu_reboot_cause(reboot_cause, key)
-                        # publish reboot cause to db
                         self.update_dpu_reboot_cause_to_db(key)
 
     def _get_module_info(self, module_index):

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -804,7 +804,7 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
                 current_status = module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
 
                 # Operational status transitioning to offline
-                if prev_status != "Empty" and prev_status != str(ModuleBase.MODULE_STATUS_OFFLINE) and current_status == str(ModuleBase.MODULE_STATUS_OFFLINE):
+                if prev_status != ModuleBase.MODULE_STATUS_EMPTY and prev_status != str(ModuleBase.MODULE_STATUS_OFFLINE) and current_status == str(ModuleBase.MODULE_STATUS_OFFLINE):
                     self.log_notice("{} operational status transitioning to offline".format(key))
 
                     # Persist dpu down time
@@ -815,7 +815,7 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
                     # publish reboot cause to db
                     self.update_dpu_reboot_cause_to_db(key)
 
-                elif (prev_status == "Empty" or prev_status == str(ModuleBase.MODULE_STATUS_OFFLINE)) and current_status != str(ModuleBase.MODULE_STATUS_OFFLINE):
+                elif (prev_status == ModuleBase.MODULE_STATUS_EMPTY or prev_status == str(ModuleBase.MODULE_STATUS_OFFLINE)) and current_status != str(ModuleBase.MODULE_STATUS_OFFLINE):
                     self.log_notice(f"{key} operational status transitioning to online")
 
                     reboot_cause = try_get(self.chassis.get_module(module_index).get_reboot_cause)

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -181,15 +181,14 @@ def test_smartswitch_moduleupdater_status_transitions():
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
 
     # Mock dependent methods
-    with patch.object(module_updater, 'retrieve_dpu_reboot_time', return_value="2024-11-19T00:00:00") \
-            as mock_retrieve_reboot_time, \
-         patch.object(module_updater, '_is_first_boot', return_value=False) as mock_is_first_boot, \
-         patch.object(module_updater, 'persist_dpu_reboot_cause') as mock_persist_reboot_cause, \
-         patch.object(module_updater, 'update_dpu_reboot_cause_to_db') as mock_update_reboot_db, \
-         patch("os.makedirs") as mock_makedirs, \
-         patch("builtins.open", mock_open()) as mock_file, \
-         patch.object(module_updater, '_get_history_path',
-                      return_value="/tmp/prev_reboot_time.txt") as mock_get_history_path:
+    with patch.object(module_updater, 'retrieve_dpu_reboot_time', return_value="2023_01_01_00_00_00") as mock_reboot_time, \
+        patch.object(module_updater, 'retrieve_dpu_reboot_cause', return_value="Switch rebooted DPU") as mock_reboot_cause, \
+        patch.object(module_updater, '_is_first_boot', return_value=False) as mock_is_first_boot, \
+        patch.object(module_updater, 'persist_dpu_reboot_cause') as mock_persist_reboot_cause, \
+        patch.object(module_updater, 'update_dpu_reboot_cause_to_db') as mock_update_reboot_db, \
+        patch("os.makedirs") as mock_makedirs, \
+        patch("builtins.open", mock_open()) as mock_file, \
+        patch.object(module_updater, '_get_history_path', return_value="/tmp/prev_reboot_time.txt") as mock_get_history_path:
 
         # Transition from ONLINE to OFFLINE
         offline_status = ModuleBase.MODULE_STATUS_OFFLINE

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -241,20 +241,24 @@ def test_online_transition_skips_reboot_update():
         mock_update.assert_not_called()
 
 def test_retrieve_dpu_reboot_info_success():
-    updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, None)
-    fake_path = "/tmp/DPU0/previous-reboot-cause.json"
-    fake_json = '{"cause": "Switch rebooted DPU", "name": "2025_06_25_17_18_52"}'
+    class DummyChassis:
+        def get_num_modules(self): return 0  # Minimal requirement
 
+    updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, DummyChassis())
+    sample_json = {"cause": "Switch rebooted DPU", "name": "2025_06_25_17_18_52"}
     with patch("os.path.exists", return_value=True), \
-         patch("builtins.open", mock_open(read_data=fake_json)):
-        cause, time_str = updater.retrieve_dpu_reboot_info("DPU0")
+         patch("builtins.open", mock_open(read_data=json.dumps(sample_json))):
+        cause, time_str = updater.retrieve_dpu_reboot_info("dpu0")
         assert cause == "Switch rebooted DPU"
         assert time_str == "2025_06_25_17_18_52"
 
 def test_retrieve_dpu_reboot_info_file_missing():
-    updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, None)
+    class DummyChassis:
+        def get_num_modules(self): return 0
+
+    updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, DummyChassis())
     with patch("os.path.exists", return_value=False):
-        cause, time_str = updater.retrieve_dpu_reboot_info("DPU0")
+        cause, time_str = updater.retrieve_dpu_reboot_info("dpu0")
         assert cause is None
         assert time_str is None
 

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -242,7 +242,8 @@ def test_online_transition_skips_reboot_update():
 
 def test_retrieve_dpu_reboot_info_success():
     class DummyChassis:
-        def get_num_modules(self): return 0  # Minimal requirement
+        def get_num_modules(self): return 0
+        def init_midplane_switch(self): return False
 
     updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, DummyChassis())
     sample_json = {"cause": "Switch rebooted DPU", "name": "2025_06_25_17_18_52"}
@@ -255,6 +256,7 @@ def test_retrieve_dpu_reboot_info_success():
 def test_retrieve_dpu_reboot_info_file_missing():
     class DummyChassis:
         def get_num_modules(self): return 0
+        def init_midplane_switch(self): return False  # required for SmartSwitchModuleUpdater
 
     updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, DummyChassis())
     with patch("os.path.exists", return_value=False):

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -226,6 +226,7 @@ def test_online_transition_skips_reboot_update():
 
     with patch.object(updater, 'retrieve_dpu_reboot_info',
                       return_value=("Switch rebooted DPU", datetime.now(timezone.utc).strftime("%Y_%m_%d_%H_%M_%S"))), \
+         patch.object(module, 'get_reboot_cause', return_value="Switch rebooted DPU"), \
          patch.object(updater, '_is_first_boot', return_value=False), \
          patch.object(updater, 'persist_dpu_reboot_cause') as mock_persist, \
          patch.object(updater, 'update_dpu_reboot_cause_to_db') as mock_update, \

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -181,8 +181,7 @@ def test_smartswitch_moduleupdater_status_transitions():
     module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
 
     # Mock dependent methods
-    with patch.object(module_updater, 'retrieve_dpu_reboot_time', return_value="2023_01_01_00_00_00") as mock_reboot_time, \
-        patch.object(module_updater, 'retrieve_dpu_reboot_cause', return_value="Switch rebooted DPU") as mock_reboot_cause, \
+    with patch.object(module_updater, 'retrieve_dpu_reboot_info', return_value=("Switch rebooted DPU", "2023_01_01_00_00_00")) as mock_reboot_info, \
         patch.object(module_updater, '_is_first_boot', return_value=False) as mock_is_first_boot, \
         patch.object(module_updater, 'persist_dpu_reboot_cause') as mock_persist_reboot_cause, \
         patch.object(module_updater, 'update_dpu_reboot_cause_to_db') as mock_update_reboot_db, \

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -240,6 +240,24 @@ def test_online_transition_skips_reboot_update():
         mock_persist.assert_not_called()
         mock_update.assert_not_called()
 
+def test_retrieve_dpu_reboot_info_success():
+    updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, None)
+    fake_path = "/tmp/DPU0/previous-reboot-cause.json"
+    fake_json = '{"cause": "Switch rebooted DPU", "name": "2025_06_25_17_18_52"}'
+
+    with patch("os.path.exists", return_value=True), \
+         patch("builtins.open", mock_open(read_data=fake_json)):
+        cause, time_str = updater.retrieve_dpu_reboot_info("DPU0")
+        assert cause == "Switch rebooted DPU"
+        assert time_str == "2025_06_25_17_18_52"
+
+def test_retrieve_dpu_reboot_info_file_missing():
+    updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, None)
+    with patch("os.path.exists", return_value=False):
+        cause, time_str = updater.retrieve_dpu_reboot_info("DPU0")
+        assert cause is None
+        assert time_str is None
+
 def test_smartswitch_moduleupdater_check_invalid_name():
     chassis = MockSmartSwitchChassis()
     index = 0


### PR DESCRIPTION
SmartSwitch - Reboot cause for DPUs not updated on complete system reboot

#### Description
SmartSwitch - Reboot cause for DPUs not updated on complete system reboot
Fixes #22430  https://github.com/sonic-net/sonic-buildimage/issues/22430

#### Motivation and Context
In melanox smartswitch platforms the reboot-cause is not persisted and updated into db after a complete switch reboot

#### How Has This Been Tested?
Issued system level reboot and checked the CLI "show reboot-cause all" and "show reboot-cause history DPU4" output.
This reflects the reboot.

root@sonic:/home/cisco# show reboot-cause all
Device    Name                 Cause                Time                             User
--------  -------------------  -------------------  -------------------------------  ------
NPU       2025_06_25_21_17_01  reboot               Wed Jun 25 09:09:00 PM UTC 2025  cisco
DPU7      2025_06_20_11_37_29  Switch rebooted DPU  Fri Jun 20 11:37:29 AM UTC 2025
DPU6      2025_06_20_11_37_23  Switch rebooted DPU  Fri Jun 20 11:37:23 AM UTC 2025
DPU5      2025_06_25_21_12_48  Switch rebooted DPU  Wed Jun 25 09:12:48 PM UTC 2025
**DPU4      2025_06_25_21_11_05  Switch rebooted DPU  Wed Jun 25 09:11:05 PM UTC 2025**
DPU3      2025_06_20_14_17_32  Switch rebooted DPU  Fri Jun 20 02:17:32 PM UTC 2025
DPU2      2025_06_20_14_17_22  Switch rebooted DPU  Fri Jun 20 02:17:22 PM UTC 2025
DPU1      2025_06_20_11_36_52  Switch rebooted DPU  Fri Jun 20 11:36:52 AM UTC 2025
DPU0      2025_06_20_11_36_46  Switch rebooted DPU  Fri Jun 20 11:36:46 AM UTC 2025
root@sonic:/home/cisco# show reboot-cause history DPU4
Device    Name                 Cause                Time                             User    Comment
--------  -------------------  -------------------  -------------------------------  ------  ------------
**DPU4      2025_06_25_21_11_05  Switch rebooted DPU  Wed Jun 25 09:11:05 PM UTC 2025          Non-Hardware**
DPU4      2025_06_25_21_00_12  Switch rebooted DPU  Wed Jun 25 09:00:12 PM UTC 2025          Non-Hardware
DPU4      2025_06_25_20_50_57  Switch rebooted DPU  Wed Jun 25 08:50:57 PM UTC 2025          Non-Hardware
DPU4      2025_06_25_20_26_51  Switch rebooted DPU  Wed Jun 25 08:26:51 PM UTC 2025          Non-Hardware
DPU4      2025_06_25_19_56_08  Switch rebooted DPU  Wed Jun 25 07:56:08 PM UTC 2025          Non-Hardware
DPU4      2025_06_25_19_46_48  Switch rebooted DPU  Wed Jun 25 07:46:48 PM UTC 2025          Non-Hardware
DPU4      2025_06_25_19_08_16  Switch rebooted DPU  Wed Jun 25 07:08:16 PM UTC 2025          Non-Hardware
DPU4      2025_06_25_18_58_16  Switch rebooted DPU  Wed Jun 25 06:58:16 PM UTC 2025          Non-Hardware
DPU4      2025_06_25_17_18_52  Switch rebooted DPU  Wed Jun 25 05:18:52 PM UTC 2025          Non-Hardware
DPU4      2025_06_25_17_10_12  Switch rebooted DPU  Wed Jun 25 05:10:12 PM UTC 2025          Non-Hardware

#### Request for 202505
- [x] 202505

#### Additional Information (Optional)
