### PR TITLE
Fix incorrect string formatting for PCIe device name

### DIFF
--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -200,7 +200,7 @@ class DaemonPcied(daemon_base.DaemonBase):
         for result in self.resultInfo:
             if result["result"] == "Failed":
                 # Convert bus, device, and function to a bus_info format like "0000:03:00.0"
-                pcie_dev = "0000:{int(result['bus'], 16):02x}:{int(result['dev'], 16):02x}.{int(result['fn'], 16)}"
+                pcie_dev = "0000:{:02x}:{:02x}.{}".format(int(result["bus"], 16), int(result["dev"], 16), int(result["fn"], 16))
 
                 # Check if the device is in detaching mode
                 if device_info.is_smartswitch() and self.is_dpu_in_detaching_mode(pcie_dev):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
The pcie_dev string was incorrectly using an f-string-style format without the f prefix or .format() usage, resulting in the placeholder being treated as a literal string. As a result, the PCIe device name was not being correctly computed and logged, which affects DPU detach warnings and related debugging.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
PCIe device name not logged correctly during DPU detachment scenarios. This change fixes the formatting using the str.format() method, ensuring the PCIe device address is constructed accurately. As a result, the correct device name will now appear in logs, aiding in proper debugging and tracking.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Tested and verified in my local testbed
tests/test_DaemonPcied.py::TestDaemonPcied::test_check_pcie_devices_detaching PASSED 

Also, to manually simulate a pass scenario and verify correct PCIe device name logging, I temporarily moved the `pcie_dev` variable declaration into the `else` block (where `result["result"] != "Failed"`) and added a log statement there. This allowed me to observe the formatted device string during normal (non-failure) conditions.

After making the changes, I restarted the `pcied` process using `supervisorctl restart pcied` and inspected the logs.

Logs Before Fix :
```
2025 Jul 19 07:51:58.815665 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:{int(result['bus'], 16):02x}:{int(result['dev'], 16):02x}.{int(result['fn'], 16)} is in detaching mode, skipping warning.
```

Logs After Fix :
```
2025 Jul 19 10:01:03.399852 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:00:00.0 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.401242 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:00:01.0 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.402128 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:00:01.1 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.402868 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:00:01.2 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.405879 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:00:01.3 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.407156 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:00:01.4 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.407883 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:00:01.5 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.408606 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:00:01.6 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.409271 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:00:01.7 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.410031 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:00:02.0 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.410746 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:00:04.0 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.411066 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:00:1f.0 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.411395 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:00:1f.2 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.411697 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:00:1f.3 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.411982 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:01:00.0 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.412671 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:02:01.0 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.412980 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:02:02.0 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.413283 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:03:00.0 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.413671 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:04:00.0 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.414050 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:05:00.0 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.414386 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:06:00.0 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.414679 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:07:00.0 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.414962 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:08:00.0 is in detaching mode, skipping warning.
2025 Jul 19 10:01:03.415338 VM0100 WARNING pmon#pcied[24]: PCIe Device:  0000:09:00.0 is in detaching mode, skipping warning.
```

#### Additional Information (Optional)
