### PR TITLE
Update code to allow xcvrd dynamic log level configuration to work

### DIFF
--- a/sonic-xcvrd/xcvrd/dom/dom_mgr.py
+++ b/sonic-xcvrd/xcvrd/dom/dom_mgr.py
@@ -454,3 +454,7 @@ class DomInfoUpdateTask(threading.Thread):
                                       self.xcvr_table_helper.get_pm_tbl(port_change_event.asic_id),
                                       self.xcvr_table_helper.get_firmware_info_tbl(port_change_event.asic_id)
                                       ])
+    def update_log_level(self):
+        """Call the logger's update log level method.
+        """
+        return self.helper_logger.update_log_level()

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2126,6 +2126,11 @@ class SfpStateUpdateTask(threading.Thread):
         # Update retry EEPROM set
         self.retry_eeprom_set -= retry_success_set
 
+    def update_log_level(self):
+        """Call the logger's update log level method.
+        """
+        return self.logger.update_log_level()
+
 
 #
 # Daemon =======================================================================
@@ -2143,11 +2148,22 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         self.threads = []
         self.sfp_obj_dict = {}
 
+    def update_loggers_log_level(self):
+        """
+        Update log level for all loggers
+        """
+        helper_logger.update_log_level()
+        self.logger_instance.update_log_level()
+        for thread in self.threads:
+            update_log_level = getattr(thread, 'update_log_level', None)
+            if update_log_level and callable(update_log_level):
+                thread.update_log_level()
+
     # Signal handler
     def signal_handler(self, sig, frame):
         if sig == signal.SIGHUP:
             self.log_notice("Caught SIGHUP...")
-            self.update_log_level()
+            self.update_loggers_log_level()
         elif sig == signal.SIGINT:
             self.log_info("Caught SIGINT - exiting...")
             self.stop_event.set()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
- Add methods to update log level in DomInfoUpdateTask and SfpStateUpdateTask.
- Call update_log_level for global helper_logger in xcvrd.py and all the threads that have update_log_level as a method.
- Encapsulate all the update_log_level in new method update_loggers_log_level and call it when SIGHUP is handled.
- Add unit tests to verify changes.

#### Motivation and Context

As described in https://github.com/sonic-net/sonic-platform-daemons/issues/664, dynamic log level for xcvrd does not work due to:
```
AttributeError: 'DaemonXcvrd' object has no attribute 'update_log_level'
```

This change allows it to work for xcvrd and all associated threads that use a logger.

#### How Has This Been Tested?

Added unit tests to ensure no regressions.
Also manually tested by changing log levels using:
```
admin@sonic:~$ sudo config syslog level -i xcvrd -l DEBUG --container pmon --program xcvrd
admin@sonic:~$ sudo config syslog level -i xcvrd -l INFO --container pmon --program xcvrd
```
The backtrace no longer happens and the logging verbosity changes based on the configuration.

#### Additional Information (Optional)
fixes #664