### PR TITLE
[xcvrd] Improve logging in case of unable to find appropriate match for optic SI settings

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -4938,6 +4938,33 @@ class TestOpticSiParser(object):
         result = get_module_vendor_key(1, mock_sfp)
         assert result is None
 
+    def test_get_port_media_settings_no_values_with_empty_default(self):
+        """Test _get_port_media_settings logging when port exists but has empty config and no default values"""
+        from xcvrd.xcvrd_utilities.optics_si_parser import _get_port_media_settings
+        import xcvrd.xcvrd_utilities.optics_si_parser as parser
+
+        original_dict = parser.g_optics_si_dict
+
+        # Set up scenario where:
+        # 1. Port exists in PORT_MEDIA_SETTINGS but has empty configuration
+        # 2. This makes len(optics_si_dict) == 0
+        # 3. Default dict is empty (len(default_dict) == 0)
+        parser.g_optics_si_dict = {
+            'PORT_MEDIA_SETTINGS': {
+                '5': {}  # Port exists but is empty - this triggers len(optics_si_dict) == 0
+            }
+        }
+
+        try:
+            # This should trigger the log_info line at lines 119-121
+            # since len(optics_si_dict) == 0 and len(default_dict) == 0
+            result = _get_port_media_settings(5, 25, "VENDOR-1234", "VENDOR", {})
+
+            # Should return empty dict when no values found and no defaults
+            assert result == {}
+        finally:
+            parser.g_optics_si_dict = original_dict
+
     def test_load_optics_si_settings_no_file(self):
         """Test load_optics_si_settings when no file exists"""
         from xcvrd.xcvrd_utilities.optics_si_parser import load_optics_si_settings

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py
@@ -116,7 +116,9 @@ def _get_port_media_settings(physical_port, lane_speed, key, vendor_name_str, de
             if len(default_dict) != 0:
                 return default_dict
             else:
-                helper_logger.log_error("Error: No values for physical port '{}'".format(physical_port))
+                helper_logger.log_info("No values for physical port '{}' lane speed '{}' "
+                                       "key '{}' vendor '{}'".format(
+                                       physical_port, lane_speed, key, vendor_name_str))
             return {}
 
         if SPEED_KEY in optics_si_dict:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
This PR improves the logging in the optics SI parser to provide better diagnostic information when unable to find an appropriate match for optic SI settings for a physical port.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The previous log message was an error which is misleading since there can be genuine cases wherein optics SI settings are not present for a module.
Hence, changing the log level to INFO and adding more debug data.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Testing is in progress currently

#### Additional Information (Optional)
MSFT ADO - 34731836