### PR TITLE
Handle restore_count and system_enable ”NoneType“ value scenario.

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -509,6 +509,38 @@ class TestXcvrdScript(object):
         dom_info_update.post_port_sfp_firmware_info_to_db(logical_port_name, port_mapping, firmware_info_tbl, stop_event)
         assert firmware_info_tbl.set.call_count == 0
 
+    @pytest.mark.parametrize(
+        "restore_count, system_enabled, expected",
+        [
+            (1, None, True),
+            (0, None, False),
+            ("2", None, True),
+            ("0", None, False),
+            (None, "true", True),
+            (None, "false", False),
+            (None, None, False),
+        ]
+    )
+    def test_is_syncd_warm_restore_complete_valid_cases(self, restore_count, system_enabled, expected):
+        mock_db = MagicMock()
+        mock_db.hget.side_effect = lambda table, key: (
+            restore_count if "WARM_RESTART_TABLE|syncd" in table else system_enabled
+        )
+
+        with patch("xcvrd.xcvrd.daemon_base.db_connect", return_value=mock_db):
+            assert is_syncd_warm_restore_complete() == expected
+
+    def test_is_syncd_warm_restore_complete_invalid_restore_count(self):
+        # restore_count = "abc" triggers ValueError in int("abc")
+        mock_db = MagicMock()
+        mock_db.hget.side_effect = lambda table, key: (
+            "abc" if "WARM_RESTART_TABLE|syncd" in table else None
+        )
+
+        with patch("xcvrd.xcvrd.daemon_base.db_connect", return_value=mock_db):
+            result = is_syncd_warm_restore_complete()
+            assert result is False
+
     def test_post_port_dom_sensor_info_to_db(self):
         def mock_get_transceiver_dom_sensor_real_value(physical_port):
             return {

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -462,7 +462,7 @@ def is_warm_reboot_enabled():
     is_warm_start = warmstart.isWarmStart()
     return is_warm_start
 
-def is_syncd_warm_restore_complete():
+def is_syncd_warm_restore_complete(self):
     """
     This function determins whether syncd's restore count is not 0, which indicates warm-reboot
     to avoid premature config push by xcvrd that caused port flaps.

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -486,8 +486,8 @@ def is_syncd_warm_restore_complete():
                 return True
 
     except Exception as e:
-        helper_logger.log_warning(f"[WARN] Unexpected value: restore_count={restore_count}, system_enabled={system_enabled}, error={e}")
-
+        helper_logger.log_warning(f" Unexpected value: restore_count={restore_count}, system_enabled={system_enabled}, error={e}")
+        log_exception_traceback()
     return False
 
 #

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -486,7 +486,7 @@ def is_syncd_warm_restore_complete():
                 return True
 
     except Exception as e:
-        helper_logger.log_warning(f" Unexpected value: restore_count={restore_count}, system_enabled={system_enabled}, error={e}")
+        helper_logger.log_warning(f"Unexpected value: restore_count={restore_count}, system_enabled={system_enabled}, error={e}")
         log_exception_traceback()
     return False
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -462,7 +462,7 @@ def is_warm_reboot_enabled():
     is_warm_start = warmstart.isWarmStart()
     return is_warm_start
 
-def is_syncd_warm_restore_complete(self):
+def is_syncd_warm_restore_complete():
     """
     This function determins whether syncd's restore count is not 0, which indicates warm-reboot
     to avoid premature config push by xcvrd that caused port flaps.

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -486,7 +486,7 @@ def is_syncd_warm_restore_complete(self):
                 return True
 
     except Exception as e:
-        self.log_warning(f"[WARN] Unexpected value: restore_count={restore_count}, system_enabled={system_enabled}, error={e}")
+        helper_logger.log_warning(f"[WARN] Unexpected value: restore_count={restore_count}, system_enabled={system_enabled}, error={e}")
 
     return False
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -462,6 +462,34 @@ def is_warm_reboot_enabled():
     is_warm_start = warmstart.isWarmStart()
     return is_warm_start
 
+def is_syncd_warm_restore_complete():
+    """
+    This function determins whether syncd's restore count is not 0, which indicates warm-reboot
+    to avoid premature config push by xcvrd that caused port flaps.
+    """
+    state_db = daemon_base.db_connect("STATE_DB")
+    restore_count = state_db.hget("WARM_RESTART_TABLE|syncd", "restore_count")
+    system_enabled = state_db.hget("WARM_RESTART_ENABLE_TABLE|system", "enable")
+    try:
+        # --- Handle restore_count (could be int, str, or None) ---
+        if restore_count is not None:
+            if isinstance(restore_count, int):
+                if restore_count > 0:
+                    return True
+            elif isinstance(restore_count, str):
+                if restore_count.strip().isdigit() and int(restore_count.strip()) > 0:
+                    return True
+
+        # --- Handle system_enabled (only care about "true"/"false"/None) ---
+        if isinstance(system_enabled, str):
+            if system_enabled.strip().lower() == "true":
+                return True
+
+    except Exception as e:
+        self.log_warning(f"[WARN] Unexpected value: restore_count={restore_count}, system_enabled={system_enabled}, error={e}")
+
+    return False
+
 #
 # Helper classes ===============================================================
 #
@@ -1493,7 +1521,7 @@ class SfpStateUpdateTask(threading.Thread):
         transceiver_dict = {}
         retry_eeprom_set = set()
 
-        is_warm_start = is_warm_reboot_enabled()
+        is_warm_start = is_syncd_warm_restore_complete()
         # Post all the current interface sfp/dom threshold info to STATE_DB
         logical_port_list = port_mapping.logical_port_list
         for logical_port_name in logical_port_list:
@@ -2216,7 +2244,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
     def deinit(self):
         self.log_info("Start daemon deinit...")
 
-        is_warm_fast_reboot = is_warm_reboot_enabled() or is_fast_reboot_enabled()
+        is_warm_fast_reboot = is_syncd_warm_restore_complete() or is_fast_reboot_enabled()
 
         # Delete all the information from DB and then exit
         port_mapping_data = port_event_helper.get_port_mapping(self.namespaces)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Handle restore_count and system_enable ”NoneType“ value scenario.

#### Motivation and Context
SFP didn't come back when system_enable is NoneType and run into failure.

#### How Has This Been Tested?
```
root@str-msn2700-20:/tmp# cat test.py
#!/usr/bin/env python3
from swsscommon import swsscommon

def get_state_db():
    return swsscommon.DBConnector("STATE_DB", 0)

def is_syncd_warm_restore_complete(restore_count, system_enabled):
    try:
        # --- Handle restore_count (could be int, str, or None) ---
        if restore_count is not None:
            if isinstance(restore_count, int):
                if restore_count > 0:
                    return True
            elif isinstance(restore_count, str):
                if restore_count.strip().isdigit() and int(restore_count.strip()) > 0:
                    return True

        # --- Handle system_enabled (only care about "true"/"false"/None) ---
        if isinstance(system_enabled, str):
            if system_enabled.strip().lower() == "true":
                return True

    except Exception as e:
        print(f"[WARN] Unexpected value: restore_count={restore_count}, system_enabled={system_enabled}, error={e}")

    return False

def main():
    state_db = get_state_db()

    restore_count = state_db.hget("WARM_RESTART_TABLE|syncd", "restore_count")
    system_enabled = state_db.hget("WARM_RESTART_ENABLE_TABLE|system", "enable")

    result = is_syncd_warm_restore_complete(restore_count, system_enabled)

    print("restore_count (raw):", restore_count)
    print("system_enabled (raw):", system_enabled)
    print("=> is_syncd_warm_restore_complete =", result)

if __name__ == "__main__":
    main()

root@str-msn2700-20:/tmp# python3 test.py
restore_count (raw): 0
system_enabled (raw): None
=> is_syncd_warm_restore_complete = False
```
20250510.17 same image cold reboot passed.
```
root@bjw2-can-7260-1:~# show reboot-cause
User issued 'reboot' command [User: admin, Time: Mon Sep  8 10:20:16 PM UTC 2025]
root@bjw2-can-7260-1:~# redis-cli -n 6 keys TRANSCEIVER_INFO\*
  1) "TRANSCEIVER_INFO|Ethernet64"
  2) "TRANSCEIVER_INFO|Ethernet140"
  3) "TRANSCEIVER_INFO|Ethernet24"
  4) "TRANSCEIVER_INFO|Ethernet250"
  5) "TRANSCEIVER_INFO|Ethernet36"
  6) "TRANSCEIVER_INFO|Ethernet142"
  7) "TRANSCEIVER_INFO|Ethernet0"
  8) "TRANSCEIVER_INFO|Ethernet8"
  9) "TRANSCEIVER_INFO|Ethernet182"
10) "TRANSCEIVER_INFO|Ethernet92"
11) "TRANSCEIVER_INFO|Ethernet38"
12) "TRANSCEIVER_INFO|Ethernet156"
13) "TRANSCEIVER_INFO|Ethernet168"
14) "TRANSCEIVER_INFO|Ethernet52"
15) "TRANSCEIVER_INFO|Ethernet14"
16) "TRANSCEIVER_INFO|Ethernet100"
17) "TRANSCEIVER_INFO|Ethernet44"
18) "TRANSCEIVER_INFO|Ethernet170"
19) "TRANSCEIVER_INFO|Ethernet48"
20) "TRANSCEIVER_INFO|Ethernet122"
21) "TRANSCEIVER_INFO|Ethernet238"
22) "TRANSCEIVER_INFO|Ethernet208"
23) "TRANSCEIVER_INFO|Ethernet6"
24) "TRANSCEIVER_INFO|Ethernet26"
25) "TRANSCEIVER_INFO|Ethernet192"
26) "TRANSCEIVER_INFO|Ethernet46"
27) "TRANSCEIVER_INFO|Ethernet198"
28) "TRANSCEIVER_INFO|Ethernet236"
29) "TRANSCEIVER_INFO|Ethernet126"
30) "TRANSCEIVER_INFO|Ethernet260"
31) "TRANSCEIVER_INFO|Ethernet68"
32) "TRANSCEIVER_INFO|Ethernet10"
33) "TRANSCEIVER_INFO|Ethernet2"
34) "TRANSCEIVER_INFO|Ethernet224"
35) "TRANSCEIVER_INFO|Ethernet124"
36) "TRANSCEIVER_INFO|Ethernet166"
37) "TRANSCEIVER_INFO|Ethernet12"
38) "TRANSCEIVER_INFO|Ethernet200"
39) "TRANSCEIVER_INFO|Ethernet82"
40) "TRANSCEIVER_INFO|Ethernet106"
41) "TRANSCEIVER_INFO|Ethernet110"
42) "TRANSCEIVER_INFO|Ethernet96"
43) "TRANSCEIVER_INFO|Ethernet196"
44) "TRANSCEIVER_INFO|Ethernet20"
45) "TRANSCEIVER_INFO|Ethernet152"
46) "TRANSCEIVER_INFO|Ethernet28"
47) "TRANSCEIVER_INFO|Ethernet194"
48) "TRANSCEIVER_INFO|Ethernet174"
49) "TRANSCEIVER_INFO|Ethernet220"
50) "TRANSCEIVER_INFO|Ethernet252"
51) "TRANSCEIVER_INFO|Ethernet76"
52) "TRANSCEIVER_INFO|Ethernet138"
53) "TRANSCEIVER_INFO|Ethernet72"
54) "TRANSCEIVER_INFO|Ethernet246"
55) "TRANSCEIVER_INFO|Ethernet104"
56) "TRANSCEIVER_INFO|Ethernet94"
57) "TRANSCEIVER_INFO|Ethernet254"
58) "TRANSCEIVER_INFO|Ethernet158"
59) "TRANSCEIVER_INFO|Ethernet42"
60) "TRANSCEIVER_INFO|Ethernet202"
61) "TRANSCEIVER_INFO|Ethernet154"
62) "TRANSCEIVER_INFO|Ethernet240"
63) "TRANSCEIVER_INFO|Ethernet160"
64) "TRANSCEIVER_INFO|Ethernet90"
65) "TRANSCEIVER_INFO|Ethernet80"
66) "TRANSCEIVER_INFO|Ethernet188"
67) "TRANSCEIVER_INFO|Ethernet226"
68) "TRANSCEIVER_INFO|Ethernet22"
69) "TRANSCEIVER_INFO|Ethernet242"
70) "TRANSCEIVER_INFO|Ethernet56"
71) "TRANSCEIVER_INFO|Ethernet162"
72) "TRANSCEIVER_INFO|Ethernet232"
73) "TRANSCEIVER_INFO|Ethernet212"
74) "TRANSCEIVER_INFO|Ethernet108"
75) "TRANSCEIVER_INFO|Ethernet86"
76) "TRANSCEIVER_INFO|Ethernet134"
77) "TRANSCEIVER_INFO|Ethernet114"
78) "TRANSCEIVER_INFO|Ethernet234"
79) "TRANSCEIVER_INFO|Ethernet186"
80) "TRANSCEIVER_INFO|Ethernet228"
81) "TRANSCEIVER_INFO|Ethernet184"
82) "TRANSCEIVER_INFO|Ethernet120"
83) "TRANSCEIVER_INFO|Ethernet84"
84) "TRANSCEIVER_INFO|Ethernet206"
85) "TRANSCEIVER_INFO|Ethernet88"
86) "TRANSCEIVER_INFO|Ethernet214"
87) "TRANSCEIVER_INFO|Ethernet132"
88) "TRANSCEIVER_INFO|Ethernet204"
89) "TRANSCEIVER_INFO|Ethernet144"
90) "TRANSCEIVER_INFO|Ethernet248"
91) "TRANSCEIVER_INFO|Ethernet4"
92) "TRANSCEIVER_INFO|Ethernet40"
93) "TRANSCEIVER_INFO|Ethernet102"
94) "TRANSCEIVER_INFO|Ethernet176"
95) "TRANSCEIVER_INFO|Ethernet116"
96) "TRANSCEIVER_INFO|Ethernet98"
97) "TRANSCEIVER_INFO|Ethernet230"
98) "TRANSCEIVER_INFO|Ethernet164"
99) "TRANSCEIVER_INFO|Ethernet128"
100) "TRANSCEIVER_INFO|Ethernet34"
101) "TRANSCEIVER_INFO|Ethernet130"
102) "TRANSCEIVER_INFO|Ethernet180"
103) "TRANSCEIVER_INFO|Ethernet16"
104) "TRANSCEIVER_INFO|Ethernet18"
105) "TRANSCEIVER_INFO|Ethernet218"
106) "TRANSCEIVER_INFO|Ethernet112"
107) "TRANSCEIVER_INFO|Ethernet244"
108) "TRANSCEIVER_INFO|Ethernet190"
109) "TRANSCEIVER_INFO|Ethernet136"
110) "TRANSCEIVER_INFO|Ethernet60"
111) "TRANSCEIVER_INFO|Ethernet30"
112) "TRANSCEIVER_INFO|Ethernet178"
113) "TRANSCEIVER_INFO|Ethernet222"
114) "TRANSCEIVER_INFO|Ethernet148"
115) "TRANSCEIVER_INFO|Ethernet216"
116) "TRANSCEIVER_INFO|Ethernet172"
117) "TRANSCEIVER_INFO|Ethernet210"
118) "TRANSCEIVER_INFO|Ethernet146"
119) "TRANSCEIVER_INFO|Ethernet32"
120) "TRANSCEIVER_INFO|Ethernet118"
121) "TRANSCEIVER_INFO|Ethernet150"
root@bjw2-can-7260-2:~# show int status
     Interface            Lanes    Speed    MTU    FEC         Alias            Vlan    Oper    Admin             Type    Asym PFC
--------------  ---------------  -------  -----  -----  ------------  --------------  ------  -------  ---------------  ----------
     Ethernet0            77,78      50G   9100    N/A   Ethernet1/1           trunk      up       up  QSFP28 or later         off
     Ethernet2            79,80      50G   9100    N/A   Ethernet1/3           trunk      up       up  QSFP28 or later         off
     Ethernet4            65,66      50G   9100    N/A   Ethernet2/1           trunk      up       up  QSFP28 or later         off
     Ethernet6            67,68      50G   9100    N/A   Ethernet2/3           trunk      up       up  QSFP28 or later         off
     Ethernet8            85,86      50G   9100    N/A   Ethernet3/1           trunk      up       up  QSFP28 or later         off
    Ethernet10            87,88      50G   9100    N/A   Ethernet3/3           trunk      up       up  QSFP28 or later         off
    Ethernet12            89,90      50G   9100    N/A   Ethernet4/1           trunk      up       up  QSFP28 or later         off
    Ethernet14            91,92      50G   9100    N/A   Ethernet4/3           trunk      up       up  QSFP28 or later         off
    Ethernet16          109,110      50G   9100    N/A   Ethernet5/1           trunk      up       up  QSFP28 or later         off
    Ethernet18          111,112      50G   9100    N/A   Ethernet5/3           trunk      up       up  QSFP28 or later         off
    Ethernet20            97,98      50G   9100    N/A   Ethernet6/1           trunk      up       up  QSFP28 or later         off
    Ethernet22           99,100      50G   9100    N/A   Ethernet6/3           trunk      up       up  QSFP28 or later         off
    Ethernet24              5,6      50G   9100    N/A   Ethernet7/1           trunk      up       up  QSFP28 or later         off
    Ethernet26              7,8      50G   9100    N/A   Ethernet7/3           trunk      up       up  QSFP28 or later         off
    Ethernet28            13,14      50G   9100    N/A   Ethernet8/1           trunk      up       up  QSFP28 or later         off
    Ethernet30            15,16      50G   9100    N/A   Ethernet8/3           trunk      up       up  QSFP28 or later         off
    Ethernet32            25,26      50G   9100    N/A   Ethernet9/1           trunk      up       up  QSFP28 or later         off
    Ethernet34            27,28      50G   9100    N/A   Ethernet9/3           trunk      up       up  QSFP28 or later         off
    Ethernet36            21,22      50G   9100    N/A  Ethernet10/1           trunk      up       up  QSFP28 or later         off
    Ethernet38            23,24      50G   9100    N/A  Ethernet10/3           trunk      up       up  QSFP28 or later         off
    Ethernet40            37,38      50G   9100    N/A  Ethernet11/1           trunk      up       up  QSFP28 or later         off
    Ethernet42            39,40      50G   9100    N/A  Ethernet11/3           trunk      up       up  QSFP28 or later         off
    Ethernet44            45,46      50G   9100    N/A  Ethernet12/1           trunk      up       up  QSFP28 or later         off
    Ethernet46            47,48      50G   9100    N/A  Ethernet12/3           trunk      up       up  QSFP28 or later         off
    Ethernet48      57,58,59,60     100G   9100     rs  Ethernet13/1  PortChannel101      up       up  QSFP28 or later         off
    Ethernet52      53,54,55,56     100G   9100     rs  Ethernet14/1  PortChannel101      up       up  QSFP28 or later         off
    Ethernet56  117,118,119,120     100G   9100     rs  Ethernet15/1  PortChannel102      up       up  QSFP28 or later         off
    Ethernet60  121,122,123,124     100G   9100     rs  Ethernet16/1  PortChannel102      up       up  QSFP28 or later         off
    Ethernet64  141,142,143,144     100G   9100     rs  Ethernet17/1  PortChannel103      up       up  QSFP28 or later         off
    Ethernet68  133,134,135,136     100G   9100     rs  Ethernet18/1  PortChannel103      up       up  QSFP28 or later         off
    Ethernet72  197,198,199,200     100G   9100     rs  Ethernet19/1  PortChannel104      up       up  QSFP28 or later         off
    Ethernet76  205,206,207,208     100G   9100     rs  Ethernet20/1  PortChannel104      up       up  QSFP28 or later         off
    Ethernet80          217,218      50G   9100    N/A  Ethernet21/1           trunk      up       up  QSFP28 or later         off
    Ethernet82          219,220      50G   9100    N/A  Ethernet21/3           trunk      up       up  QSFP28 or later         off
    Ethernet84          213,214      50G   9100    N/A  Ethernet22/1           trunk      up       up  QSFP28 or later         off
    Ethernet86          215,216      50G   9100    N/A  Ethernet22/3           trunk      up       up  QSFP28 or later         off
    Ethernet88          229,230      50G   9100    N/A  Ethernet23/1           trunk      up       up  QSFP28 or later         off
    Ethernet90          231,232      50G   9100    N/A  Ethernet23/3           trunk      up       up  QSFP28 or later         off
    Ethernet92          237,238      50G   9100    N/A  Ethernet24/1           trunk      up       up  QSFP28 or later         off
    Ethernet94          239,240      50G   9100    N/A  Ethernet24/3           trunk      up       up  QSFP28 or later         off
    Ethernet96          249,250      50G   9100    N/A  Ethernet25/1           trunk      up       up  QSFP28 or later         off
    Ethernet98          251,252      50G   9100    N/A  Ethernet25/3           trunk      up       up  QSFP28 or later         off
   Ethernet100          245,246      50G   9100    N/A  Ethernet26/1           trunk      up       up  QSFP28 or later         off
   Ethernet102          247,248      50G   9100    N/A  Ethernet26/3           trunk      up       up  QSFP28 or later         off
   Ethernet104          149,150      50G   9100    N/A  Ethernet27/1           trunk      up       up  QSFP28 or later         off
   Ethernet106          151,152      50G   9100    N/A  Ethernet27/3           trunk      up       up  QSFP28 or later         off
   Ethernet108          153,154      50G   9100    N/A  Ethernet28/1           trunk      up       up  QSFP28 or later         off
   Ethernet110          155,156      50G   9100    N/A  Ethernet28/3           trunk      up       up  QSFP28 or later         off
```
20241110.30 -> 20250510.17 warm reboot:
```
admin@str2-7060cx-32s-29:/var/log$ sudo show reboot-cause
User issued 'warm-reboot' command [User: admin, Time: Tue Sep  9 12:56:05 AM UTC 2025]
admin@str2-7060cx-32s-29:/var/log$ sudo grep -E "to down|to up" /var/log/syslog
2025 Sep  9 00:59:35.769479 str2-7060cx-32s-29 NOTICE teamd#teammgrd: :- setLagAdminStatus: Set port channel PortChannel101 admin status to up
2025 Sep  9 00:59:36.051253 str2-7060cx-32s-29 NOTICE teamd#teammgrd: :- setLagAdminStatus: Set port channel PortChannel102 admin status to up
2025 Sep  9 00:59:36.237499 str2-7060cx-32s-29 NOTICE teamd#teammgrd: :- setLagAdminStatus: Set port channel PortChannel103 admin status to up
2025 Sep  9 00:59:36.502966 str2-7060cx-32s-29 NOTICE teamd#teammgrd: :- setLagAdminStatus: Set port channel PortChannel104 admin status to up
2025 Sep  9 01:00:02.772803 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet0 admin status to down
2025 Sep  9 01:00:02.833012 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet100 admin status to down
2025 Sep  9 01:00:02.873239 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet104 admin status to down
2025 Sep  9 01:00:02.954506 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet108 admin status to down
2025 Sep  9 01:00:03.022578 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet112 admin status to up
2025 Sep  9 01:00:03.120151 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet116 admin status to up
2025 Sep  9 01:00:03.182558 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet12 admin status to up
2025 Sep  9 01:00:03.255291 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet120 admin status to up
2025 Sep  9 01:00:03.313936 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet124 admin status to up
2025 Sep  9 01:00:03.382784 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet16 admin status to up
2025 Sep  9 01:00:03.430273 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet20 admin status to up
2025 Sep  9 01:00:03.496863 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet24 admin status to up
2025 Sep  9 01:00:03.565550 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet28 admin status to up
2025 Sep  9 01:00:03.622927 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet32 admin status to up
2025 Sep  9 01:00:03.683946 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet36 admin status to up
2025 Sep  9 01:00:03.726294 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet4 admin status to up
2025 Sep  9 01:00:03.787884 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet40 admin status to up
2025 Sep  9 01:00:03.841726 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet44 admin status to up
2025 Sep  9 01:00:03.916285 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet48 admin status to up
2025 Sep  9 01:00:03.962632 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet52 admin status to up
2025 Sep  9 01:00:04.018857 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet56 admin status to up
2025 Sep  9 01:00:04.081088 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet60 admin status to up
2025 Sep  9 01:00:04.145039 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet64 admin status to up
2025 Sep  9 01:00:04.196280 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet68 admin status to up
2025 Sep  9 01:00:04.240887 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet72 admin status to up
2025 Sep  9 01:00:04.294277 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet76 admin status to up
2025 Sep  9 01:00:04.362301 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet8 admin status to up
2025 Sep  9 01:00:04.415837 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet80 admin status to up
2025 Sep  9 01:00:04.472724 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet84 admin status to up
2025 Sep  9 01:00:04.521157 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet88 admin status to up
2025 Sep  9 01:00:04.567213 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet92 admin status to up
2025 Sep  9 01:00:04.623856 str2-7060cx-32s-29 NOTICE swss#portmgrd: :- doTask: Configure Ethernet96 admin status to up
2025 Sep  9 01:00:06.557649 str2-7060cx-32s-29 NOTICE swss#orchagent: :- updatePortOperStatus: Port PortChannel101 oper state set from unknown to down
2025 Sep  9 01:00:06.559773 str2-7060cx-32s-29 NOTICE swss#orchagent: :- updatePortOperStatus: Port PortChannel102 oper state set from unknown to down
2025 Sep  9 01:00:06.561931 str2-7060cx-32s-29 NOTICE swss#orchagent: :- updatePortOperStatus: Port PortChannel103 oper state set from unknown to down
2025 Sep  9 01:00:06.563959 str2-7060cx-32s-29 NOTICE swss#orchagent: :- updatePortOperStatus: Port PortChannel104 oper state set from unknown to down
```

#### Additional Information (Optional)
