### PR TITLE
[chassis] modify chassisd to add fabric card information to PHYSICAL_ENTITY_INFO table only if module is present

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -407,14 +407,18 @@ class ModuleUpdater(logger.Logger):
                 prev_status = self.get_module_current_status(key)
                 self.module_table.set(key, fvs)
 
-                update_entity_info(self.phy_entity_table,
-                                   "chassis {}".format(1),
-                                   key,
-                                   module_index,
-                                   module_info_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD],
-                                   module_info_dict[CHASSIS_MODULE_INFO_MODEL_FIELD],
-                                   module_info_dict[CHASSIS_MODULE_INFO_REPLACEABLE_FIELD])
-
+                if module_info_dict[CHASSIS_MODULE_INFO_PRESENCE_FIELD].lower() == "true":
+                    update_entity_info(self.phy_entity_table,
+                                       "chassis {}".format(1),
+                                       key,
+                                       module_index,
+                                       module_info_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD],
+                                       module_info_dict[CHASSIS_MODULE_INFO_MODEL_FIELD],
+                                       module_info_dict[CHASSIS_MODULE_INFO_REPLACEABLE_FIELD])
+                else:
+                    if self.phy_entity_table.get(key) is not None:
+                        self.phy_entity_table._del(key)
+                    
                 # Construct key for down_modules dict. Example down_modules key format: LINE-CARD0|<hostname>
                 fvs = self.hostname_table.get(key)
                 if isinstance(fvs, list) and fvs[0] is True:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Update chassisd to add fabric card module information to `PHYSICAL_ENTITY_INFO` table in `STATE_DB`  only if the module is present.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Fixes [#23372](https://github.com/sonic-net/sonic-buildimage/issues/23372)
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Run `sonic-db-cli STATE_DB keys "PHYSICAL_ENTITY_INFO|FABRIC*`"`
It should only list the fabric card modules that are present.

#### Additional Information (Optional)
