### PR TITLE
Fix rare timing issue in test_CmisManagerTask_task_worker_decommission

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -3426,9 +3426,7 @@ class TestXcvrdScript(object):
         # Force config status check to failed
         mock_xcvr_api.get_config_datapath_hostlane_status.return_value = gen_cmis_config_status_dict('ConfigRejected')
         mock_xcvr_api.get_datapath_state = MagicMock(return_value=gen_cmis_dp_state_dict('DataPathDeactivated'))
-        mock_xcvr_api.get_datapath_init_duration = MagicMock(return_value=0)
-        mock_xcvr_api.get_module_pwr_up_duration = MagicMock(return_value=0)
-        mock_xcvr_api.get_datapath_deinit_duration = MagicMock(return_value=0)
+        task.is_timer_expired = MagicMock(return_value=True)
 
         # Insert 1st subport event
         port_change_event = PortChangeEvent('Ethernet0', physical_port_idx, 0, PortChangeEvent.PORT_SET, {'speed':'100000', 'lanes':'1,2', 'subport': '1'})


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

If the CPU of build server is very fast, testcase `test_CmisManagerTask_task_worker_decommission` might have a chance to fail at https://github.com/sonic-net/sonic-platform-daemons/blob/d555defff9b9b1dd7727340055f8cd908188670f/sonic-xcvrd/tests/test_xcvrd.py#L3441


The reason is:
- Test code incorrectly assumes `update_cmis_state_expiration_time(lport, duration_seconds=0.0)` will set `cmis_expired` as current_time (i.e. current_time + `0.0`, meaning expired immediately), however there's always a `CMIS_EXPIRATION_BUFFER_MS` (`2ms`) getting added on top of it.
https://github.com/sonic-net/sonic-platform-daemons/blob/d555defff9b9b1dd7727340055f8cd908188670f/sonic-xcvrd/xcvrd/xcvrd.py#L1084-L1094

e.g. if current_time is `01:36:25.528`, calling `self.update_cmis_state_expiration_time(lport, 0.0)`, will set `cmis_expired` to `01:36:25.530`, i.e. 2ms ahead of current time. 

When testcase is testing `timeout for 'ConfigSuccess'` scenario:
https://github.com/sonic-net/sonic-platform-daemons/blob/d555defff9b9b1dd7727340055f8cd908188670f/sonic-xcvrd/xcvrd/xcvrd.py#L1435-L1441

- On my build server, this testcase always pass. It constantly takes more than `2ms` to run through one [while/for loop](https://github.com/sonic-net/sonic-platform-daemons/blob/d555defff9b9b1dd7727340055f8cd908188670f/sonic-xcvrd/xcvrd/xcvrd.py#L1123-L1129) iteration, so after `self.update_cmis_state_expiration_time(lport, 0.0)`, it costs only two while/loop to become `is_timer_expired()==True` reaching `timeout for 'ConfigSuccess'`, in total it constantly costs only 17 while/for loop iterations to reach CMIS_STATE_FAILED after retries, in which case [`task_stopping_event.is_set = MagicMock(side_effect=[False]*50 + [True]*2)`](https://github.com/sonic-net/sonic-platform-daemons/blob/d555defff9b9b1dd7727340055f8cd908188670f/sonic-xcvrd/tests/test_xcvrd.py#L3437) is more than enough.
- But if the CPU of build server is very fast, it has a chance to be able to run through multiple while/for loop iterations within `2ms`, costing more while/for loop iterations to reach `timeout for 'ConfigSuccess'`, which might end up running out of [`task_stopping_event.is_set = MagicMock(side_effect=[False]*50 + [True]*2)`](https://github.com/sonic-net/sonic-platform-daemons/blob/d555defff9b9b1dd7727340055f8cd908188670f/sonic-xcvrd/tests/test_xcvrd.py#L3437) too soon , not being able to even reach CMIS_STATE_FAILED, causing testcase [assertion failure](https://github.com/sonic-net/sonic-platform-daemons/blob/d555defff9b9b1dd7727340055f8cd908188670f/sonic-xcvrd/tests/test_xcvrd.py#L3441).


In below example, CPU is fast, within 2ms, it's able to run through 5 while/for loop iterations. In other words, it costs 5 while/for loop iterations to reach `timeout for 'ConfigSuccess'` after `self.update_cmis_state_expiration_time(lport, 0.0)`:
```
2025-07-26 07:45:08.244422 CMIS: Ethernet0: DpDeinit duration 0.0 secs, modulePwrUp duration 0.0 secs
2025-07-26 07:45:08.244469 CMIS: update_cmis_state_expiration_time(0.0) set expired_time to 2025-07-26 07:45:08.246441, current_time 2025-07-26 07:45:08.244441
2025-07-26 07:45:08.244838 CMIS: Ethernet0: 100G, lanemask=0xff, CMIS state=AP_CONFIGURED(decommission*), ... retries=2
2025-07-26 07:45:08.245373 CMIS: Ethernet0: 100G, lanemask=0xff, CMIS state=DP_INIT(decommission*), ... retries=2
2025-07-26 07:45:08.245446 CMIS: is_timer_expired() = False
2025-07-26 07:45:08.245809 CMIS: Ethernet0: 100G, lanemask=0xff, CMIS state=DP_INIT(decommission*), ... retries=2
2025-07-26 07:45:08.245885 CMIS: is_timer_expired() = False
2025-07-26 07:45:08.246266 CMIS: Ethernet0: 100G, lanemask=0xff, CMIS state=DP_INIT(decommission*), ... retries=2
2025-07-26 07:45:08.246345 CMIS: is_timer_expired() = False
2025-07-26 07:45:08.246715 CMIS: Ethernet0: 100G, lanemask=0xff, CMIS state=DP_INIT(decommission*), ... retries=2
2025-07-26 07:45:08.246795 CMIS: is_timer_expired() = True
2025-07-26 07:45:08.246857 CMIS: Ethernet0: timeout for 'ConfigSuccess', current ConfigStatus: ['ConfigRejected', 'ConfigRejected', 'ConfigRejected', 'ConfigRejected', 'ConfigRejected', 'ConfigRejected', 'ConfigRejected', 'ConfigRejected']
2025-07-26 07:45:08.247248 CMIS: Ethernet0: 100G, lanemask=0xff, CMIS state=INSERTED(decommission*), ... retries=3
```


#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Testcase passed

#### Additional Information (Optional)
