### PR TITLE
[202405] [xcvrd] Improve logging in case of unable to find appropriate match for optic SI settings (#672) 

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -315,18 +315,19 @@ class ModuleUpdater(logger.Logger):
                         # identifying module operational status change. But the clean up will not be attempted for supervisor
 
                         if down_module_key not in self.down_modules:
-                            self.log_warning("Module {} went off-line!".format(key))
+                            self.log_warning("Module {} (Slot {}) went off-line!".format(key, module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD]))
                             self.down_modules[down_module_key] = {}
                             self.down_modules[down_module_key]['down_time'] = time.time()
                             self.down_modules[down_module_key]['cleaned'] = False
+                            self.down_modules[down_module_key]['slot'] = module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD]
                     continue
                 else:
                     # Module is operational. Remove it from down time tracking.
                     if down_module_key in self.down_modules:
-                        self.log_notice("Module {} recovered on-line!".format(key))
+                        self.log_notice("Module {} (Slot {}) recovered on-line!".format(key, module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD]))
                         del self.down_modules[down_module_key]
                     elif prev_status != ModuleBase.MODULE_STATUS_ONLINE:
-                        self.log_notice("Module {} is on-line!".format(key))
+                        self.log_notice("Module {} (Slot {}) is on-line!".format(key, module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD] ))
 
                     module_cfg_status = self.get_module_admin_status(key)
 
@@ -452,17 +453,17 @@ class ModuleUpdater(logger.Logger):
             if midplane_access is False and current_midplane_state == 'True':
                 if self.is_module_reboot_expected(module_key):
                     self.module_reboot_set_time(module_key)
-                    self.log_warning("Expected: Module {} lost midplane connectivity".format(module_key))
+                    self.log_warning("Expected: Module {} (Slot {}) lost midplane connectivity".format(module_key, module.get_slot()))
                 else:
-                    self.log_warning("Unexpected: Module {} lost midplane connectivity".format(module_key))
+                    self.log_warning("Unexpected: Module {} (Slot {}) lost midplane connectivity".format(module_key, module.get_slot()))
             elif midplane_access is True and current_midplane_state == 'False':
-                self.log_notice("Module {} midplane connectivity is up".format(module_key))
+                self.log_notice("Module {} (Slot {}) midplane connectivity is up".format(module_key, module.get_slot()))
                 # clean up the reboot_info_table
                 if self.module_reboot_table.get(module_key) is not None:
                     self.module_reboot_table._del(module_key)
             elif midplane_access is False and current_midplane_state == 'False':
                 if self.is_module_reboot_system_up_expired(module_key):
-                    self.log_warning("Unexpected: Module {} midplane connectivity is not restored in {} seconds".format(module_key, self.linecard_reboot_timeout))
+                    self.log_warning("Unexpected: Module {} (Slot {}) midplane connectivity is not restored in {} seconds".format(module_key, module.get_slot(), self.linecard_reboot_timeout))
                     
             # Update db with midplane information
             fvs = swsscommon.FieldValuePairs([(CHASSIS_MIDPLANE_INFO_IP_FIELD, midplane_ip),
@@ -549,11 +550,12 @@ class ModuleUpdater(logger.Logger):
         for module in self.down_modules:
             if self.down_modules[module]['cleaned'] == False:
                 down_time = self.down_modules[module]['down_time']
+                slot = self.down_modules[module]['slot']
                 delta = (time_now - down_time) / 60
                 if delta >= CHASSIS_DB_CLEANUP_MODULE_DOWN_PERIOD:
                     if module.startswith(ModuleBase.MODULE_TYPE_LINE):
                         # Module is down for more than 30 minutes. Do the chassis clean up
-                        self.log_notice("Module {} is down for long time. Initiating chassis app db clean up".format(module))
+                        self.log_notice("Module {} (Slot {}) is down for long time. Initiating chassis app db clean up".format(module, slot))
                         self._cleanup_chassis_app_db(module)
                     self.down_modules[module]['cleaned'] = True
 

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -276,7 +276,7 @@ class ModuleUpdater(logger.Logger):
 
         for module_index in range(0, self.num_modules):
             module_info_dict = self._get_module_info(module_index)
-            if self.my_slot == int(module_info_dict['slot']):
+            if self.my_slot == module_info_dict['slot']:
                 my_index = module_index
 
             if module_info_dict is not None:
@@ -293,7 +293,7 @@ class ModuleUpdater(logger.Logger):
 
                 fvs = swsscommon.FieldValuePairs([(CHASSIS_MODULE_INFO_DESC_FIELD, module_info_dict[CHASSIS_MODULE_INFO_DESC_FIELD]),
                                                   (CHASSIS_MODULE_INFO_SLOT_FIELD,
-                                                   module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD]),
+                                                   str(module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD])),
                                                   (CHASSIS_MODULE_INFO_OPERSTATUS_FIELD, module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]),
                                                   (CHASSIS_MODULE_INFO_NUM_ASICS_FIELD, str(len(module_info_dict[CHASSIS_MODULE_INFO_ASICS]))),
                                                   (CHASSIS_MODULE_INFO_SERIAL_FIELD, module_info_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD])])
@@ -350,8 +350,8 @@ class ModuleUpdater(logger.Logger):
 
         # In line card push the hostname of the module and num_asics to the chassis state db.
         # The hostname is used as key to access chassis app db entries 
-        module_info_dict = self._get_module_info(my_index)
         if not self._is_supervisor():
+           module_info_dict = self._get_module_info(my_index)
            hostname_key = "{}{}".format(ModuleBase.MODULE_TYPE_LINE, int(self.my_slot) - 1)
            hostname = try_get(device_info.get_hostname, default="None")
            hostname_fvs = swsscommon.FieldValuePairs([(CHASSIS_MODULE_INFO_SLOT_FIELD, str(self.my_slot)), 
@@ -386,7 +386,7 @@ class ModuleUpdater(logger.Logger):
 
         module_info_dict[CHASSIS_MODULE_INFO_NAME_FIELD] = name
         module_info_dict[CHASSIS_MODULE_INFO_DESC_FIELD] = str(desc)
-        module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD] = str(slot)
+        module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD] = slot
         module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD] = str(status)
         module_info_dict[CHASSIS_MODULE_INFO_ASICS] = asics
         module_info_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD] = str(serial)

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -507,6 +507,7 @@ class ModuleUpdater(logger.Logger):
                 local lagid = redis.call('HGET', 'SYSTEM_LAG_ID_TABLE', lagname)\n\
                 redis.call('SREM', 'SYSTEM_LAG_ID_SET', lagid)\n\
                 redis.call('HDEL', 'SYSTEM_LAG_ID_TABLE', lagname)\n\
+                redis.call('rpush', 'SYSTEM_LAG_IDS_FREE_LIST', lagid)\n\
             end\n\
         end\n\
         return"

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -360,13 +360,14 @@ class ModuleUpdater(logger.Logger):
            self.hostname_table.set(hostname_key, hostname_fvs)
 
         # Asics that are on the "not online" modules need to be cleaned up
-        asics = list(self.asic_table.getKeys())
-        for asic in asics:
-            fvs = self.asic_table.get(asic)
-            if isinstance(fvs, list):
-                fvs = dict(fvs[-1])
-            if fvs[CHASSIS_MODULE_INFO_NAME_FIELD] in notOnlineModules:
-                self.asic_table._del(asic)
+        if notOnlineModules:
+            asics = list(self.asic_table.getKeys())
+            for asic in asics:
+                fvs = self.asic_table.get(asic)
+                if isinstance(fvs, list):
+                    fvs = dict(fvs[-1])
+                if CHASSIS_MODULE_INFO_NAME_FIELD in fvs.keys() and fvs[CHASSIS_MODULE_INFO_NAME_FIELD] in notOnlineModules:
+                    self.asic_table._del(asic)
 
     def _get_module_info(self, module_index):
         """

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -272,9 +272,13 @@ class ModuleUpdater(logger.Logger):
 
     def module_db_update(self):
         notOnlineModules = []
+        my_index = None
 
         for module_index in range(0, self.num_modules):
             module_info_dict = self._get_module_info(module_index)
+            if self.my_slot == int(module_info_dict['slot']):
+                my_index = module_index
+
             if module_info_dict is not None:
                 key = module_info_dict[CHASSIS_MODULE_INFO_NAME_FIELD]
 
@@ -346,6 +350,7 @@ class ModuleUpdater(logger.Logger):
 
         # In line card push the hostname of the module and num_asics to the chassis state db.
         # The hostname is used as key to access chassis app db entries 
+        module_info_dict = self._get_module_info(my_index)
         if not self._is_supervisor():
            hostname_key = "{}{}".format(ModuleBase.MODULE_TYPE_LINE, int(self.my_slot) - 1)
            hostname = try_get(device_info.get_hostname, default="None")

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -280,6 +280,54 @@ def test_configupdater_check_num_modules():
     fvs = module_updater.chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
     assert fvs == None
 
+def test_moduleupdater_check_string_slot():
+    chassis = MockChassis()
+
+    #Supervisor
+    index = 0
+    name = "SUPERVISOR0"
+    desc = "Supervisor card"
+    slot = "A"
+    serial = "RP1000101"
+    module_type = ModuleBase.MODULE_TYPE_SUPERVISOR
+    supervisor = MockModule(index, name, desc, module_type, slot, serial)
+    supervisor.set_midplane_ip()
+    chassis.module_list.append(supervisor)
+
+    #Linecard
+    index = 1
+    name = "LINE-CARD0"
+    desc = "36 port 400G card"
+    slot = "1"
+    serial = "LC1000101"
+    module_type = ModuleBase.MODULE_TYPE_LINE
+    module = MockModule(index, name, desc, module_type, slot, serial)
+    module.set_midplane_ip()
+    chassis.module_list.append(module)
+
+    #Fabric-card
+    index = 1
+    name = "FABRIC-CARD0"
+    desc = "Switch fabric card"
+    slot = "17"
+    serial = "FC1000101"
+    module_type = ModuleBase.MODULE_TYPE_FABRIC
+    fabric = MockModule(index, name, desc, module_type, slot, serial)
+    chassis.module_list.append(fabric)
+
+    #Run on supervisor
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, slot,
+                                   module.supervisor_slot)
+    module_updater.supervisor_slot = supervisor.get_slot()
+    module_updater.my_slot = supervisor.get_slot()
+    module_updater.modules_num_update()
+    module_updater.module_db_update()
+    module_updater.check_midplane_reachability()
+
+    midplane_table = module_updater.midplane_table
+    #Check only one entry in database
+    assert 1 == midplane_table.size()
+    
 def test_midplane_presence_modules():
     chassis = MockChassis()
 

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -553,6 +553,21 @@ def test_midplane_presence_supervisor():
     fvs = midplane_table.get(name)
     assert fvs == None
 
+def verify_asic(asic_name, asic_pci_address, module_name, asic_id_in_module, asic_table):
+    fvs = asic_table.get(asic_name)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert fvs[CHASSIS_ASIC_PCI_ADDRESS_FIELD] == asic_pci_address
+    assert fvs[CHASSIS_MODULE_INFO_NAME_FIELD] == module_name
+    assert fvs[CHASSIS_ASIC_ID_IN_MODULE_FIELD] == asic_id_in_module
+
+def verify_asic_in_module_table(lc, slot, num_asics, chassis_module_table):
+    fvs = chassis_module_table.get(lc)
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert fvs['slot'] == str(slot)
+    assert fvs['num_asics'] == str(num_asics)
+
 def test_asic_presence():
     chassis = MockChassis()
 
@@ -603,16 +618,8 @@ def test_asic_presence():
     fabric_asic_table = module_updater.asic_table
     assert len(fabric_asic_table.getKeys()) == 2
 
-    def verify_fabric_asic(asic_name, asic_pci_address, module_name, asic_id_in_module):
-        fvs = fabric_asic_table.get(asic_name)
-        if isinstance(fvs, list):
-            fvs = dict(fvs[-1])
-        assert fvs[CHASSIS_ASIC_PCI_ADDRESS_FIELD] == asic_pci_address
-        assert fvs[CHASSIS_MODULE_INFO_NAME_FIELD] == module_name
-        assert fvs[CHASSIS_ASIC_ID_IN_MODULE_FIELD] == asic_id_in_module
-
-    verify_fabric_asic("asic4", "0000:04:00.0", name, "0")
-    verify_fabric_asic("asic5", "0000:05:00.0", name, "1")
+    verify_asic("asic4", "0000:04:00.0", name, "0", fabric_asic_table)
+    verify_asic("asic5", "0000:05:00.0", name, "1", fabric_asic_table)
 
     #Card goes down and asics should be gone
     fabric.set_oper_status(ModuleBase.MODULE_STATUS_OFFLINE)
@@ -626,8 +633,65 @@ def test_asic_presence():
     midplane_table = module_updater.midplane_table
     fvs = midplane_table.get(name)
     assert fvs == None
-    verify_fabric_asic("asic4", "0000:04:00.0", name, "0")
-    verify_fabric_asic("asic5", "0000:05:00.0", name, "1")
+    verify_asic("asic4", "0000:04:00.0", name, "0", fabric_asic_table)
+    verify_asic("asic5", "0000:05:00.0", name, "1", fabric_asic_table)
+
+def test_forwarding_asic_presence():
+    chassis = MockChassis()
+
+    #Supervisor
+    index = 0
+    name = "SUPERVISOR0"
+    desc = "Supervisor card"
+    slot = 16
+    serial = "RP1000101"
+    module_type = ModuleBase.MODULE_TYPE_SUPERVISOR
+    supervisor = MockModule(index, name, desc, module_type, slot, serial)
+    supervisor.set_midplane_ip()
+    chassis.module_list.append(supervisor)
+
+    #Linecard
+    index = 1
+    name = "LINE-CARD0"
+    desc = "36 port 400G card with 2 ASICs"
+    slot = 1
+    serial = "LC1000101"
+    module_type = ModuleBase.MODULE_TYPE_LINE
+    asic_list = [("4", "0000:04:00.0"), ("5", "0000:05:00.0")]
+    module = MockModule(index, name, desc, module_type, slot, serial, asic_list)
+    module.set_midplane_ip()
+    chassis.module_list.append(module)
+
+    #Run on linecard
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis,
+                                   slot,
+                                   module.supervisor_slot)
+
+    module_updater.modules_num_update()
+    module_updater.check_midplane_reachability()
+    module.set_oper_status(ModuleBase.MODULE_STATUS_ONLINE)
+    module_updater.module_db_update()
+    asic_table = module_updater.asic_table
+    assert len(asic_table.getKeys()) == 2
+
+    # Check CHASSIS_ASIC_TABLE
+    verify_asic("LINE-CARD0|asic4", "0000:04:00.0", name, "0", asic_table)
+    verify_asic("LINE-CARD0|asic5", "0000:05:00.0", name, "1", asic_table)
+
+    # Card goes down and asics should be gone
+    module.set_oper_status(ModuleBase.MODULE_STATUS_OFFLINE)
+    module_updater.module_db_update()
+    assert len(asic_table.getKeys()) == 0
+
+    module.set_oper_status(ModuleBase.MODULE_STATUS_ONLINE)
+    module_updater.module_db_update()
+    assert len(asic_table.getKeys()) == 2
+
+    verify_asic("LINE-CARD0|asic4", "0000:04:00.0", name, "0", asic_table)
+    verify_asic("LINE-CARD0|asic5", "0000:05:00.0", name, "1", asic_table)
+
+    # Check CHASSIS_MODULE_TABLE
+    verify_asic_in_module_table(name, slot, len(asic_list), module_updater.hostname_table)
 
 def test_signal_handler():
     exit_code = 0

--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -268,6 +268,8 @@ class PsuChassisInfo(logger.Logger):
                                   'PSU supplied power warning: {}W supplied-power less than {}W consumed-power'.format(
                                       self.total_supplied_power, self.total_consumed_power)
                                   )
+        if self.first_run:
+            self.first_run = False
 
         return set_led
 

--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -405,9 +405,6 @@ class DaemonPsud(daemon_base.DaemonBase):
         fvs = swsscommon.FieldValuePairs([(CHASSIS_INFO_PSU_NUM_FIELD, str(self.num_psus))])
         self.chassis_tbl.set(CHASSIS_INFO_KEY, fvs)
 
-        # Update predefined position_in_parent and parent_name for PSU
-        self._update_psu_entity_info()
-
     def __del__(self):
         # Delete all the information from DB and then exit
         for psu_index in range(1, self.num_psus + 1):
@@ -437,6 +434,13 @@ class DaemonPsud(daemon_base.DaemonBase):
         if self.stop_event.wait(PSU_INFO_UPDATE_PERIOD_SECS):
             # We received a fatal signal
             return False
+
+        # Update predefined position_in_parent and parent_name for PSU
+        # it was in the __init__ function which means will be run only once
+        # But there's chance that the keys(PHYSICAL_ENTITY_INFO|*) got removed by other processes,
+        # like the exit function during the restart of thermalctld,
+        # hence move it to the iteration run, so the key will be filled again after removed.
+        self._update_psu_entity_info()
 
         self.update_psu_data()
         self._update_led_color()

--- a/sonic-psud/tests/test_PsuChassisInfo.py
+++ b/sonic-psud/tests/test_PsuChassisInfo.py
@@ -76,14 +76,14 @@ class TestPsuChassisInfo(object):
 
         # Test good values while in good state
         ret = chassis_info.update_master_status()
-        assert ret == True
+        assert ret == False
         assert chassis_info.master_status_good == True
 
         # Test unknown total_supplied_power (0.0)
         chassis_info.total_supplied_power = 0.0
         chassis_info.master_status_good = False
         ret = chassis_info.update_master_status()
-        assert ret == True
+        assert ret == False
         assert chassis_info.master_status_good == False
 
         # Test bad values while in good state
@@ -282,6 +282,15 @@ class TestPsuChassisInfo(object):
         assert ret == True
         assert psud.Psu.get_status_master_led() == MockPsu.STATUS_LED_COLOR_RED
 
+        # first time with good power usage
+        chassis_info = psud.PsuChassisInfo(SYSLOG_IDENTIFIER, chassis)
+        chassis_info.total_supplied_power = 510.0
+        chassis_info.total_consumed_power = 350.0
+        ret = chassis_info.update_master_status()
+        assert ret == True
+        assert psud.Psu.get_status_master_led() == MockPsu.STATUS_LED_COLOR_GREEN
+
+        chassis_info = psud.PsuChassisInfo(SYSLOG_IDENTIFIER, chassis)
         chassis_info.total_supplied_power = 510.0
         chassis_info.total_consumed_power = 350.0
         chassis_info.master_status_good = True

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2908,6 +2908,15 @@ class TestXcvrdScript(object):
         mock_chassis.get_sfp = MagicMock(side_effect=NotImplementedError)
         assert not _wrapper_is_flat_memory(1)
 
+    @patch('xcvrd.xcvrd.platform_chassis')
+    def test_wrapper_is_flat_memory_no_xcvr_api(self, mock_chassis):
+        mock_object = MagicMock()
+        mock_object.get_xcvr_api = MagicMock(return_value=None)
+        mock_chassis.get_sfp = MagicMock(return_value=mock_object)
+
+        from xcvrd.xcvrd import _wrapper_is_flat_memory
+        assert _wrapper_is_flat_memory(1) == True
+
     def test_check_port_in_range(self):
         range_str = '1 - 32'
         physical_port = 1

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -225,6 +225,14 @@ class TestXcvrdThreadException(object):
         task.task_worker()
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_READY
 
+        # Case 2.5: get_module_type_abbreviation() returns unsupported module type. In this case, CMIS SM should transition to READY state
+        mock_xcvr_api.is_flat_memory = MagicMock(return_value=False)
+        mock_xcvr_api.get_module_type_abbreviation = MagicMock(return_value='SFP')
+        task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
+        task.on_port_update_event(port_change_event)
+        task.task_worker()
+        assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_READY
+
         # Case 3: get_cmis_application_desired() raises an exception
         mock_xcvr_api.is_flat_memory = MagicMock(return_value=False)
         mock_xcvr_api.is_coherent_module = MagicMock(return_value=False)
@@ -542,6 +550,17 @@ class TestXcvrdScript(object):
         dom_tbl = Table("STATE_DB", TRANSCEIVER_DOM_SENSOR_TABLE)
         transceiver_dict = {}
         post_port_sfp_info_to_db(logical_port_name, port_mapping, dom_tbl, transceiver_dict, stop_event)
+
+    @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=False))
+    def test_post_port_sfp_info_to_db_with_sfp_not_present(self):
+        logical_port_name = "Ethernet0"
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        intf_tbl = Table("STATE_DB", TRANSCEIVER_INFO_TABLE)
+        transceiver_dict = {}
+        post_port_sfp_info_to_db(logical_port_name, port_mapping, intf_tbl , transceiver_dict, stop_event)
+        assert xcvrd._wrapper_get_presence.call_count == 1
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd.platform_sfputil', MagicMock(return_value=[0]))
@@ -1868,6 +1887,36 @@ class TestXcvrdScript(object):
                 'DP8State': 'DataPathDeactivated'
             },
             {
+                'DP1State': 'DataPathDeactivated',
+                'DP2State': 'DataPathDeactivated',
+                'DP3State': 'DataPathDeactivated',
+                'DP4State': 'DataPathDeactivated',
+                'DP5State': 'DataPathDeactivated',
+                'DP6State': 'DataPathDeactivated',
+                'DP7State': 'DataPathDeactivated',
+                'DP8State': 'DataPathDeactivated'
+            },
+            {
+                'DP1State': 'DataPathDeactivated',
+                'DP2State': 'DataPathDeactivated',
+                'DP3State': 'DataPathDeactivated',
+                'DP4State': 'DataPathDeactivated',
+                'DP5State': 'DataPathDeactivated',
+                'DP6State': 'DataPathDeactivated',
+                'DP7State': 'DataPathDeactivated',
+                'DP8State': 'DataPathDeactivated'
+            },
+            {
+                'DP1State': 'DataPathDeactivated',
+                'DP2State': 'DataPathDeactivated',
+                'DP3State': 'DataPathDeactivated',
+                'DP4State': 'DataPathDeactivated',
+                'DP5State': 'DataPathDeactivated',
+                'DP6State': 'DataPathDeactivated',
+                'DP7State': 'DataPathDeactivated',
+                'DP8State': 'DataPathDeactivated'
+            },
+            {
                 'DP1State': 'DataPathInitialized',
                 'DP2State': 'DataPathInitialized',
                 'DP3State': 'DataPathInitialized',
@@ -1876,6 +1925,46 @@ class TestXcvrdScript(object):
                 'DP6State': 'DataPathInitialized',
                 'DP7State': 'DataPathInitialized',
                 'DP8State': 'DataPathInitialized'
+            },
+            {
+                'DP1State': 'DataPathInitialized',
+                'DP2State': 'DataPathInitialized',
+                'DP3State': 'DataPathInitialized',
+                'DP4State': 'DataPathInitialized',
+                'DP5State': 'DataPathInitialized',
+                'DP6State': 'DataPathInitialized',
+                'DP7State': 'DataPathInitialized',
+                'DP8State': 'DataPathInitialized'
+            },
+            {
+                'DP1State': 'DataPathInitialized',
+                'DP2State': 'DataPathInitialized',
+                'DP3State': 'DataPathInitialized',
+                'DP4State': 'DataPathInitialized',
+                'DP5State': 'DataPathInitialized',
+                'DP6State': 'DataPathInitialized',
+                'DP7State': 'DataPathInitialized',
+                'DP8State': 'DataPathInitialized'
+            },
+            {
+                'DP1State': 'DataPathInitialized',
+                'DP2State': 'DataPathInitialized',
+                'DP3State': 'DataPathInitialized',
+                'DP4State': 'DataPathInitialized',
+                'DP5State': 'DataPathInitialized',
+                'DP6State': 'DataPathInitialized',
+                'DP7State': 'DataPathInitialized',
+                'DP8State': 'DataPathInitialized'
+            },
+            {
+                'DP1State': 'DataPathActivated',
+                'DP2State': 'DataPathActivated',
+                'DP3State': 'DataPathActivated',
+                'DP4State': 'DataPathActivated',
+                'DP5State': 'DataPathActivated',
+                'DP6State': 'DataPathActivated',
+                'DP7State': 'DataPathActivated',
+                'DP8State': 'DataPathActivated'
             },
             {
                 'DP1State': 'DataPathActivated',

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -64,6 +64,32 @@ with open(os.path.join(test_path, 'media_settings_extended_format.json'), 'r') a
     media_settings_extended_format_dict = json.load(f)
 
 
+# Define some example keys/values of media_settings.json for testing purposes
+asic_serdes_si_value_dict = {'lane' + str(i): '0x0000000d' for i in range(4)}
+asic_serdes_si_value_dict2 = {'lane' + str(i): '0x0000000a' for i in range(4)}
+asic_serdes_si_value_dict3 = {'lane' + str(i): '0x0000000b' for i in range(8)}
+asic_serdes_si_value_dict4 = {'lane' + str(i): '0x00000003' for i in range(8)}
+asic_serdes_si_value_dict5 = {'lane' + str(i): '0x00000004' for i in range(8)}
+asic_serdes_si_settings_example = {
+    'idriver': asic_serdes_si_value_dict,
+    'pre1': asic_serdes_si_value_dict,
+    'ob_m2lp': asic_serdes_si_value_dict,
+}
+asic_serdes_si_settings_example2 = {'idriver': asic_serdes_si_value_dict2}
+asic_serdes_si_settings_example3 = {'main': asic_serdes_si_value_dict3}
+asic_serdes_si_settings_example4 = {'main': asic_serdes_si_value_dict4}
+asic_serdes_si_settings_example5 = {'idriver': asic_serdes_si_value_dict5}
+asic_serdes_si_settings_example3_expected_value_in_db = \
+    {attr: ','.join(value_dict.values()) for attr, value_dict in asic_serdes_si_settings_example3.items()}
+asic_serdes_si_settings_example3_expected_value_in_db_4_lanes = \
+    {attr: ','.join(list(value_dict.values())[:4]) for attr, value_dict in asic_serdes_si_settings_example3.items()}
+asic_serdes_si_settings_example4_expected_value_in_db = \
+    {attr: ','.join(list(value_dict.values())) for attr, value_dict in asic_serdes_si_settings_example4.items()}
+asic_serdes_si_settings_example4_expected_value_in_db_4_lanes = \
+    {attr: ','.join(list(value_dict.values())[:4]) for attr, value_dict in asic_serdes_si_settings_example4.items()}
+asic_serdes_si_settings_example5_expected_value_in_db = \
+    {attr: ','.join(value_dict.values()) for attr, value_dict in asic_serdes_si_settings_example5.items()}
+
 # Creating instances of media_settings.json for testing purposes
 # Each instance represents a different possible structure for media_settings.json.
 media_settings_global_range_media_key_lane_speed_si = copy.deepcopy(media_settings_extended_format_dict)
@@ -102,7 +128,7 @@ media_settings_global_list_of_ranges_media_key_si = copy.deepcopy(media_settings
 media_settings_global_list_of_ranges_media_key_si['GLOBAL_MEDIA_SETTINGS']['0-15,16-31'] = media_settings_global_list_of_ranges_media_key_si['GLOBAL_MEDIA_SETTINGS'].pop('0-31')
 
 media_settings_global_list_of_ranges_media_key_lane_speed_si_with_default_section = copy.deepcopy(media_settings_extended_format_dict)
-media_settings_global_list_of_ranges_media_key_lane_speed_si_with_default_section['GLOBAL_MEDIA_SETTINGS']['0-31']['Default'] = {'speed:400GAUI-8': {'idriver': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'pre1': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'ob_m2lp': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}}}
+media_settings_global_list_of_ranges_media_key_lane_speed_si_with_default_section['GLOBAL_MEDIA_SETTINGS']['0-31']['Default'] = asic_serdes_si_settings_example
 
 media_settings_port_media_key_lane_speed_si = copy.deepcopy(media_settings_extended_format_dict)
 media_settings_port_media_key_lane_speed_si['PORT_MEDIA_SETTINGS'] = {'7': media_settings_port_media_key_lane_speed_si['GLOBAL_MEDIA_SETTINGS'].pop('0-31')}
@@ -134,11 +160,37 @@ media_settings_port_generic_vendor_key_si['PORT_MEDIA_SETTINGS']['7']['GENERIC_V
 
 media_settings_global_default_port_media_key_lane_speed_si = copy.deepcopy(media_settings_extended_format_dict)
 port_media_settings_data = {'7': media_settings_global_default_port_media_key_lane_speed_si['GLOBAL_MEDIA_SETTINGS'].pop('0-31')}
-media_settings_global_default_port_media_key_lane_speed_si['GLOBAL_MEDIA_SETTINGS'] = {'0-31': {'Default': {'speed:400GAUI-8': {'idriver': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'pre1': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'ob_m2lp': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}}}}}
+media_settings_global_default_port_media_key_lane_speed_si['GLOBAL_MEDIA_SETTINGS'] = {'0-31': {'Default': asic_serdes_si_settings_example}}
 media_settings_global_default_port_media_key_lane_speed_si['PORT_MEDIA_SETTINGS'] = port_media_settings_data
 
 media_settings_port_default_media_key_lane_speed_si = copy.deepcopy(media_settings_port_media_key_lane_speed_si)
-media_settings_port_default_media_key_lane_speed_si['PORT_MEDIA_SETTINGS']['7']['Default'] = {'speed:400GAUI-8': {'idriver': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'pre1': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'ob_m2lp': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}}}
+media_settings_port_default_media_key_lane_speed_si['PORT_MEDIA_SETTINGS']['7']['Default'] = {
+    LANE_SPEED_DEFAULT_KEY: asic_serdes_si_settings_example,
+    'speed:400GAUI-8': asic_serdes_si_settings_example2,
+}
+
+media_settings_optic_copper_si = {
+    'GLOBAL_MEDIA_SETTINGS': {
+        '0-31': {
+            '(SFP|QSFP(\\+|28|-DD)*)-(?!.*((40|100)GBASE-CR|100G ACC|Active Copper Cable|passive_copper_media_interface)).*': {
+                'speed:400GAUI-8': asic_serdes_si_settings_example4,
+                'speed:200GAUI-8|100GAUI-4|50GAUI-2|25G': asic_serdes_si_settings_example3,
+            },
+            '(SFP|QSFP(\\+|28|-DD)*)-((40|100)GBASE-CR|100G ACC|Active Copper Cable|passive_copper_media_interface).*': {
+                'speed:400GAUI-8|200GAUI-4|100GAUI-2': asic_serdes_si_settings_example3,
+                'speed:25G': asic_serdes_si_settings_example4,
+                LANE_SPEED_DEFAULT_KEY: asic_serdes_si_settings_example5,
+            },
+        },
+        '32-63': {
+            'INNOLIGHT': asic_serdes_si_settings_example5,
+            'Default': {
+                'speed:400GAUI-8': asic_serdes_si_settings_example3,
+                LANE_SPEED_DEFAULT_KEY: asic_serdes_si_settings_example4,
+            }
+        },
+    }
+}
 
 media_settings_empty = {}
 
@@ -687,13 +739,43 @@ class TestXcvrdScript(object):
 
         # Test a good 'specification_compliance' value
         result = media_settings_parser.get_media_settings_key(0, xcvr_info_dict, 100000, 2)
-        assert result == { 'vendor_key': 'MOLEX-1064141421', 'media_key': 'QSFP+-10GBase-SR-255M', 'lane_speed_key': None }
+        assert result == { 'vendor_key': 'MOLEX-1064141421', 'media_key': 'QSFP+-10GBase-SR-255M', 'lane_speed_key': 'speed:50G'}
 
         # Test a bad 'specification_compliance' value
         xcvr_info_dict[0]['specification_compliance'] = 'N/A'
         result = media_settings_parser.get_media_settings_key(0, xcvr_info_dict, 100000, 2)
-        assert result == { 'vendor_key': 'MOLEX-1064141421', 'media_key': 'QSFP+-*', 'lane_speed_key': None }
+        assert result == { 'vendor_key': 'MOLEX-1064141421', 'media_key': 'QSFP+-*', 'lane_speed_key': 'speed:50G'}
         # TODO: Ensure that error message was logged
+
+        xcvr_info_dict_for_qsfp28 = {
+            0: {
+                "type": "QSFP28 or later",
+                "type_abbrv_name": "QSFP28",
+                "vendor_rev": "05",
+                "serial": "AAABBBCCCDDD",
+                "manufacturer": "AVAGO",
+                "model": "XXX-YYY-ZZZ",
+                "connector": "MPO 1x12",
+                "encoding": "64B/66B",
+                "ext_identifier": "Power Class 4 Module (3.5W max.), CLEI code present in Page 02h, CDR present in TX, CDR present in RX",
+                "ext_rateselect_compliance": "Unknown",
+                "cable_type": "Length Cable Assembly(m)",
+                "cable_length": 50.0,
+                "nominal_bit_rate": 255,
+                "specification_compliance": "{'10/40G Ethernet Compliance Code': 'Unknown', 'SONET Compliance Codes': 'Unknown', 'SAS/SATA Compliance Codes': 'Unknown', 'Gigabit Ethernet Compliant Codes': 'Unknown', 'Fibre Channel Link Length': 'Unknown', 'Fibre Channel Transmitter Technology': 'Unknown', 'Fibre Channel Transmission Media': 'Unknown', 'Fibre Channel Speed': 'Unknown', 'Extended Specification Compliance': '100GBASE-SR4 or 25GBASE-SR'}",
+                "vendor_date": "2020-11-11",
+                "vendor_oui": "00-77-7a",
+                "application_advertisement": "N/A",
+            }
+        }
+        result = media_settings_parser.get_media_settings_key(
+            0, xcvr_info_dict_for_qsfp28, 100000, 4
+        )
+        assert result == {
+            "vendor_key": "AVAGO-XXX-YYY-ZZZ",
+            "media_key": "QSFP28-100GBASE-SR4 or 25GBASE-SR-50.0M",
+            "lane_speed_key": "speed:25G",
+        }
 
         mock_is_cmis_api.return_value = True
         xcvr_info_dict = {
@@ -723,17 +805,18 @@ class TestXcvrdScript(object):
         assert result == { 'vendor_key': 'MOLEX-1064141421', 'media_key': 'QSFP-DD-sm_media_interface', 'lane_speed_key': 'speed:100GBASE-CR2' }
 
     @pytest.mark.parametrize("data_found, data, expected", [
-        (True, [('speed', '400000'), ('lanes', '1,2,3,4,5,6,7,8'), ('mtu', '9100')], ('400000', 8)),
-        (True, [('lanes', '1,2,3,4,5,6,7,8'), ('mtu', '9100')], ('0', 0)),
-        (True, [('speed', '400000'), ('mtu', '9100')], ('0', 0)),
-        (False, [], ('0', 0))
+        (True, [('speed', '400000'), ('lanes', '1,2,3,4,5,6,7,8'), ('mtu', '9100')], (400000, 8, 0)),
+        (True, [('speed', '25000'), ('lanes', '1'), ('mtu', '9100'), ('subport', '1')], (25000, 1, 1)),
+        (True, [('lanes', '1,2,3,4,5,6,7,8'), ('mtu', '9100')], (0, 0, 0)),
+        (True, [('speed', '400000'), ('mtu', '9100')], (0, 0, 0)),
+        (False, [], (0, 0, 0))
     ])
-    def test_get_speed_and_lane_count(self, data_found, data, expected):
+    def test_get_speed_lane_count_and_subport(self, data_found, data, expected):
         cfg_port_tbl = MagicMock()
         cfg_port_tbl.get = MagicMock(return_value=(data_found, data))
         port = MagicMock()
 
-        assert media_settings_parser.get_speed_and_lane_count(port, cfg_port_tbl) == expected
+        assert media_settings_parser.get_speed_lane_count_and_subport(port, cfg_port_tbl) == expected
 
     def test_is_si_per_speed_supported(self):
         media_dict = {
@@ -804,7 +887,7 @@ class TestXcvrdScript(object):
     (media_settings_global_list_media_key_si, 7, {'vendor_key': 'UNKOWN', 'media_key': 'QSFP-DD-active_cable_media_interface', 'lane_speed_key': 'UNKOWN'}, {'pre1': {'lane0': '0x00000002', 'lane1': '0x00000002'}, 'main': {'lane0': '0x00000020', 'lane1': '0x00000020'}, 'post1': {'lane0': '0x00000006', 'lane1': '0x00000006'}, 'regn_bfm1n': {'lane0': '0x000000aa', 'lane1': '0x000000aa'}}),
     (media_settings_global_list_of_ranges_media_key_lane_speed_si, 7, {'vendor_key': 'UNKOWN', 'media_key': 'QSFP-DD-active_cable_media_interface', 'lane_speed_key': 'speed:100GAUI-2'}, {'pre1': {'lane0': '0x00000002', 'lane1': '0x00000002'}, 'main': {'lane0': '0x00000020', 'lane1': '0x00000020'}, 'post1': {'lane0': '0x00000006', 'lane1': '0x00000006'}, 'regn_bfm1n': {'lane0': '0x000000aa', 'lane1': '0x000000aa'}}),
     (media_settings_global_list_of_ranges_media_key_si, 7, {'vendor_key': 'UNKOWN', 'media_key': 'QSFP-DD-active_cable_media_interface', 'lane_speed_key': 'UNKOWN'}, {'pre1': {'lane0': '0x00000002', 'lane1': '0x00000002'}, 'main': {'lane0': '0x00000020', 'lane1': '0x00000020'}, 'post1': {'lane0': '0x00000006', 'lane1': '0x00000006'}, 'regn_bfm1n': {'lane0': '0x000000aa', 'lane1': '0x000000aa'}}),
-    (media_settings_global_default_port_media_key_lane_speed_si, 6, {'vendor_key': 'AMPHANOL-5678', 'media_key': 'UNKOWN', 'lane_speed_key': 'speed:100GAUI-2'}, {'speed:400GAUI-8': {'idriver': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'pre1': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'ob_m2lp': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}}}),
+    (media_settings_global_default_port_media_key_lane_speed_si, 6, {'vendor_key': 'AMPHANOL-5678', 'media_key': 'UNKOWN', 'lane_speed_key': 'speed:100GAUI-2'}, asic_serdes_si_settings_example),
     (media_settings_port_vendor_key_lane_speed_si, -1, {'vendor_key': 'AMPHANOL-5678', 'media_key': 'UNKOWN', 'lane_speed_key': 'speed:100GAUI-2'}, {}),
     (media_settings_port_media_key_lane_speed_si, 7, {'vendor_key': 'UNKOWN', 'media_key': 'QSFP-DD-active_cable_media_interface', 'lane_speed_key': 'speed:100GAUI-2'}, {'pre1': {'lane0': '0x00000002', 'lane1': '0x00000002'}, 'main': {'lane0': '0x00000020', 'lane1': '0x00000020'}, 'post1': {'lane0': '0x00000006', 'lane1': '0x00000006'}, 'regn_bfm1n': {'lane0': '0x000000aa', 'lane1': '0x000000aa'}}),
     (media_settings_port_media_key_lane_speed_si, 7, {'vendor_key': 'UNKOWN', 'media_key': 'QSFP-DD-active_cable_media_interface', 'lane_speed_key': 'MISSING'}, {}),
@@ -815,9 +898,9 @@ class TestXcvrdScript(object):
     (media_settings_port_generic_vendor_key_lane_speed_si, 7, {'vendor_key': 'GENERIC_VENDOR-1234', 'media_key': 'UNKOWN', 'lane_speed_key': 'MISSING'}, {}),
     (media_settings_port_vendor_key_si, 7, {'vendor_key': 'AMPHANOL-5678', 'media_key': 'UNKOWN', 'lane_speed_key': 'UNKOWN'}, {'pre1': {'lane0': '0x00000002', 'lane1': '0x00000002'}, 'main': {'lane0': '0x00000020', 'lane1': '0x00000020'}, 'post1': {'lane0': '0x00000006', 'lane1': '0x00000006'}, 'regn_bfm1n': {'lane0': '0x000000aa', 'lane1': '0x000000aa'}}),
     (media_settings_port_generic_vendor_key_si, 7, {'vendor_key': 'GENERIC_VENDOR-1234', 'media_key': 'UNKOWN', 'lane_speed_key': 'UNKOWN'}, {'pre1': {'lane0': '0x00000002', 'lane1': '0x00000002'}, 'main': {'lane0': '0x00000020', 'lane1': '0x00000020'}, 'post1': {'lane0': '0x00000006', 'lane1': '0x00000006'}, 'regn_bfm1n': {'lane0': '0x000000aa', 'lane1': '0x000000aa'}}),
-    (media_settings_port_default_media_key_lane_speed_si, 7, {'vendor_key': 'MISSING', 'media_key': 'MISSING', 'lane_speed_key': 'MISSING'}, {'speed:400GAUI-8': {'idriver': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'pre1': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'ob_m2lp': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}}}),
-    (media_settings_global_default_port_media_key_lane_speed_si, 7, {'vendor_key': 'MISSING', 'media_key': 'MISSING', 'lane_speed_key': 'MISSING'}, {'speed:400GAUI-8': {'idriver': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'pre1': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'ob_m2lp': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}}}),
-    (media_settings_global_list_of_ranges_media_key_lane_speed_si_with_default_section, 7, {'vendor_key': 'MISSING', 'media_key': 'MISSING', 'lane_speed_key': 'MISSING'}, {'speed:400GAUI-8': {'idriver': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'pre1': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'ob_m2lp': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}}}),
+    (media_settings_port_default_media_key_lane_speed_si, 7, {'vendor_key': 'MISSING', 'media_key': 'MISSING', 'lane_speed_key': 'MISSING'}, asic_serdes_si_settings_example),
+    (media_settings_global_default_port_media_key_lane_speed_si, 7, {'vendor_key': 'MISSING', 'media_key': 'MISSING', 'lane_speed_key': 'MISSING'}, asic_serdes_si_settings_example),
+    (media_settings_global_list_of_ranges_media_key_lane_speed_si_with_default_section, 7, {'vendor_key': 'MISSING', 'media_key': 'MISSING', 'lane_speed_key': 'MISSING'}, asic_serdes_si_settings_example),
     (media_settings_empty, 7, {'vendor_key': 'AMPHANOL-5678', 'media_key': 'QSFP-DD-active_cable_media_interface', 'lane_speed_key': 'speed:100GAUI-2'}, {}),
     (media_settings_with_regular_expression_dict, 7, {'vendor_key': 'UNKOWN', 'media_key': 'QSFP28-40GBASE-CR4-1M', 'lane_speed_key': 'UNKOWN'}, {'preemphasis': {'lane0': '0x16440A', 'lane1': '0x16440A', 'lane2': '0x16440A', 'lane3': '0x16440A'}}),
     (media_settings_with_regular_expression_dict, 7, {'vendor_key': 'UNKOWN', 'media_key': 'QSFP+-40GBASE-CR4-2M', 'lane_speed_key': 'UNKOWN'}, {'preemphasis': {'lane0': '0x18420A', 'lane1': '0x18420A', 'lane2': '0x18420A', 'lane3': '0x18420A'}}),
@@ -828,26 +911,65 @@ class TestXcvrdScript(object):
             result = media_settings_parser.get_media_settings_value(port, key)
             assert result == expected
 
-    @patch('xcvrd.xcvrd.g_dict', media_settings_dict)
     @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_cfg_port_tbl', MagicMock())
-    @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_media_settings_key', MagicMock(return_value={ 'vendor_key': 'MOLEX-1064141421', 'media_key': 'QSFP+-10GBase-SR-255M', 'lane_speed_key': 'speed:100GBASE-CR2' }))
-    @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_speed_and_lane_count', MagicMock(return_value=(100000, 2)))
+    @patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict', media_settings_optic_copper_si)
+    @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_media_settings_key',
+           MagicMock(return_value={'vendor_key': 'INNOLIGHT-X-DDDDD-NNN', 'media_key': 'QSFP-DD-sm_media_interface', 'lane_speed_key': 'speed:400GAUI-8'}))
+    @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_speed_lane_count_and_subport', MagicMock(return_value=(400000, 8, 0)))
     def test_notify_media_setting(self):
-        self._check_notify_media_setting(1)
+        # Test matching 400G optical transceiver (lane speed 50G)
+        self._check_notify_media_setting(1, True, asic_serdes_si_settings_example4_expected_value_in_db)
 
-    @patch('xcvrd.xcvrd.g_dict', media_settings_with_comma_dict)
+        # Test matching 100G optical transceiver (lane speed 25G), via regular expression lane speed pattern
+        with patch.multiple('xcvrd.xcvrd_utilities.media_settings_parser',
+                            get_media_settings_key=MagicMock(return_value={'vendor_key':'INNOLIGHT-X-DDDDD-NNN', 'media_key': 'QSFP28-100GBASE-SR4', 'lane_speed_key': 'speed:25G'}),
+                            get_speed_lane_count_and_subport=MagicMock(return_value=(100000, 4, 0))):
+            self._check_notify_media_setting(1, True, asic_serdes_si_settings_example3_expected_value_in_db_4_lanes)
+
+        # Test matching 100G copper transceiver (lane speed 25G)
+        with patch.multiple('xcvrd.xcvrd_utilities.media_settings_parser',
+                            get_media_settings_key=MagicMock(return_value={'vendor_key':'INNOLIGHT-X-DDDDD-NNN', 'media_key': 'QSFP28-100GBASE-CR4, 25GBASE-CR CA-25G-L or 50GBASE-CR2 with RS-1.0M', 'lane_speed_key': 'speed:25G'}),
+                            get_speed_lane_count_and_subport=MagicMock(return_value=(100000, 4, 0))):
+            self._check_notify_media_setting(1, True, asic_serdes_si_settings_example4_expected_value_in_db_4_lanes)
+
+        # Test with lane speed None
+        with patch.multiple('xcvrd.xcvrd_utilities.media_settings_parser',
+                            get_media_settings_key=MagicMock(return_value={'vendor_key':'INNOLIGHT-X-DDDDD-NNN', 'media_key': 'QSFP28-100GBASE-CR4', 'lane_speed_key': None}),
+                            get_speed_lane_count_and_subport=MagicMock(return_value=(100000, 4, 0))):
+            self._check_notify_media_setting(1)
+
+        # Test default value in the case of no matched lane speed for 800G copper transceiver (lane speed 100G)
+        with patch.multiple('xcvrd.xcvrd_utilities.media_settings_parser',
+                            get_media_settings_key=MagicMock(return_value={'vendor_key':'INNOLIGHT-X-DDDDD-NNN', 'media_key': 'QSFP-DD-passive_copper_media_interface', 'lane_speed_key': 'speed:800G-ETC-CR8'}),
+                            get_speed_lane_count_and_subport=MagicMock(return_value=(800000, 8, 0))):
+            self._check_notify_media_setting(1, True, asic_serdes_si_settings_example5_expected_value_in_db)
+
+        # Test lane speed matching under 'Default' vendor/media for 400G transceiver (lane speed 50G)
+        with patch.multiple('xcvrd.xcvrd_utilities.media_settings_parser',
+                            get_media_settings_key=MagicMock(return_value={'vendor_key':'Molex', 'media_key': 'QSFP-DD-passive_copper_media_interface', 'lane_speed_key': 'speed:400GAUI-8'}),
+                            get_speed_lane_count_and_subport=MagicMock(return_value=(400000, 8, 0))):
+            self._check_notify_media_setting(41, True, asic_serdes_si_settings_example3_expected_value_in_db)
+
+        # Test with empty xcvr_info_dict
+        self._check_notify_media_setting(1, False, None, {})
+
+        # Test with sfp not present
+        with patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=False)):
+            self._check_notify_media_setting(1)
+
     @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_cfg_port_tbl', MagicMock())
+    @patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict', media_settings_with_comma_dict)
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_media_settings_key', MagicMock(return_value={ 'vendor_key': 'MOLEX-1064141421', 'media_key': 'QSFP+-10GBase-SR-255M', 'lane_speed_key': 'speed:100GBASE-CR2' }))
-    @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_speed_and_lane_count', MagicMock(return_value=(100000, 2)))
+    @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_speed_lane_count_and_subport', MagicMock(return_value=(100000, 2, 0)))
     def test_notify_media_setting_with_comma(self):
-        self._check_notify_media_setting(1)
-        self._check_notify_media_setting(6)
+        self._check_notify_media_setting(1, True, {'preemphasis': ','.join(['0x164509'] * 2)})
+        self._check_notify_media_setting(6, True, {'preemphasis': ','.join(['0x124A08'] * 2)})
 
-    def _check_notify_media_setting(self, index):
+    def _check_notify_media_setting(self, index, expected_found=False, expected_value=None, xcvr_info_dict=None):
         xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         cfg_port_tbl = MagicMock()
         mock_cfg_table = xcvr_table_helper.get_cfg_port_tbl = MagicMock(return_value=cfg_port_tbl)
@@ -862,12 +984,16 @@ class TestXcvrdScript(object):
                 'specification_compliance': "{'10/40G Ethernet Compliance Code': '10GBase-SR'}",
                 'type_abbrv_name': 'QSFP+'
             }
-        }
+        } if xcvr_info_dict is None else xcvr_info_dict
         app_port_tbl = Table("APPL_DB", 'PORT_TABLE')
         port_mapping = PortMapping()
         port_change_event = PortChangeEvent('Ethernet0', index, 0, PortChangeEvent.PORT_ADD)
         port_mapping.handle_port_change_event(port_change_event)
         media_settings_parser.notify_media_setting(logical_port_name, xcvr_info_dict, app_port_tbl, mock_cfg_table, port_mapping)
+        found, result = app_port_tbl.get(logical_port_name)
+        result_dict = dict(result) if result else None
+        assert found == expected_found
+        assert result_dict == expected_value
 
     @patch('xcvrd.xcvrd_utilities.optics_si_parser.g_optics_si_dict', optics_si_settings_dict)
     @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))
@@ -883,7 +1009,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd_utilities.optics_si_parser.g_optics_si_dict', port_optics_si_settings)
     @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))
     def test_fetch_optics_si_setting_with_port(self):
-       self._check_fetch_optics_si_setting(1)
+        self._check_fetch_optics_si_setting(1)
 
     @patch('xcvrd.xcvrd_utilities.optics_si_parser.g_optics_si_dict', port_optics_si_settings)
     @patch('xcvrd.xcvrd_utilities.optics_si_parser.get_module_vendor_key', MagicMock(return_value=(None, None)))
@@ -930,7 +1056,6 @@ class TestXcvrdScript(object):
 
         assert not is_error_block_eeprom_reading(int(SFP_STATUS_INSERTED))
         assert not is_error_block_eeprom_reading(int(SFP_STATUS_REMOVED))
-
 
     @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
     @patch('swsscommon.swsscommon.Table')
@@ -983,7 +1108,6 @@ class TestXcvrdScript(object):
         assert observer.handle_port_update_event()
         assert len(port_change_event_handler.port_event_cache) == 2
         assert list(observer.port_event_cache.keys()) == [('Ethernet0', CONFIG_DB, PORT_TABLE), ('Ethernet16', CONFIG_DB, PORT_TABLE)]
-
 
     @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
     @patch('swsscommon.swsscommon.SubscriberStateTable')
@@ -1517,7 +1641,6 @@ class TestXcvrdScript(object):
         task.on_port_update_event(port_change_event)
         assert len(task.port_dict) == 1
 
-
     @patch('xcvrd.xcvrd.XcvrTableHelper')
     def test_CmisManagerTask_get_configured_freq(self, mock_table_helper):
         port_mapping = PortMapping()
@@ -1809,7 +1932,6 @@ class TestXcvrdScript(object):
         host_lanes_mask = 0xf
         ret = task.post_port_active_apsel_to_db(mock_xcvr_api, lport, host_lanes_mask)
         assert int_tbl.getKeys() == []
-
 
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_status_tbl')
     @patch('xcvrd.xcvrd.platform_chassis')
@@ -2220,7 +2342,6 @@ class TestXcvrdScript(object):
         task.task_worker()
 
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_READY
-
 
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_status_tbl')
     @patch('xcvrd.xcvrd.platform_chassis')
@@ -3030,21 +3151,40 @@ class TestXcvrdScript(object):
         physical_port = 33
         assert not check_port_in_range(range_str, physical_port)
 
-    def test_get_media_val_str_from_dict(self):
-        media_dict = {'lane0': '1', 'lane1': '2'}
-        media_str = media_settings_parser.get_media_val_str_from_dict(media_dict)
-        assert media_str == '1,2'
-
-    def test_get_media_val_str(self):
-        num_logical_ports = 1
+    def test_get_serdes_si_setting_val_str(self):
         lane_dict = {'lane0': '1', 'lane1': '2', 'lane2': '3', 'lane3': '4'}
-        logical_idx = 1
-        media_str = get_media_val_str(num_logical_ports, lane_dict, logical_idx)
+        # non-breakout case
+        lane_count = 4
+        subport_num = 0
+        media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
         assert media_str == '1,2,3,4'
-        num_logical_ports = 2
-        logical_idx = 1
-        media_str = get_media_val_str(num_logical_ports, lane_dict, logical_idx)
+        # breakout case
+        lane_count = 2
+        subport_num = 2
+        media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
         assert media_str == '3,4'
+        # breakout case without subport number specified in config
+        lane_count = 2
+        subport_num = 0
+        media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
+        assert media_str == '1,2'
+        # breakout case with out-of-range subport number
+        lane_count = 2
+        subport_num = 3
+        media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
+        assert media_str == '1,2'
+        # breakout case with smaler lane_dict
+        lane_dict = {'lane0': '1', 'lane1': '2'}
+        lane_count = 2
+        subport_num = 2
+        media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
+        assert media_str == '1,2'
+        # lane key-value pair inserted in non-asceding order
+        lane_dict = {'lane0': 'a', 'lane2': 'c', 'lane1': 'b', 'lane3': 'd'}
+        lane_count = 2
+        subport_num = 2
+        media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
+        assert media_str == 'c,d'
 
     class MockPortMapping:
         logical_port_list = [0, 1, 2]
@@ -3100,7 +3240,7 @@ class TestXcvrdScript(object):
             xcvrdaemon.deinit()
 
             status_tbl.hdel.assert_called()
-            
+
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=(test_path, '/invalid/path')))
     def test_load_optical_si_file_from_platform_folder(self):
         assert optics_si_parser.load_optics_si_settings() != {}
@@ -3116,7 +3256,7 @@ class TestXcvrdScript(object):
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/invalid/path', test_path)))
     def test_load_media_settings_file_from_hwsku_folder(self):
         assert media_settings_parser.load_media_settings() != {}
-        
+
     @pytest.mark.parametrize("lport, freq, grid, expected", [
          (1, 193100, 75, True),
          (1, 193100, 100, False),

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1667,6 +1667,29 @@ class TestXcvrdScript(object):
         appl = get_cmis_application_desired(mock_xcvr_api, host_lane_count, speed)
         assert task.get_cmis_host_lanes_mask(mock_xcvr_api, appl, host_lane_count, subport) == expected
 
+    @patch('swsscommon.swsscommon.FieldValuePairs')
+    def test_CmisManagerTask_post_port_active_apsel_to_db_error_cases(self, mock_field_value_pairs):
+        mock_xcvr_api = MagicMock()
+        mock_xcvr_api.get_active_apsel_hostlane = MagicMock()
+        mock_xcvr_api.get_application_advertisement = MagicMock()
+
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
+        lport = "Ethernet0"
+        host_lanes_mask = 0xff
+
+        # Case: table does not exist
+        task.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=None)
+        task.post_port_active_apsel_to_db(mock_xcvr_api, lport, host_lanes_mask)
+        assert mock_field_value_pairs.call_count == 0
+
+        # Case: lport is not in the table
+        int_tbl = MagicMock()
+        int_tbl.get = MagicMock(return_value=(False, dict))
+        task.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=int_tbl)
+        task.post_port_active_apsel_to_db(mock_xcvr_api, lport, host_lanes_mask)
+        assert mock_field_value_pairs.call_count == 0
 
     def test_CmisManagerTask_post_port_active_apsel_to_db(self):
         mock_xcvr_api = MagicMock()
@@ -1709,6 +1732,7 @@ class TestXcvrdScript(object):
         ])
 
         int_tbl = Table("STATE_DB", TRANSCEIVER_INFO_TABLE)
+        int_tbl.get = MagicMock(return_value=(True, dict))
 
         port_mapping = PortMapping()
         stop_event = threading.Event()

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -302,7 +302,7 @@ class TestXcvrdThreadException(object):
         port_mapping = PortMapping()
         stop_event = threading.Event()
         mock_cmis_manager = MagicMock()
-        dom_info_update = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, mock_cmis_manager)
+        dom_info_update = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, mock_cmis_manager, helper_logger)
         exception_received = None
         trace = None
         try:
@@ -315,7 +315,7 @@ class TestXcvrdThreadException(object):
         assert not dom_info_update.is_alive()
         assert(type(exception_received) == NotImplementedError)
         assert("NotImplementedError" in str(trace) and "effect" in str(trace))
-        assert("sonic-xcvrd/xcvrd/xcvrd.py" in str(trace))
+        assert("sonic-xcvrd/xcvrd/dom_mgr.py" in str(trace))
         assert("subscribe_port_config_change" in str(trace))
 
     @patch('xcvrd.xcvrd.SfpStateUpdateTask.init', MagicMock())
@@ -414,9 +414,10 @@ class TestXcvrdScript(object):
         assert xcvr_table_helper.is_npu_si_settings_update_required("Ethernet0", port_mapping)
         assert not xcvr_table_helper.is_npu_si_settings_update_required("Ethernet0", port_mapping)
 
+    @patch('xcvrd.xcvrd._wrapper_is_flat_memory')
+    @patch('xcvrd.xcvrd._wrapper_get_presence')
     @patch('xcvrd.xcvrd._wrapper_get_sfp_type')
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
-    @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd._wrapper_get_transceiver_dom_info', MagicMock(return_value={'temperature': '22.75',
                                                                                     'voltage': '0.5',
                                                                                     'rx1power': '0.7',
@@ -443,26 +444,50 @@ class TestXcvrdScript(object):
                                                                                     'tx6power': '0.7',
                                                                                     'tx7power': '0.7',
                                                                                     'tx8power': '0.7', }))
-    def test_post_port_dom_info_to_db(self, mock_get_sfp_type):
+    def test_post_port_dom_info_to_db(self, mock_get_sfp_type, mock_get_presence, mock_is_flat_memory):
         logical_port_name = "Ethernet0"
         port_mapping = PortMapping()
         stop_event = threading.Event()
+        mock_cmis_manager = MagicMock()
         dom_tbl = Table("STATE_DB", TRANSCEIVER_DOM_SENSOR_TABLE)
-        post_port_dom_info_to_db(logical_port_name, port_mapping, dom_tbl, stop_event)
+        dom_info_update = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, mock_cmis_manager, helper_logger)
+        stop_event.set()
+        dom_info_update.post_port_dom_info_to_db(logical_port_name, port_mapping, dom_tbl, stop_event)
+        assert dom_tbl.get_size() == 0
+        stop_event.clear()
+        mock_get_presence.return_value = False
+        dom_info_update.post_port_dom_info_to_db(logical_port_name, port_mapping, dom_tbl, stop_event)
+        assert dom_tbl.get_size() == 0
+        mock_get_presence.return_value = True
+        mock_is_flat_memory.return_value = True
+        dom_info_update.post_port_dom_info_to_db(logical_port_name, port_mapping, dom_tbl, stop_event)
+        assert dom_tbl.get_size() == 0
+        mock_is_flat_memory.return_value = False
+        dom_info_update.post_port_dom_info_to_db(logical_port_name, port_mapping, dom_tbl, stop_event)
         mock_get_sfp_type.return_value = 'QSFP_DD'
-        post_port_dom_info_to_db(logical_port_name, port_mapping, dom_tbl, stop_event)
+        dom_info_update.post_port_dom_info_to_db(logical_port_name, port_mapping, dom_tbl, stop_event)
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
-    @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd._wrapper_get_transceiver_firmware_info', MagicMock(return_value={'active_firmware': '2.1.1',
                                                                               'inactive_firmware': '1.2.4'}))
-    def test_post_port_sfp_firmware_info_to_db(self):
+    @patch('xcvrd.xcvrd._wrapper_is_flat_memory')
+    @patch('xcvrd.xcvrd._wrapper_get_presence')
+    def test_post_port_sfp_firmware_info_to_db(self, mock_get_presence, mock_is_flat_memory):
         logical_port_name = "Ethernet0"
         port_mapping = PortMapping()
         stop_event = threading.Event()
+        mock_cmis_manager = MagicMock()
+        dom_info_update = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, mock_cmis_manager, helper_logger)
         firmware_info_tbl = Table("STATE_DB", TRANSCEIVER_FIRMWARE_INFO_TABLE)
+        stop_event.set()
+        dom_info_update.post_port_sfp_firmware_info_to_db(logical_port_name, port_mapping, firmware_info_tbl, stop_event)
         assert firmware_info_tbl.get_size() == 0
-        post_port_sfp_firmware_info_to_db(logical_port_name, port_mapping, firmware_info_tbl, stop_event)
+        stop_event.clear()
+        mock_get_presence.return_value = False
+        dom_info_update.post_port_sfp_firmware_info_to_db(logical_port_name, port_mapping, firmware_info_tbl, stop_event)
+        assert firmware_info_tbl.get_size() == 0
+        mock_get_presence.return_value = True
+        dom_info_update.post_port_sfp_firmware_info_to_db(logical_port_name, port_mapping, firmware_info_tbl, stop_event)
         assert firmware_info_tbl.get_size_for_key(logical_port_name) == 2
 
     def test_post_port_dom_threshold_info_to_db(self, mock_get_sfp_type):
@@ -470,9 +495,9 @@ class TestXcvrdScript(object):
         port_mapping = PortMapping()
         stop_event = threading.Event()
         dom_threshold_tbl = Table("STATE_DB", TRANSCEIVER_DOM_THRESHOLD_TABLE)
-        post_port_dom_info_to_db(logical_port_name, port_mapping, dom_threshold_tbl, stop_event)
+        post_port_dom_threshold_info_to_db(logical_port_name, port_mapping, dom_threshold_tbl, stop_event)
         mock_get_sfp_type.return_value = 'QSFP_DD'
-        post_port_dom_info_to_db(logical_port_name, port_mapping, dom_threshold_tbl, stop_event)
+        post_port_dom_threshold_info_to_db(logical_port_name, port_mapping, dom_threshold_tbl, stop_event)
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))
@@ -486,9 +511,11 @@ class TestXcvrdScript(object):
         logical_port_name = "Ethernet0"
         port_mapping = PortMapping()
         stop_event = threading.Event()
+        mock_cmis_manager = MagicMock()
+        dom_info_update = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, mock_cmis_manager, helper_logger)
         pm_tbl = Table("STATE_DB", TRANSCEIVER_PM_TABLE)
         assert pm_tbl.get_size() == 0
-        post_port_pm_info_to_db(logical_port_name, port_mapping, pm_tbl, stop_event)
+        dom_info_update.post_port_pm_info_to_db(logical_port_name, port_mapping, pm_tbl, stop_event)
         assert pm_tbl.get_size_for_key(logical_port_name) == 6
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -524,9 +551,11 @@ class TestXcvrdScript(object):
         logical_port_name = "Ethernet0"
         port_mapping = PortMapping()
         stop_event = threading.Event()
+        mock_cmis_manager = MagicMock()
+        dom_info_update = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, mock_cmis_manager, helper_logger)
         status_tbl = Table("STATE_DB", TRANSCEIVER_STATUS_TABLE)
         assert status_tbl.get_size() == 0
-        update_port_transceiver_status_table_hw(logical_port_name, port_mapping, status_tbl, stop_event)
+        dom_info_update.update_port_transceiver_status_table_hw(logical_port_name, port_mapping, status_tbl, stop_event)
         assert status_tbl.get_size_for_key(logical_port_name) == 5
 
     @patch('xcvrd.xcvrd.get_physical_port_name_dict', MagicMock(return_value={0: 'Ethernet0'}))
@@ -2547,7 +2576,7 @@ class TestXcvrdScript(object):
         port_mapping = PortMapping()
         stop_event = threading.Event()
         mock_cmis_manager = MagicMock()
-        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, mock_cmis_manager)
+        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, mock_cmis_manager, helper_logger)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.port_mapping.handle_port_change_event(PortChangeEvent('Ethernet4', 1, 0, PortChangeEvent.PORT_ADD))
         task.port_mapping.handle_port_change_event(PortChangeEvent('Ethernet12', 1, 0, PortChangeEvent.PORT_ADD))
@@ -2573,7 +2602,7 @@ class TestXcvrdScript(object):
         lport = 'Ethernet0'
         port_change_event = PortChangeEvent(lport, 1, 0, PortChangeEvent.PORT_ADD)
         stop_event = threading.Event()
-        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, skip_cmis_manager)
+        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, skip_cmis_manager, helper_logger)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.on_port_config_change(port_change_event)
         mock_get_cmis_state_from_state_db.return_value = mock_cmis_state
@@ -2581,13 +2610,41 @@ class TestXcvrdScript(object):
             lport='INVALID_PORT'
         assert task.is_port_in_cmis_initialization_process(lport) == expected_result
 
+    def test_beautify_dom_info_dict(self):
+        dom_info_dict = {
+            'temperature': '0C',
+            'eSNR' : 1.1,
+        }
+        expected_dom_info_dict = {
+            'temperature': '0',
+            'eSNR' : '1.1',
+        }
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, MagicMock(), helper_logger)
+        task.beautify_dom_info_dict(dom_info_dict, None)
+        assert dom_info_dict == expected_dom_info_dict
+
+    def test_beautify_info_dict(self):
+        dom_info_dict = {
+            'eSNR' : 1.1,
+        }
+        expected_dom_info_dict = {
+            'eSNR' : '1.1',
+        }
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, MagicMock(), helper_logger)
+        task.beautify_info_dict(dom_info_dict)
+        assert dom_info_dict == expected_dom_info_dict
+
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     @patch('xcvrd.xcvrd.delete_port_from_status_table_hw')
     def test_DomInfoUpdateTask_handle_port_change_event(self, mock_del_status_tbl_hw):
         port_mapping = PortMapping()
         stop_event = threading.Event()
         mock_cmis_manager = MagicMock()
-        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, mock_cmis_manager)
+        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, mock_cmis_manager, helper_logger)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         task.on_port_config_change(port_change_event)
@@ -2611,20 +2668,20 @@ class TestXcvrdScript(object):
         port_mapping = PortMapping()
         stop_event = threading.Event()
         mock_cmis_manager = MagicMock()
-        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, mock_cmis_manager)
+        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, mock_cmis_manager, helper_logger)
         task.start()
         task.join()
         assert not task.is_alive()
 
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     @patch('xcvrd.xcvrd_utilities.sfp_status_helper.detect_port_in_error_status')
-    @patch('xcvrd.xcvrd.post_port_sfp_firmware_info_to_db')
-    @patch('xcvrd.xcvrd.post_port_dom_info_to_db')
+    @patch('xcvrd.dom_mgr.DomInfoUpdateTask.post_port_sfp_firmware_info_to_db')
+    @patch('xcvrd.dom_mgr.DomInfoUpdateTask.post_port_dom_info_to_db')
     @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
     @patch('swsscommon.swsscommon.SubscriberStateTable')
     @patch('swsscommon.swsscommon.Select.select')
-    @patch('xcvrd.xcvrd.update_port_transceiver_status_table_hw')
-    @patch('xcvrd.xcvrd.post_port_pm_info_to_db')
+    @patch('xcvrd.dom_mgr.DomInfoUpdateTask.update_port_transceiver_status_table_hw')
+    @patch('xcvrd.dom_mgr.DomInfoUpdateTask.post_port_pm_info_to_db')
     def test_DomInfoUpdateTask_task_worker(self, mock_post_pm_info, mock_update_status_hw,
                                            mock_select, mock_sub_table,
                                            mock_post_dom_info, mock_post_firmware_info, mock_detect_error):
@@ -2637,7 +2694,7 @@ class TestXcvrdScript(object):
         port_mapping = PortMapping()
         stop_event = threading.Event()
         mock_cmis_manager = MagicMock()
-        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, mock_cmis_manager)
+        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, mock_cmis_manager, helper_logger)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.task_stopping_event.wait = MagicMock(side_effect=[False, True])
         task.get_dom_polling_from_config_db = MagicMock(return_value='enabled')
@@ -2791,7 +2848,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd._wrapper_get_transceiver_change_event')
     @patch('xcvrd.xcvrd.del_port_sfp_dom_info_from_db')
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.notify_media_setting')
-    @patch('xcvrd.xcvrd.post_port_sfp_firmware_info_to_db')
+    @patch('xcvrd.dom_mgr.DomInfoUpdateTask.post_port_sfp_firmware_info_to_db')
     @patch('xcvrd.xcvrd.post_port_dom_threshold_info_to_db')
     @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')
     @patch('xcvrd.xcvrd.update_port_transceiver_status_table_sw')

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -45,6 +45,13 @@ media_settings_with_comma_dict = copy.deepcopy(media_settings_dict)
 global_media_settings = media_settings_with_comma_dict['GLOBAL_MEDIA_SETTINGS'].pop('1-32')
 media_settings_with_comma_dict['GLOBAL_MEDIA_SETTINGS']['1-5,6,7-20,21-32'] = global_media_settings
 
+media_settings_with_regular_expression_dict = copy.deepcopy(media_settings_dict)
+media_settings_with_regular_expression_dict['GLOBAL_MEDIA_SETTINGS']['1-32'] = {}
+# Generate regular expression patterns for QSFP28-40GBASE-CR4-xxM and QSFP+-40GBASE-CR4-xxM that have the same pre-emphasis value
+media_settings_with_regular_expression_dict['GLOBAL_MEDIA_SETTINGS']['1-32']['QSFP(\\+|28)-40GBASE-CR4-1M'] = global_media_settings['QSFP28-40GBASE-CR4-1M']
+media_settings_with_regular_expression_dict['GLOBAL_MEDIA_SETTINGS']['1-32']['QSFP(\\+|28)-40GBASE-CR4-2M'] = global_media_settings['QSFP28-40GBASE-CR4-2M']
+media_settings_with_regular_expression_dict['GLOBAL_MEDIA_SETTINGS']['1-32']['QSFP(\\+|28)-40GBASE-CR4-(3|4|5|7|10)M'] = global_media_settings['QSFP28-40GBASE-CR4-3M']
+
 with open(os.path.join(test_path, 'optics_si_settings.json'), 'r') as fn:
     optics_si_settings_dict = json.load(fn)
 port_optics_si_settings = {}
@@ -792,7 +799,10 @@ class TestXcvrdScript(object):
     (media_settings_port_default_media_key_lane_speed_si, 7, {'vendor_key': 'MISSING', 'media_key': 'MISSING', 'lane_speed_key': 'MISSING'}, {'speed:400GAUI-8': {'idriver': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'pre1': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'ob_m2lp': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}}}),
     (media_settings_global_default_port_media_key_lane_speed_si, 7, {'vendor_key': 'MISSING', 'media_key': 'MISSING', 'lane_speed_key': 'MISSING'}, {'speed:400GAUI-8': {'idriver': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'pre1': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'ob_m2lp': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}}}),
     (media_settings_global_list_of_ranges_media_key_lane_speed_si_with_default_section, 7, {'vendor_key': 'MISSING', 'media_key': 'MISSING', 'lane_speed_key': 'MISSING'}, {'speed:400GAUI-8': {'idriver': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'pre1': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}, 'ob_m2lp': {'lane0': '0x0000000d', 'lane1': '0x0000000d', 'lane2': '0x0000000d', 'lane3': '0x0000000d'}}}),
-    (media_settings_empty, 7, {'vendor_key': 'AMPHANOL-5678', 'media_key': 'QSFP-DD-active_cable_media_interface', 'lane_speed_key': 'speed:100GAUI-2'}, {})
+    (media_settings_empty, 7, {'vendor_key': 'AMPHANOL-5678', 'media_key': 'QSFP-DD-active_cable_media_interface', 'lane_speed_key': 'speed:100GAUI-2'}, {}),
+    (media_settings_with_regular_expression_dict, 7, {'vendor_key': 'UNKOWN', 'media_key': 'QSFP28-40GBASE-CR4-1M', 'lane_speed_key': 'UNKOWN'}, {'preemphasis': {'lane0': '0x16440A', 'lane1': '0x16440A', 'lane2': '0x16440A', 'lane3': '0x16440A'}}),
+    (media_settings_with_regular_expression_dict, 7, {'vendor_key': 'UNKOWN', 'media_key': 'QSFP+-40GBASE-CR4-2M', 'lane_speed_key': 'UNKOWN'}, {'preemphasis': {'lane0': '0x18420A', 'lane1': '0x18420A', 'lane2': '0x18420A', 'lane3': '0x18420A'}}),
+    (media_settings_with_regular_expression_dict, 7, {'vendor_key': 'UNKOWN', 'media_key': 'QSFP+-40GBASE-CR4-10M', 'lane_speed_key': 'UNKOWN'}, {'preemphasis': {'lane0': '0x1A400A', 'lane1': '0x1A400A', 'lane2': '0x1A400A', 'lane3': '0x1A400A'}})
     ])
     def test_get_media_settings_value(self, media_settings_dict, port, key, expected):
         with patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict', media_settings_dict):

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -197,6 +197,7 @@ class TestXcvrdThreadException(object):
         task.get_host_tx_status = MagicMock(return_value='true')
         task.get_port_admin_status = MagicMock(return_value='up')
         task.get_cfg_port_tbl = MagicMock()
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl.return_value = mock_get_status_tbl
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_SET,
                                             {'speed':'400000', 'lanes':'1,2,3,4,5,6,7,8'})
@@ -1450,6 +1451,7 @@ class TestXcvrdScript(object):
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_SET)
         task.on_port_update_event(port_change_event)
 
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl = MagicMock(return_value=None)
         task.update_port_transceiver_status_table_sw_cmis_state("Ethernet0", CMIS_STATE_INSERTED)
 
@@ -1495,6 +1497,7 @@ class TestXcvrdScript(object):
         cfg_port_tbl = MagicMock()
         cfg_port_tbl.get = MagicMock(return_value=(True, (('laser_freq', 193100),)))
         mock_table_helper.get_cfg_port_tbl = MagicMock(return_value=cfg_port_tbl)
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_cfg_port_tbl = mock_table_helper.get_cfg_port_tbl
         assert task.get_configured_laser_freq_from_db('Ethernet0') == 193100
 
@@ -1506,6 +1509,7 @@ class TestXcvrdScript(object):
         cfg_port_tbl = MagicMock()
         cfg_port_tbl.get = MagicMock(return_value=(True, (('tx_power', -10),)))
         mock_table_helper.get_cfg_port_tbl = MagicMock(return_value=cfg_port_tbl)
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_cfg_port_tbl = mock_table_helper.get_cfg_port_tbl
         assert task.get_configured_tx_power_from_db('Ethernet0') == -10
 
@@ -1680,6 +1684,7 @@ class TestXcvrdScript(object):
         host_lanes_mask = 0xff
 
         # Case: table does not exist
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=None)
         task.post_port_active_apsel_to_db(mock_xcvr_api, lport, host_lanes_mask)
         assert mock_field_value_pairs.call_count == 0
@@ -1737,6 +1742,7 @@ class TestXcvrdScript(object):
         port_mapping = PortMapping()
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=int_tbl)
 
         # case: partial lanes update
@@ -1883,6 +1889,7 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
         task.port_mapping.logical_port_list = ['Ethernet0']
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl.return_value = mock_get_status_tbl
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
@@ -1949,6 +1956,7 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
         task.port_mapping.logical_port_list = ['Ethernet1']
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl.return_value = mock_get_status_tbl
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
@@ -2085,6 +2093,7 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
         task.port_mapping.logical_port_list = ['Ethernet0']
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl.return_value = mock_get_status_tbl
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
@@ -2220,6 +2229,7 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
         task.port_mapping.logical_port_list = ['Ethernet0']
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl.return_value = mock_get_status_tbl
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()

--- a/sonic-xcvrd/xcvrd/dom_mgr.py
+++ b/sonic-xcvrd/xcvrd/dom_mgr.py
@@ -1,0 +1,360 @@
+"""
+DOM Info Update task manager
+Updates various transceiver diagnostic information in the DB periodically, running
+as a child thread of xcvrd main thread.
+"""
+
+try:
+    import threading
+    import copy
+    import sys
+    import re
+
+    from natsort import natsorted
+    from swsscommon import swsscommon
+
+    from . import xcvrd
+    from .xcvrd_utilities import sfp_status_helper
+    from .xcvrd_utilities.xcvr_table_helper import *
+    from .xcvrd_utilities import port_event_helper
+except ImportError as e:
+    raise ImportError(str(e) + " - required module not found in dom_mgr.py")
+
+class DomInfoUpdateTask(threading.Thread):
+    DOM_LOGGER_PREFIX = "DOM-INFO-UPDATE: "
+    DOM_INFO_UPDATE_PERIOD_SECS = 60
+
+    def __init__(self, namespaces, port_mapping, main_thread_stop_event, skip_cmis_mgr, helper_logger):
+        threading.Thread.__init__(self)
+        self.name = "DomInfoUpdateTask"
+        self.exc = None
+        self.task_stopping_event = threading.Event()
+        self.main_thread_stop_event = main_thread_stop_event
+        self.helper_logger = helper_logger
+        self.port_mapping = copy.deepcopy(port_mapping)
+        self.namespaces = namespaces
+        self.skip_cmis_mgr = skip_cmis_mgr
+
+    def log_debug(self, message):
+        self.helper_logger.log_debug("{}{}".format(self.DOM_LOGGER_PREFIX, message))
+
+    def log_info(self, message):
+        self.helper_logger.log_info("{}{}".format(self.DOM_LOGGER_PREFIX, message))
+
+    def log_notice(self, message):
+        self.helper_logger.log_notice("{}{}".format(self.DOM_LOGGER_PREFIX, message))
+
+    def log_warning(self, message):
+        self.helper_logger.log_warning("{}{}".format(self.DOM_LOGGER_PREFIX, message))
+
+    def log_error(self, message):
+        self.helper_logger.log_error("{}{}".format(self.DOM_LOGGER_PREFIX, message))
+
+    def get_dom_polling_from_config_db(self, lport):
+        """
+            Returns the value of dom_polling field from PORT table in CONFIG_DB
+            For non-breakout ports, this function will get dom_polling field from PORT table of lport (subport = 0)
+            For breakout ports, this function will get dom_polling field from PORT table of the first subport
+            of lport's corresponding breakout group (subport = 1)
+
+            Returns:
+                'disabled' if dom_polling is set to 'disabled', otherwise 'enabled'
+        """
+        dom_polling = 'enabled'
+
+        pport_list = self.port_mapping.get_logical_to_physical(lport)
+        if not pport_list:
+            self.log_warning("Get dom disabled: Got unknown physical port list {} for lport {}".format(pport_list, lport))
+            return dom_polling
+        pport = pport_list[0]
+
+        logical_port_list = self.port_mapping.get_physical_to_logical(pport)
+        if logical_port_list is None:
+            self.log_warning("Get dom disabled: Got unknown FP port index {}".format(pport))
+            return dom_polling
+
+        # Sort the logical port list to make sure we always get the first subport
+        logical_port_list = natsorted(logical_port_list, key=lambda y: y.lower())
+        first_logical_port = logical_port_list[0]
+
+        asic_index = self.port_mapping.get_asic_id_for_logical_port(first_logical_port)
+        port_tbl = self.xcvr_table_helper.get_cfg_port_tbl(asic_index)
+
+        found, port_info = port_tbl.get(first_logical_port)
+        if found and 'dom_polling' in dict(port_info):
+            dom_polling = dict(port_info)['dom_polling']
+
+        return dom_polling
+
+    """
+    Checks if the port is going through CMIS initialization process
+    This API assumes CMIS_STATE_UNKNOWN as a transitional state since it is the
+    first state after starting CMIS state machine.
+    This assumption allows the DomInfoUpdateTask thread to skip polling on the port
+    to allow CMIS initialization to complete if needed.
+    Returns:
+        True if the port is in CMIS initialization process,
+        otherwise False
+    """
+    def is_port_in_cmis_initialization_process(self, logical_port_name):
+        # If CMIS manager is not available for the platform, return False
+        if self.skip_cmis_mgr:
+            return False
+
+        asic_index = self.port_mapping.get_asic_id_for_logical_port(logical_port_name)
+        if asic_index is None:
+            self.log_warning("Got invalid asic index for {} while checking cmis init status".format(logical_port_name))
+            return False
+
+        cmis_state = xcvrd.get_cmis_state_from_state_db(logical_port_name, self.xcvr_table_helper.get_status_tbl(asic_index))
+        if cmis_state not in xcvrd.CMIS_TERMINAL_STATES:
+            return True
+        else:
+            return False
+
+    def is_port_dom_monitoring_disabled(self, logical_port_name):
+        return self.get_dom_polling_from_config_db(logical_port_name) == 'disabled' or \
+                self.is_port_in_cmis_initialization_process(logical_port_name)
+
+    # Remove unnecessary unit from the raw data
+    def beautify_dom_info_dict(self, dom_info_dict, physical_port):
+        for k, v in dom_info_dict.items():
+            if k == 'temperature':
+                dom_info_dict[k] = xcvrd.strip_unit_and_beautify(v, xcvrd.TEMP_UNIT)
+            elif k == 'voltage':
+                dom_info_dict[k] = xcvrd.strip_unit_and_beautify(v, xcvrd.VOLT_UNIT)
+            elif re.match('^(tx|rx)[1-8]power$', k):
+                dom_info_dict[k] = xcvrd.strip_unit_and_beautify(v, xcvrd.POWER_UNIT)
+            elif re.match('^(tx|rx)[1-8]bias$', k):
+                dom_info_dict[k] = xcvrd.strip_unit_and_beautify(v, xcvrd.BIAS_UNIT)
+            elif type(v) is not str:
+                # For all the other keys:
+                dom_info_dict[k] = str(v)
+
+    def beautify_info_dict(self, info_dict):
+        for k, v in info_dict.items():
+            if not isinstance(v, str):
+                info_dict[k] = str(v)
+
+    # Update port sfp firmware info in db
+    def post_port_sfp_firmware_info_to_db(self, logical_port_name, port_mapping, table,
+                                stop_event=threading.Event(), firmware_info_cache=None):
+        for physical_port, physical_port_name in xcvrd.get_physical_port_name_dict(logical_port_name, port_mapping).items():
+            if stop_event.is_set():
+                break
+
+            if not xcvrd._wrapper_get_presence(physical_port):
+                continue
+
+            try:
+                if firmware_info_cache is not None and physical_port in firmware_info_cache:
+                    # If cache is enabled and firmware information is in cache, just read from cache, no need read from EEPROM
+                    transceiver_firmware_info_dict = firmware_info_cache[physical_port]
+                else:
+                    transceiver_firmware_info_dict = xcvrd._wrapper_get_transceiver_firmware_info(physical_port)
+                    if firmware_info_cache is not None:
+                        # If cache is enabled, put firmware information to cache
+                        firmware_info_cache[physical_port] = transceiver_firmware_info_dict
+                if transceiver_firmware_info_dict:
+                    fvs = swsscommon.FieldValuePairs([(k, v) for k, v in transceiver_firmware_info_dict.items()])
+                    table.set(physical_port_name, fvs)
+                else:
+                    return xcvrd.SFP_EEPROM_NOT_READY
+
+            except NotImplementedError:
+                helper_logger.log_error("Transceiver firmware info functionality is currently not implemented for this platform")
+                sys.exit(xcvrd.NOT_IMPLEMENTED_ERROR)
+
+    # Update port dom sensor info in db
+    def post_port_dom_info_to_db(self, logical_port_name, port_mapping, table, stop_event=threading.Event(), dom_info_cache=None):
+        for physical_port, physical_port_name in xcvrd.get_physical_port_name_dict(logical_port_name, port_mapping).items():
+            if stop_event.is_set():
+                break
+
+            if not xcvrd._wrapper_get_presence(physical_port):
+                continue
+
+            if xcvrd._wrapper_is_flat_memory(physical_port) == True:
+                continue
+
+            try:
+                if dom_info_cache is not None and physical_port in dom_info_cache:
+                    # If cache is enabled and dom information is in cache, just read from cache, no need read from EEPROM
+                    dom_info_dict = dom_info_cache[physical_port]
+                else:
+                    dom_info_dict = xcvrd._wrapper_get_transceiver_dom_info(physical_port)
+                    if dom_info_cache is not None:
+                        # If cache is enabled, put dom information to cache
+                        dom_info_cache[physical_port] = dom_info_dict
+                if dom_info_dict is not None:
+                    self.beautify_dom_info_dict(dom_info_dict, physical_port)
+                    fvs = swsscommon.FieldValuePairs([(k, v) for k, v in dom_info_dict.items()])
+                    table.set(physical_port_name, fvs)
+                else:
+                    return xcvrd.SFP_EEPROM_NOT_READY
+
+            except NotImplementedError:
+                helper_logger.log_error("This functionality is currently not implemented for this platform")
+                sys.exit(xcvrd.NOT_IMPLEMENTED_ERROR)
+
+    # Update port SFP status table for HW fields
+    def update_port_transceiver_status_table_hw(self, logical_port_name, port_mapping,
+                                                table, stop_event=threading.Event(), transceiver_status_cache=None):
+        for physical_port, physical_port_name in xcvrd.get_physical_port_name_dict(logical_port_name, port_mapping).items():
+            if stop_event.is_set():
+                break
+
+            if not xcvrd._wrapper_get_presence(physical_port):
+                continue
+
+            if transceiver_status_cache is not None and physical_port in transceiver_status_cache:
+                # If cache is enabled and status info is in cache, just read from cache, no need read from EEPROM
+                transceiver_status_dict = transceiver_status_cache[physical_port]
+            else:
+                transceiver_status_dict = xcvrd._wrapper_get_transceiver_status(physical_port)
+                if transceiver_status_cache is not None:
+                    # If cache is enabled, put status info to cache
+                    transceiver_status_cache[physical_port] = transceiver_status_dict
+            if transceiver_status_dict is not None:
+                # Skip if empty (i.e. get_transceiver_status API is not applicable for this xcvr)
+                if not transceiver_status_dict:
+                    continue
+                self.beautify_info_dict(transceiver_status_dict)
+                fvs = swsscommon.FieldValuePairs([(k, v) for k, v in transceiver_status_dict.items()])
+                table.set(physical_port_name, fvs)
+            else:
+                return xcvrd.SFP_EEPROM_NOT_READY
+
+    # Update port pm info in db
+    def post_port_pm_info_to_db(self, logical_port_name, port_mapping, table, stop_event=threading.Event(), pm_info_cache=None):
+        for physical_port, physical_port_name in xcvrd.get_physical_port_name_dict(logical_port_name, port_mapping).items():
+            if stop_event.is_set():
+                break
+
+            if not xcvrd._wrapper_get_presence(physical_port):
+                continue
+
+            if xcvrd._wrapper_is_flat_memory(physical_port) == True:
+                continue
+
+            if pm_info_cache is not None and physical_port in pm_info_cache:
+                # If cache is enabled and pm info is in cache, just read from cache, no need read from EEPROM
+                pm_info_dict = pm_info_cache[physical_port]
+            else:
+                pm_info_dict = xcvrd._wrapper_get_transceiver_pm(physical_port)
+                if pm_info_cache is not None:
+                    # If cache is enabled, put dom information to cache
+                    pm_info_cache[physical_port] = pm_info_dict
+            if pm_info_dict is not None:
+                # Skip if empty (i.e. get_transceiver_pm API is not applicable for this xcvr)
+                if not pm_info_dict:
+                    continue
+                self.beautify_info_dict(pm_info_dict)
+                fvs = swsscommon.FieldValuePairs([(k, v) for k, v in pm_info_dict.items()])
+                table.set(physical_port_name, fvs)
+            else:
+                return xcvrd.SFP_EEPROM_NOT_READY
+
+    def task_worker(self):
+        self.xcvr_table_helper = XcvrTableHelper(self.namespaces)
+        self.log_notice("Start DOM monitoring loop")
+        firmware_info_cache = {}
+        dom_info_cache = {}
+        transceiver_status_cache = {}
+        pm_info_cache = {}
+        sel, asic_context = port_event_helper.subscribe_port_config_change(self.namespaces)
+
+        # Start loop to update dom info in DB periodically
+        while not self.task_stopping_event.wait(self.DOM_INFO_UPDATE_PERIOD_SECS):
+            # Clear the cache at the begin of the loop to make sure it will be clear each time
+            firmware_info_cache.clear()
+            dom_info_cache.clear()
+            transceiver_status_cache.clear()
+            pm_info_cache.clear()
+
+            # Handle port change event from main thread
+            port_event_helper.handle_port_config_change(sel, asic_context, self.task_stopping_event, self.port_mapping, self.helper_logger, self.on_port_config_change)
+            logical_port_list = self.port_mapping.logical_port_list
+            for logical_port_name in logical_port_list:
+                if self.is_port_dom_monitoring_disabled(logical_port_name):
+                    continue
+
+                # Get the asic to which this port belongs
+                asic_index = self.port_mapping.get_asic_id_for_logical_port(logical_port_name)
+                if asic_index is None:
+                    self.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
+                    continue
+
+                if not sfp_status_helper.detect_port_in_error_status(logical_port_name, self.xcvr_table_helper.get_status_tbl(asic_index)):
+                    try:
+                        self.post_port_sfp_firmware_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_firmware_info_tbl(asic_index), self.task_stopping_event, firmware_info_cache=firmware_info_cache)
+                    except (KeyError, TypeError) as e:
+                        #continue to process next port since execption could be raised due to port reset, transceiver removal
+                        self.log_warning("Got exception {} while processing firmware info for port {}, ignored".format(repr(e), logical_port_name))
+                        continue
+                    try:
+                        self.post_port_dom_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_dom_tbl(asic_index), self.task_stopping_event, dom_info_cache=dom_info_cache)
+                    except (KeyError, TypeError) as e:
+                        #continue to process next port since execption could be raised due to port reset, transceiver removal
+                        self.log_warning("Got exception {} while processing dom info for port {}, ignored".format(repr(e), logical_port_name))
+                        continue
+                    try:
+                        self.update_port_transceiver_status_table_hw(logical_port_name,
+                                                                self.port_mapping,
+                                                                self.xcvr_table_helper.get_status_tbl(asic_index),
+                                                                self.task_stopping_event,
+                                                                transceiver_status_cache=transceiver_status_cache)
+                    except (KeyError, TypeError) as e:
+                        #continue to process next port since execption could be raised due to port reset, transceiver removal
+                        self.log_warning("Got exception {} while processing transceiver status hw for port {}, ignored".format(repr(e), logical_port_name))
+                        continue
+                    try:
+                        self.post_port_pm_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_pm_tbl(asic_index), self.task_stopping_event, pm_info_cache=pm_info_cache)
+                    except (KeyError, TypeError) as e:
+                        #continue to process next port since execption could be raised due to port reset, transceiver removal
+                        self.log_warning("Got exception {} while processing pm info for port {}, ignored".format(repr(e), logical_port_name))
+                        continue
+
+        self.log_info("Stop DOM monitoring loop")
+
+    def run(self):
+        if self.task_stopping_event.is_set():
+            return
+        try:
+            self.task_worker()
+        except Exception as e:
+            self.log_error("Exception occured at {} thread due to {}".format(threading.current_thread().getName(), repr(e)))
+            xcvrd.log_exception_traceback()
+            self.exc = e
+            self.main_thread_stop_event.set()
+
+    def join(self):
+        self.task_stopping_event.set()
+        threading.Thread.join(self)
+        if self.exc:
+            raise self.exc
+
+    def on_port_config_change(self, port_change_event):
+        if port_change_event.event_type == port_event_helper.PortChangeEvent.PORT_REMOVE:
+            self.on_remove_logical_port(port_change_event)
+        self.port_mapping.handle_port_change_event(port_change_event)
+
+    def on_remove_logical_port(self, port_change_event):
+        """Called when a logical port is removed from CONFIG_DB
+
+        Args:
+            port_change_event (object): port change event
+        """
+        # To avoid race condition, remove the entry TRANSCEIVER_FIRMWARE_INFO, TRANSCEIVER_DOM_SENSOR, TRANSCEIVER_PM and HW section of TRANSCEIVER_STATUS table.
+        # This thread only updates TRANSCEIVER_FIRMWARE_INFO, TRANSCEIVER_DOM_SENSOR, TRANSCEIVER_PM and HW section of TRANSCEIVER_STATUS table,
+        # so we don't have to remove entries from TRANSCEIVER_INFO and TRANSCEIVER_DOM_THRESHOLD
+        xcvrd.del_port_sfp_dom_info_from_db(port_change_event.port_name,
+                                      self.port_mapping,
+                                      None,
+                                      self.xcvr_table_helper.get_dom_tbl(port_change_event.asic_id),
+                                      None,
+                                      self.xcvr_table_helper.get_pm_tbl(port_change_event.asic_id),
+                                      self.xcvr_table_helper.get_firmware_info_tbl(port_change_event.asic_id))
+        xcvrd.delete_port_from_status_table_hw(port_change_event.port_name,
+                                      self.port_mapping,
+                                      self.xcvr_table_helper.get_status_tbl(port_change_event.asic_id))

--- a/sonic-xcvrd/xcvrd/sff_mgr.py
+++ b/sonic-xcvrd/xcvrd/sff_mgr.py
@@ -14,6 +14,7 @@ try:
 
     from .xcvrd_utilities.port_event_helper import PortChangeObserver
     from .xcvrd_utilities.xcvr_table_helper import XcvrTableHelper
+    from sonic_platform_base.sonic_xcvr.api.public.sff8472 import Sff8472Api
 except ImportError as e:
     raise ImportError(str(e) + " - required module not found")
 
@@ -434,6 +435,18 @@ class SffManagerTask(threading.Thread):
                 except (AttributeError, NotImplementedError):
                     # Skip if these essential routines are not available
                     continue
+                
+                if xcvr_inserted:
+                    set_lp_success = (
+                        sfp.set_lpmode(False) 
+                        if isinstance(api, Sff8472Api) 
+                        else api.set_lpmode(False)
+                    )
+                    if not set_lp_success:
+                        self.log_error(
+                            "{}: Failed to take module out of low power mode.".format(
+                                lport)
+                        )
 
                 if active_lanes is None:
                     active_lanes = self.get_active_lanes_for_lport(lport, subport_idx,

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -440,6 +440,7 @@ def post_port_sfp_info_to_db(logical_port_name, port_mapping, table, transceiver
             break
 
         if not _wrapper_get_presence(physical_port):
+            helper_logger.log_notice("Transceiver not present in port {}".format(logical_port_name))
             continue
 
         port_name = get_physical_port_name(logical_port_name, ganged_member_num, ganged_port)
@@ -1379,6 +1380,7 @@ class CmisManagerTask(threading.Thread):
                     # Skip if it's not a CMIS module
                     type = api.get_module_type_abbreviation()
                     if (type is None) or (type not in self.CMIS_MODULE_TYPES):
+                        self.log_notice("{}: skipping CMIS state machine for non-CMIS module with type {}".format(lport, type))
                         self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
                         continue
 
@@ -1413,9 +1415,9 @@ class CmisManagerTask(threading.Thread):
                     self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
                     continue
 
-                self.log_notice("{}: {}G, lanemask=0x{:x}, state={}, appl {} host_lane_count {} "
-                                "retries={}".format(lport, int(speed/1000), host_lanes_mask,
-                                state, appl, host_lane_count, retries))
+                self.log_notice("{}: {}G, lanemask=0x{:x}, CMIS state={}, Module state={}, DP state={}, appl {} host_lane_count {} "
+                                "retries={}".format(lport, int(speed/1000), host_lanes_mask, state,
+                                api.get_module_state(), api.get_datapath_state(), appl, host_lane_count, retries))
                 if retries > self.CMIS_MAX_RETRIES:
                     self.log_error("{}: FAILED".format(lport))
                     self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1314,6 +1314,8 @@ class CmisManagerTask(threading.Thread):
         for lport in logical_port_list:
             self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_UNKNOWN)
 
+        is_fast_reboot = is_fast_reboot_enabled()
+
         # APPL_DB for CONFIG updates, and STATE_DB for insertion/removal
         port_change_observer = PortChangeObserver(self.namespaces, helper_logger,
                                                   self.task_stopping_event,
@@ -1460,9 +1462,12 @@ class CmisManagerTask(threading.Thread):
 
                         if self.port_dict[lport]['host_tx_ready'] != 'true' or \
                                 self.port_dict[lport]['admin_status'] != 'up':
-                           self.log_notice("{} Forcing Tx laser OFF".format(lport))
-                           # Force DataPath re-init
-                           api.tx_disable_channel(media_lanes_mask, True)
+                           if is_fast_reboot and self.check_datapath_state(api, host_lanes_mask, ['DataPathActivated']):
+                               self.log_notice("{} Skip datapath re-init in fast-reboot".format(lport))
+                           else:
+                               self.log_notice("{} Forcing Tx laser OFF".format(lport))
+                               # Force DataPath re-init
+                               api.tx_disable_channel(media_lanes_mask, True)
                            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
                            continue
                     # Configure the target output power if ZR module

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -160,6 +160,7 @@ def get_cmis_application_desired(api, host_lane_count, speed):
         get_interface_speed(app_info.get('host_electrical_interface_id')) == speed):
             return (index & 0xf)
 
+    helper_logger.log_notice(f'No application found from {appl_dict} with host_lane_count={host_lane_count} speed={speed}')
     return None
 
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -319,6 +319,8 @@ def _wrapper_is_flat_memory(physical_port):
         try:
             sfp = platform_chassis.get_sfp(physical_port)
             api = sfp.get_xcvr_api()
+            if not api:
+                return True
             return api.is_flat_memory()
         except NotImplementedError:
             pass

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -819,7 +819,6 @@ class CmisManagerTask(threading.Thread):
         self.main_thread_stop_event = main_thread_stop_event
         self.port_dict = {}
         self.port_mapping = copy.deepcopy(port_mapping)
-        self.xcvr_table_helper = XcvrTableHelper(namespaces)
         self.isPortInitDone = False
         self.isPortConfigDone = False
         self.skip_cmis_mgr = skip_cmis_mgr

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -194,8 +194,7 @@ def get_interface_speed(ifname):
         speed = 10000
     elif '1000BASE' in ifname:
         speed = 1000
-    else:
-        helper_logger.log_error("No interface speed found for: '{}'".format(ifname))
+
     return speed
 
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -28,6 +28,7 @@ try:
 
     from .xcvrd_utilities import sfp_status_helper
     from .sff_mgr import SffManagerTask
+    from .dom_mgr import DomInfoUpdateTask
     from .xcvrd_utilities.xcvr_table_helper import *
     from .xcvrd_utilities import port_event_helper
     from .xcvrd_utilities.port_event_helper import PortChangeObserver
@@ -73,7 +74,6 @@ MGMT_INIT_TIME_DELAY_SECS = 2
 # SFP insert event poll duration
 SFP_INSERT_EVENT_POLL_PERIOD_MSECS = 1000
 
-DOM_INFO_UPDATE_PERIOD_SECS = 60
 STATE_MACHINE_UPDATE_PERIOD_MSECS = 60000
 TIME_FOR_SFP_READY_SECS = 1
 
@@ -374,23 +374,6 @@ def _wrapper_get_sfp_error_description(physical_port):
             pass
     return None
 
-# Remove unnecessary unit from the raw data
-
-def beautify_dom_info_dict(dom_info_dict, physical_port):
-    for k, v in dom_info_dict.items():
-        if k == 'temperature':
-            dom_info_dict[k] = strip_unit_and_beautify(v, TEMP_UNIT)
-        elif k == 'voltage':
-            dom_info_dict[k] = strip_unit_and_beautify(v, VOLT_UNIT)
-        elif re.match('^(tx|rx)[1-8]power$', k):
-            dom_info_dict[k] = strip_unit_and_beautify(v, POWER_UNIT)
-        elif re.match('^(tx|rx)[1-8]bias$', k):
-            dom_info_dict[k] = strip_unit_and_beautify(v, BIAS_UNIT)
-        elif type(v) is not str:
-            # For all the other keys:
-            dom_info_dict[k] = str(v)
-
-
 def beautify_dom_threshold_info_dict(dom_info_dict):
     for k, v in dom_info_dict.items():
         if re.search('temp', k) is not None:
@@ -404,20 +387,6 @@ def beautify_dom_threshold_info_dict(dom_info_dict):
         elif type(v) is not str:
             # For all the other keys:
             dom_info_dict[k] = str(v)
-
-
-def beautify_transceiver_status_dict(transceiver_status_dict, physical_port):
-    for k, v in transceiver_status_dict.items():
-        if type(v) is str:
-            continue
-        transceiver_status_dict[k] = str(v)
-
-
-def beautify_pm_info_dict(pm_info_dict, physical_port):
-    for k, v in pm_info_dict.items():
-        if type(v) is str:
-            continue
-        pm_info_dict[k] = str(v)
 
 # Update port sfp info in db
 
@@ -538,36 +507,6 @@ def post_port_sfp_info_to_db(logical_port_name, port_mapping, table, transceiver
             helper_logger.log_error("This functionality is currently not implemented for this platform")
             sys.exit(NOT_IMPLEMENTED_ERROR)
 
-# Update port sfp firmware info in db
-
-def post_port_sfp_firmware_info_to_db(logical_port_name, port_mapping, table,
-                             stop_event=threading.Event(), firmware_info_cache=None):
-    for physical_port, physical_port_name in get_physical_port_name_dict(logical_port_name, port_mapping).items():
-        if stop_event.is_set():
-            break
-
-        if not _wrapper_get_presence(physical_port):
-            continue
-
-        try:
-            if firmware_info_cache is not None and physical_port in firmware_info_cache:
-                # If cache is enabled and firmware information is in cache, just read from cache, no need read from EEPROM
-                transceiver_firmware_info_dict = firmware_info_cache[physical_port]
-            else:
-                transceiver_firmware_info_dict = _wrapper_get_transceiver_firmware_info(physical_port)
-                if firmware_info_cache is not None:
-                    # If cache is enabled, put firmware information to cache
-                    firmware_info_cache[physical_port] = transceiver_firmware_info_dict
-            if transceiver_firmware_info_dict:
-                fvs = swsscommon.FieldValuePairs([(k, v) for k, v in transceiver_firmware_info_dict.items()])
-                table.set(physical_port_name, fvs)
-            else:
-                return SFP_EEPROM_NOT_READY
-
-        except NotImplementedError:
-            helper_logger.log_error("Transceiver firmware info functionality is currently not implemented for this platform")
-            sys.exit(NOT_IMPLEMENTED_ERROR)
-
 # Update port dom threshold info in db
 
 
@@ -617,72 +556,6 @@ def post_port_dom_threshold_info_to_db(logical_port_name, port_mapping, table,
         except NotImplementedError:
             helper_logger.log_error("This functionality is currently not implemented for this platform")
             sys.exit(NOT_IMPLEMENTED_ERROR)
-
-# Update port dom sensor info in db
-
-
-def post_port_dom_info_to_db(logical_port_name, port_mapping, table, stop_event=threading.Event(), dom_info_cache=None):
-    for physical_port, physical_port_name in get_physical_port_name_dict(logical_port_name, port_mapping).items():
-        if stop_event.is_set():
-            break
-
-        if not _wrapper_get_presence(physical_port):
-            continue
-
-        if _wrapper_is_flat_memory(physical_port) == True:
-            continue
-
-        try:
-            if dom_info_cache is not None and physical_port in dom_info_cache:
-                # If cache is enabled and dom information is in cache, just read from cache, no need read from EEPROM
-                dom_info_dict = dom_info_cache[physical_port]
-            else:
-                dom_info_dict = _wrapper_get_transceiver_dom_info(physical_port)
-                if dom_info_cache is not None:
-                    # If cache is enabled, put dom information to cache
-                    dom_info_cache[physical_port] = dom_info_dict
-            if dom_info_dict is not None:
-                beautify_dom_info_dict(dom_info_dict, physical_port)
-                fvs = swsscommon.FieldValuePairs([(k, v) for k, v in dom_info_dict.items()])
-                table.set(physical_port_name, fvs)
-            else:
-                return SFP_EEPROM_NOT_READY
-
-        except NotImplementedError:
-            helper_logger.log_error("This functionality is currently not implemented for this platform")
-            sys.exit(NOT_IMPLEMENTED_ERROR)
-
-# Update port pm info in db
-
-
-def post_port_pm_info_to_db(logical_port_name, port_mapping, table, stop_event=threading.Event(), pm_info_cache=None):
-    for physical_port, physical_port_name in get_physical_port_name_dict(logical_port_name, port_mapping).items():
-        if stop_event.is_set():
-            break
-
-        if not _wrapper_get_presence(physical_port):
-            continue
-
-        if _wrapper_is_flat_memory(physical_port) == True:
-            continue
-
-        if pm_info_cache is not None and physical_port in pm_info_cache:
-            # If cache is enabled and pm info is in cache, just read from cache, no need read from EEPROM
-            pm_info_dict = pm_info_cache[physical_port]
-        else:
-            pm_info_dict = _wrapper_get_transceiver_pm(physical_port)
-            if pm_info_cache is not None:
-                # If cache is enabled, put dom information to cache
-                pm_info_cache[physical_port] = pm_info_dict
-        if pm_info_dict is not None:
-            # Skip if empty (i.e. get_transceiver_pm API is not applicable for this xcvr)
-            if not pm_info_dict:
-                continue
-            beautify_pm_info_dict(pm_info_dict, physical_port)
-            fvs = swsscommon.FieldValuePairs([(k, v) for k, v in pm_info_dict.items()])
-            table.set(physical_port_name, fvs)
-        else:
-            return SFP_EEPROM_NOT_READY
 
 # Delete port dom/sfp info from db
 
@@ -736,37 +609,6 @@ def get_cmis_state_from_state_db(lport, status_tbl):
         return dict(transceiver_status_dict)['cmis_state']
     else:
         return CMIS_STATE_UNKNOWN
-
-
-# Update port SFP status table for HW fields
-
-
-def update_port_transceiver_status_table_hw(logical_port_name, port_mapping,
-                                            table, stop_event=threading.Event(), transceiver_status_cache=None):
-    for physical_port, physical_port_name in get_physical_port_name_dict(logical_port_name, port_mapping).items():
-        if stop_event.is_set():
-            break
-
-        if not _wrapper_get_presence(physical_port):
-            continue
-
-        if transceiver_status_cache is not None and physical_port in transceiver_status_cache:
-            # If cache is enabled and status info is in cache, just read from cache, no need read from EEPROM
-            transceiver_status_dict = transceiver_status_cache[physical_port]
-        else:
-            transceiver_status_dict = _wrapper_get_transceiver_status(physical_port)
-            if transceiver_status_cache is not None:
-                # If cache is enabled, put status info to cache
-                transceiver_status_cache[physical_port] = transceiver_status_dict
-        if transceiver_status_dict is not None:
-            # Skip if empty (i.e. get_transceiver_status API is not applicable for this xcvr)
-            if not transceiver_status_dict:
-                continue
-            beautify_transceiver_status_dict(transceiver_status_dict, physical_port)
-            fvs = swsscommon.FieldValuePairs([(k, v) for k, v in transceiver_status_dict.items()])
-            table.set(physical_port_name, fvs)
-        else:
-            return SFP_EEPROM_NOT_READY
 
 # Delete port from SFP status table
 
@@ -1678,191 +1520,6 @@ class CmisManagerTask(threading.Thread):
             if self.exc:
                 raise self.exc
 
-# Thread wrapper class to update dom info periodically
-
-
-class DomInfoUpdateTask(threading.Thread):
-    def __init__(self, namespaces, port_mapping, main_thread_stop_event, skip_cmis_mgr):
-        threading.Thread.__init__(self)
-        self.name = "DomInfoUpdateTask"
-        self.exc = None
-        self.task_stopping_event = threading.Event()
-        self.main_thread_stop_event = main_thread_stop_event
-        self.port_mapping = copy.deepcopy(port_mapping)
-        self.namespaces = namespaces
-        self.skip_cmis_mgr = skip_cmis_mgr
-
-    def get_dom_polling_from_config_db(self, lport):
-        """
-            Returns the value of dom_polling field from PORT table in CONFIG_DB
-            For non-breakout ports, this function will get dom_polling field from PORT table of lport (subport = 0)
-            For breakout ports, this function will get dom_polling field from PORT table of the first subport
-            of lport's correpsonding breakout group (subport = 1)
-
-            Returns:
-                'disabled' if dom_polling is set to 'disabled', otherwise 'enabled'
-        """
-        dom_polling = 'enabled'
-
-        pport_list = self.port_mapping.get_logical_to_physical(lport)
-        if not pport_list:
-            helper_logger.log_warning("Get dom disabled: Got unknown physical port list {} for lport {}".format(pport_list, lport))
-            return dom_polling
-        pport = pport_list[0]
-
-        logical_port_list = self.port_mapping.get_physical_to_logical(pport)
-        if logical_port_list is None:
-            helper_logger.log_warning("Get dom disabled: Got unknown FP port index {}".format(pport))
-            return dom_polling
-
-        # Sort the logical port list to make sure we always get the first subport
-        logical_port_list = natsorted(logical_port_list, key=lambda y: y.lower())
-        first_logical_port = logical_port_list[0]
-
-        asic_index = self.port_mapping.get_asic_id_for_logical_port(first_logical_port)
-        port_tbl = self.xcvr_table_helper.get_cfg_port_tbl(asic_index)
-
-        found, port_info = port_tbl.get(first_logical_port)
-        if found and 'dom_polling' in dict(port_info):
-            dom_polling = dict(port_info)['dom_polling']
-
-        return dom_polling
-
-    """
-    Checks if the port is going through CMIS initialization process
-    This API assumes CMIS_STATE_UNKNOWN as a transitional state since it is the
-    first state after starting CMIS state machine.
-    This assumption allows the DomInfoUpdateTask thread to skip polling on the port
-    to allow CMIS initialization to complete if needed.
-    Returns:
-        True if the port is in CMIS initialization process,
-        otherwise False
-    """
-    def is_port_in_cmis_initialization_process(self, logical_port_name):
-        # If CMIS manager is not available for the platform, return False
-        if self.skip_cmis_mgr:
-            return False
-
-        asic_index = self.port_mapping.get_asic_id_for_logical_port(logical_port_name)
-        if asic_index is None:
-            helper_logger.log_warning("Got invalid asic index for {} while checking cmis init status".format(logical_port_name))
-            return False
-
-        cmis_state = get_cmis_state_from_state_db(logical_port_name, self.xcvr_table_helper.get_status_tbl(asic_index))
-        if cmis_state not in CMIS_TERMINAL_STATES:
-            return True
-        else:
-            return False
-
-    def is_port_dom_monitoring_disabled(self, logical_port_name):
-        return self.get_dom_polling_from_config_db(logical_port_name) == 'disabled' or \
-                self.is_port_in_cmis_initialization_process(logical_port_name)
-
-    def task_worker(self):
-        self.xcvr_table_helper = XcvrTableHelper(self.namespaces)
-        helper_logger.log_info("Start DOM monitoring loop")
-        firmware_info_cache = {}
-        dom_info_cache = {}
-        transceiver_status_cache = {}
-        pm_info_cache = {}
-        sel, asic_context = port_event_helper.subscribe_port_config_change(self.namespaces)
-
-        # Start loop to update dom info in DB periodically
-        while not self.task_stopping_event.wait(DOM_INFO_UPDATE_PERIOD_SECS):
-            # Clear the cache at the begin of the loop to make sure it will be clear each time
-            firmware_info_cache.clear()
-            dom_info_cache.clear()
-            transceiver_status_cache.clear()
-            pm_info_cache.clear()
-
-            # Handle port change event from main thread
-            port_event_helper.handle_port_config_change(sel, asic_context, self.task_stopping_event, self.port_mapping, helper_logger, self.on_port_config_change)
-            logical_port_list = self.port_mapping.logical_port_list
-            for logical_port_name in logical_port_list:
-                if self.is_port_dom_monitoring_disabled(logical_port_name):
-                    continue
-
-                # Get the asic to which this port belongs
-                asic_index = self.port_mapping.get_asic_id_for_logical_port(logical_port_name)
-                if asic_index is None:
-                    helper_logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
-                    continue
-
-                if not sfp_status_helper.detect_port_in_error_status(logical_port_name, self.xcvr_table_helper.get_status_tbl(asic_index)):
-                    try:
-                        post_port_sfp_firmware_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_firmware_info_tbl(asic_index), self.task_stopping_event, firmware_info_cache=firmware_info_cache)
-                    except (KeyError, TypeError) as e:
-                        #continue to process next port since execption could be raised due to port reset, transceiver removal
-                        helper_logger.log_warning("Got exception {} while processing firmware info for port {}, ignored".format(repr(e), logical_port_name))
-                        continue
-                    try:
-                        post_port_dom_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_dom_tbl(asic_index), self.task_stopping_event, dom_info_cache=dom_info_cache)
-                    except (KeyError, TypeError) as e:
-                        #continue to process next port since execption could be raised due to port reset, transceiver removal
-                        helper_logger.log_warning("Got exception {} while processing dom info for port {}, ignored".format(repr(e), logical_port_name))
-                        continue
-                    try:
-                        update_port_transceiver_status_table_hw(logical_port_name,
-                                                                self.port_mapping,
-                                                                self.xcvr_table_helper.get_status_tbl(asic_index),
-                                                                self.task_stopping_event,
-                                                                transceiver_status_cache=transceiver_status_cache)
-                    except (KeyError, TypeError) as e:
-                        #continue to process next port since execption could be raised due to port reset, transceiver removal
-                        helper_logger.log_warning("Got exception {} while processing transceiver status hw for port {}, ignored".format(repr(e), logical_port_name))
-                        continue
-                    try:
-                        post_port_pm_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_pm_tbl(asic_index), self.task_stopping_event, pm_info_cache=pm_info_cache)
-                    except (KeyError, TypeError) as e:
-                        #continue to process next port since execption could be raised due to port reset, transceiver removal
-                        helper_logger.log_warning("Got exception {} while processing pm info for port {}, ignored".format(repr(e), logical_port_name))
-                        continue
-
-        helper_logger.log_info("Stop DOM monitoring loop")
-
-    def run(self):
-        if self.task_stopping_event.is_set():
-            return
-        try:
-            self.task_worker()
-        except Exception as e:
-            helper_logger.log_error("Exception occured at {} thread due to {}".format(threading.current_thread().getName(), repr(e)))
-            log_exception_traceback()
-            self.exc = e
-            self.main_thread_stop_event.set()
-
-    def join(self):
-        self.task_stopping_event.set()
-        threading.Thread.join(self)
-        if self.exc:
-            raise self.exc
-
-    def on_port_config_change(self, port_change_event):
-        if port_change_event.event_type == port_event_helper.PortChangeEvent.PORT_REMOVE:
-            self.on_remove_logical_port(port_change_event)
-        self.port_mapping.handle_port_change_event(port_change_event)
-
-    def on_remove_logical_port(self, port_change_event):
-        """Called when a logical port is removed from CONFIG_DB
-
-        Args:
-            port_change_event (object): port change event
-        """
-        # To avoid race condition, remove the entry TRANSCEIVER_FIRMWARE_INFO, TRANSCEIVER_DOM_SENSOR, TRANSCEIVER_PM and HW section of TRANSCEIVER_STATUS table.
-        # This thread only updates TRANSCEIVER_FIRMWARE_INFO, TRANSCEIVER_DOM_SENSOR, TRANSCEIVER_PM and HW section of TRANSCEIVER_STATUS table,
-        # so we don't have to remove entries from TRANSCEIVER_INFO and TRANSCEIVER_DOM_THRESHOLD
-        del_port_sfp_dom_info_from_db(port_change_event.port_name,
-                                      self.port_mapping,
-                                      None,
-                                      self.xcvr_table_helper.get_dom_tbl(port_change_event.asic_id),
-                                      None,
-                                      self.xcvr_table_helper.get_pm_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_firmware_info_tbl(port_change_event.asic_id))
-        delete_port_from_status_table_hw(port_change_event.port_name,
-                                      self.port_mapping,
-                                      self.xcvr_table_helper.get_status_tbl(port_change_event.asic_id))
-
-
 # Thread wrapper class to update sfp state info periodically
 
 
@@ -2580,7 +2237,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
             self.threads.append(cmis_manager)
 
         # Start the dom sensor info update thread
-        dom_info_update = DomInfoUpdateTask(self.namespaces, port_mapping_data, self.stop_event, self.skip_cmis_mgr)
+        dom_info_update = DomInfoUpdateTask(self.namespaces, port_mapping_data, self.stop_event, self.skip_cmis_mgr, helper_logger)
         dom_info_update.start()
         self.threads.append(dom_info_update)
 
@@ -2596,7 +2253,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
 
         self.stop_event.wait()
 
-        self.log_info("Stop daemon main loop")
+        self.log_notice("Stop daemon main loop")
 
         generate_sigkill = False
         # check all threads are alive

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -78,9 +78,6 @@ def get_lane_speed_key(physical_port, port_speed, lane_count):
             host_electrical_interface_id = appl_adv_dict[app_id].get('host_electrical_interface_id')
             if host_electrical_interface_id:
                 lane_speed_key = LANE_SPEED_KEY_PREFIX + host_electrical_interface_id.split()[0]
-        if not lane_speed_key:
-            helper_logger.log_error("No host_electrical_interface_id found for CMIS module on physical port {}"
-                                    ", failed to construct lane_speed_key".format(physical_port))
     else:
         # Directly calculate lane speed and use it as key, this is especially useful for
         # non-CMIS transceivers which typically have no host_electrical_interface_id

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py
@@ -65,7 +65,9 @@ def get_optics_si_settings_value(physical_port, lane_speed, key, vendor_name_str
             if len(default_dict) != 0:
                 return default_dict
             else:
-                helper_logger.log_error("Error: No values for physical port '{}'".format(physical_port))
+                helper_logger.log_info("No values for physical port '{}' lane speed '{}' "
+                                       "key '{}' vendor '{}'".format(
+                                       physical_port, lane_speed, key, vendor_name_str))
             return {}
 
         key_dict = {}

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -1754,7 +1754,7 @@ class TestYCableScript(object):
             patched_util.get_asic_id_for_logical_port.return_value = 0
 
             rc = change_ports_status_for_y_cable_change_event(
-                logical_port_dict,  y_cable_presence, port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, state_db, stop_event=threading.Event())
+                logical_port_dict,  y_cable_presence, port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, state_db, stop_event=threading.Event())
 
             assert(rc == None)
 
@@ -1787,7 +1787,7 @@ class TestYCableScript(object):
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
             rc = change_ports_status_for_y_cable_change_event(
-                logical_port_dict,  y_cable_presence,  port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, state_db, stop_event=threading.Event())
+                logical_port_dict,  y_cable_presence,  port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, state_db, stop_event=threading.Event())
 
             assert(rc == None)
 
@@ -1831,7 +1831,7 @@ class TestYCableScript(object):
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
             rc = change_ports_status_for_y_cable_change_event(
-                logical_port_dict,  y_cable_presence,  port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, state_db, stop_event=threading.Event())
+                logical_port_dict,  y_cable_presence,  port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, state_db, stop_event=threading.Event())
 
             assert(rc == None)
 
@@ -1878,7 +1878,7 @@ class TestYCableScript(object):
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
             rc = change_ports_status_for_y_cable_change_event(
-                logical_port_dict,  y_cable_presence,  port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, state_db, stop_event=threading.Event())
+                logical_port_dict,  y_cable_presence,  port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, state_db, stop_event=threading.Event())
 
             assert(rc == None)
 
@@ -1918,7 +1918,7 @@ class TestYCableScript(object):
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
             rc = change_ports_status_for_y_cable_change_event(
-                logical_port_dict,  y_cable_presence,port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, state_db, stop_event=threading.Event())
+                logical_port_dict,  y_cable_presence,port_tbl, port_table_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, state_db, stop_event=threading.Event())
 
             assert(rc == None)
 
@@ -6496,7 +6496,7 @@ class TestYCableScript(object):
         port_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "PORT_INFO_TABLE")
         grpc_client , fwd_state_response_tbl = {}, {}
-        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0, port_tbl, grpc_client, fwd_state_response_tbl)
+        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0, port_tbl, grpc_client)
         assert(rc == False)
 
     @patch('ycable.ycable_utilities.y_cable_helper.setup_grpc_channel_for_port', MagicMock(return_value=(None,None)))
@@ -6514,7 +6514,7 @@ class TestYCableScript(object):
         port_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "PORT_INFO_TABLE")
         grpc_client , fwd_state_response_tbl = {}, {}
-        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0, port_tbl, grpc_client, fwd_state_response_tbl)
+        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0, port_tbl, grpc_client)
         assert(rc == False)
 
     def test_process_loopback_interface_and_get_read_side_rc(self):
@@ -6532,7 +6532,7 @@ class TestYCableScript(object):
         port_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "PORT_INFO_TABLE")
         grpc_client , fwd_state_response_tbl = {}, {}
-        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0 , port_tbl, grpc_client, fwd_state_response_tbl )
+        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0 , port_tbl, grpc_client)
         assert(rc == False)
 
     @patch('ycable.ycable_utilities.y_cable_helper.setup_grpc_channel_for_port', MagicMock(return_value=(True,True)))
@@ -6550,7 +6550,7 @@ class TestYCableScript(object):
         port_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "PORT_INFO_TABLE")
         grpc_client , fwd_state_response_tbl = {}, {}
-        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0, port_tbl, grpc_client, fwd_state_response_tbl)
+        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0, port_tbl, grpc_client)
         assert(rc == True)
 
     @patch('ycable.ycable_utilities.y_cable_helper.setup_grpc_channel_for_port', MagicMock(return_value=(None,None)))
@@ -6568,7 +6568,7 @@ class TestYCableScript(object):
         port_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "PORT_INFO_TABLE")
         grpc_client , fwd_state_response_tbl = {}, {}
-        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0, port_tbl, grpc_client, fwd_state_response_tbl)
+        rc = retry_setup_grpc_channel_for_port("Ethernet0", 0, port_tbl, grpc_client)
         assert(rc == False)
 
     def test_process_loopback_interface_and_get_read_side_rc(self):
@@ -6619,7 +6619,7 @@ class TestYCableScript(object):
         mux_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "MUX_INFO_TABLE")
 
-        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence, grpc_client, fwd_state_response_tbl)
+        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence, grpc_client)
 
         assert(rc == None)
 
@@ -6655,7 +6655,7 @@ class TestYCableScript(object):
         mux_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "MUX_INFO_TABLE")
 
-        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence, grpc_client, fwd_state_response_tbl)
+        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence, grpc_client)
 
         assert(rc == None)
 
@@ -6692,7 +6692,7 @@ class TestYCableScript(object):
         mux_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "MUX_INFO_TABLE")
 
-        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence, grpc_client, fwd_state_response_tbl)
+        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence, grpc_client)
         assert(rc == None)
 
 
@@ -6730,7 +6730,7 @@ class TestYCableScript(object):
         mux_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], "MUX_INFO_TABLE")
 
-        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence, grpc_client, fwd_state_response_tbl)
+        rc = check_identifier_presence_and_setup_channel("Ethernet0", port_tbl, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index, read_side, mux_tbl, y_cable_presence, grpc_client)
 
         assert(rc == None)
 
@@ -6754,7 +6754,7 @@ class TestYCableScript(object):
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
-            (channel, stub) = setup_grpc_channel_for_port("Ethernet0", "192.168.0.1", asic_index, grpc_client, fwd_state_response_tbl, False)
+            (channel, stub) = setup_grpc_channel_for_port("Ethernet0", "192.168.0.1", asic_index, grpc_client, False)
 
         assert(stub == True)
         assert(channel != None)
@@ -6779,7 +6779,7 @@ class TestYCableScript(object):
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
             patched_util.get_asic_id_for_logical_port.return_value = 0
-            (channel, stub) = setup_grpc_channel_for_port("Ethernet0", "192.168.0.1", asic_index, grpc_client, fwd_state_response_tbl, False)
+            (channel, stub) = setup_grpc_channel_for_port("Ethernet0", "192.168.0.1", asic_index, grpc_client, False)
 
         assert(stub == True)
         assert(channel != None)
@@ -6803,7 +6803,7 @@ class TestYCableScript(object):
             patched_util.logical.return_value = ['Ethernet0', 'Ethernet4']
             patched_util.get_asic_id_for_logical_port.return_value = 0
             loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, port_tbl, loopback_tbl, port_table_keys, grpc_client, fwd_state_response_tbl = {}, {}, {}, {}, {}, {}, {}, {}
-            rc = setup_grpc_channels(stop_event, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, port_tbl, loopback_tbl, port_table_keys, grpc_client, fwd_state_response_tbl)
+            rc = setup_grpc_channels(stop_event, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, port_tbl, loopback_tbl, port_table_keys, grpc_client)
 
             assert(rc == None)
 
@@ -7764,3 +7764,25 @@ class TestYcableScriptExecution(object):
         assert swsscommon.Select.select.call_count == 1
 
 
+    def test_ycable_wait_for_state_change(self):
+
+        channel_conn = grpc.ChannelConnectivity.TRANSIENT_FAILURE
+        port = 'Ethernet0'
+        rc = wait_for_state_change(channel_conn, port)
+
+        assert (rc == None)
+
+        channel_conn = grpc.ChannelConnectivity.CONNECTING
+        rc = wait_for_state_change(channel_conn, port)
+
+        assert (rc == None)
+
+        channel_conn = grpc.ChannelConnectivity.READY
+        rc = wait_for_state_change(channel_conn, port)
+
+        assert (rc == None)
+
+        channel_conn = grpc.ChannelConnectivity.SHUTDOWN
+        rc = wait_for_state_change(channel_conn, port)
+
+        assert (rc == None)

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -113,7 +113,7 @@ def handle_state_update_task(op, port, fvp_dict, y_cable_presence, port_tbl, por
         port_dict[port] = SFP_STATUS_REMOVED
 
     y_cable_helper.change_ports_status_for_y_cable_change_event(
-        port_dict, y_cable_presence, port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, state_db, stopping_event)
+        port_dict, y_cable_presence, port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, state_db, stopping_event)
 
 #
 # Helper classes ===============================================================


### PR DESCRIPTION
202405 cherry-pick for https://github.com/sonic-net/sonic-platform-daemons/pull/672

Description
This PR improves the logging in the optics SI parser to provide better diagnostic information when unable to find an appropriate match for optic SI settings for a physical port.

Motivation and Context
The previous log message was an error which is misleading since there can be genuine cases wherein optics SI settings are not present for a module.
Hence, changing the log level to INFO and adding more debug data.

How Has This Been Tested?
Verified

Additional Information (Optional)
MSFT ADO - 34731836