### PR TITLE
Fix physical entity tables in statedb to account for modified psu key naming

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -297,7 +297,7 @@ class FanUpdater(logger.Logger):
         """
         drawer_name = NOT_AVAILABLE if fan_type != FanType.DRAWER else str(try_get(parent.get_name))
         if fan_type == FanType.PSU:
-            parent_name = 'PSU {}'.format(parent_index + 1)
+            parent_name = try_get(parent.get_name, default='PSU {}'.format(parent_index + 1))
         elif fan_type == FanType.MODULE:
             parent_name = try_get(parent.get_name, default='Module {}'.format(parent_index + 1))
         else:
@@ -600,7 +600,7 @@ class TemperatureUpdater(logger.Logger):
             self._refresh_temperature_status(CHASSIS_INFO_KEY, thermal, index)
 
         for psu_index, psu in enumerate(self.chassis.get_all_psus()):
-            parent_name = 'PSU {}'.format(psu_index + 1)
+            parent_name = try_get(psu.get_name, default='PSU {}'.format(psu_index + 1))
             if psu.get_presence():
                 for thermal_index, thermal in enumerate(psu.get_all_thermals()):
                     if self.task_stopping_event.is_set():
@@ -641,7 +641,7 @@ class TemperatureUpdater(logger.Logger):
 
                 for psu_index, psu in enumerate(module.get_all_psus()):
                     if psu.get_presence():
-                        psu_name = '{} PSU {}'.format(module_name, psu_index + 1)
+                        psu_name = try_get(psu.get_name, default='{} PSU {}'.format(module_name, psu_index + 1))
                         for thermal_index, thermal in enumerate(psu.get_all_thermals()):
                             if self.task_stopping_event.is_set():
                                 return


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Modify every instance of PSU parent naming to attempt to call the get_name API from the PSU/parent object, falling back to the prior implemented default behavior in the case that the API is not yet implemented by the vendor.

#### Motivation and Context
Issue raised: https://github.com/sonic-net/sonic-platform-daemons/issues/638, the key changes that took place previously on PSUD missing updating their associated phy entity tables in thermalctld. This PR makes the changes to account for this change.

#### How Has This Been Tested?
Ensure that phy entity tables in the statedb correctly reflect the name of their associated parent (in this case the PSU's get_name API response),  and run the SNMP docker to ensure that the reported failure no longer triggers.

Failure behavior:
```
2025 Jul  9 07:13:00.815494 MtFuji INFO snmp#snmp-subagent [ax_interface] INFO: OID registration complete. Waiting to receive PDUs...
2025 Jul  9 07:13:01.293223 MtFuji INFO snmp#supervisord 2025-07-09 07:13:01,292 INFO exited: dependent-startup (exit status 0; expected)
2025 Jul  9 07:13:05.800822 MtFuji ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: fan_name = PSU1.fan0 get fan parent failed
2025 Jul  9 07:13:05.801176 MtFuji ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: fan_name = PSU0.fan0 get fan parent failed
2025 Jul  9 07:13:11.831223 MtFuji ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: fan_name = PSU1.fan0 get fan parent failed
2025 Jul  9 07:13:11.831596 MtFuji ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: fan_name = PSU0.fan0 get fan parent failed
2025 Jul  9 07:13:17.860779 MtFuji ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: fan_name = PSU1.fan0 get fan parent failed
2025 Jul  9 07:13:17.861094 MtFuji ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: fan_name = PSU0.fan0 get fan parent failed
```
```
root@MtFuji:/home/cisco# redis-dump -d 6 -y -k "PHYSICAL_ENTITY_INFO*PSU*"
{
  "PHYSICAL_ENTITY_INFO|PSU0": {
    "expireat": 1752045619.0828245,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "parent_name": "chassis 1",
      "position_in_parent": "1"
    }
  },
  "PHYSICAL_ENTITY_INFO|PSU0 HSNK_Temp": {
    "expireat": 1752045619.0828173,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "parent_name": "PSU 1",
      "position_in_parent": "2"
    }
  },
  "PHYSICAL_ENTITY_INFO|PSU0 Inlet_Temp": {
    "expireat": 1752045619.0828152,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "parent_name": "PSU 1",
      "position_in_parent": "1"
    }
  },
  "PHYSICAL_ENTITY_INFO|PSU0 Outlet_Temp": {
    "expireat": 1752045619.0828078,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "parent_name": "PSU 1",
      "position_in_parent": "3"
    }
  },
  "PHYSICAL_ENTITY_INFO|PSU0.fan0": {
    "expireat": 1752045619.0828207,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "parent_name": "PSU 1",
      "position_in_parent": "1"
    }
  },
  "PHYSICAL_ENTITY_INFO|PSU1": {
    "expireat": 1752045619.0828226,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "parent_name": "chassis 1",
      "position_in_parent": "2"
    }
  },
  "PHYSICAL_ENTITY_INFO|PSU1.fan0": {
    "expireat": 1752045619.0828116,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "parent_name": "PSU 2",
      "position_in_parent": "1"
    }
  }
}
```
In the above, we can see that even though the PSU itself is PSU0, its sensors and fans are reporting parent of 'PSU 1'


Fixed behavior:
```
root@MtFuji:/home/cisco# redis-dump -d 6 -y -k "PHYSICAL_ENTITY_INFO*PSU*"
{
  "PHYSICAL_ENTITY_INFO|PSU0": {
    "expireat": 1752044827.375372,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "parent_name": "chassis 1",
      "position_in_parent": "1"
    }
  },
  "PHYSICAL_ENTITY_INFO|PSU0 HSNK_Temp": {
    "expireat": 1752044827.3753655,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "parent_name": "PSU0",
      "position_in_parent": "2"
    }
  },
  "PHYSICAL_ENTITY_INFO|PSU0 Inlet_Temp": {
    "expireat": 1752044827.375363,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "parent_name": "PSU0",
      "position_in_parent": "1"
    }
  },
  "PHYSICAL_ENTITY_INFO|PSU0 Outlet_Temp": {
    "expireat": 1752044827.3753557,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "parent_name": "PSU0",
      "position_in_parent": "3"
    }
  },
  "PHYSICAL_ENTITY_INFO|PSU0.fan0": {
    "expireat": 1752044827.375368,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "parent_name": "PSU0",
      "position_in_parent": "1"
    }
  },
  "PHYSICAL_ENTITY_INFO|PSU1": {
    "expireat": 1752044827.3753705,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "parent_name": "chassis 1",
      "position_in_parent": "2"
    }
  },
  "PHYSICAL_ENTITY_INFO|PSU1.fan0": {
    "expireat": 1752044827.3753598,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "parent_name": "PSU1",
      "position_in_parent": "1"
    }
  }
}
```
#### Additional Information (Optional)
