### PR TITLE
[Smartswitch][DPU]Add multiple key handling

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -1555,6 +1555,10 @@ class DpuStateManagerTask(ProcessTaskBase):
                     if result is None:
                         continue
                     key, op, fvp = result  # Changed from _ to fvp to match what we use below
+                    if key != '' and s.getDbConnector().getDbName() != 'CHASSIS_STATE_DB':
+                        # If there is any change in the non-DPU_STATE table, we need to update the state
+                        update_required = True
+                        break
                     # Check if this is the DPU_STATE table
                     if s.getDbConnector().getDbName() == 'CHASSIS_STATE_DB':
                         # Don't update if this is a change for another DPU

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -1555,10 +1555,6 @@ class DpuStateManagerTask(ProcessTaskBase):
                     if result is None:
                         continue
                     key, op, fvp = result  # Changed from _ to fvp to match what we use below
-                    if key != '' and s.getDbConnector().getDbName() != 'CHASSIS_STATE_DB':
-                        # If there is any change in the non-DPU_STATE table, we need to update the state
-                        update_required = True
-                        break
                     # Check if this is the DPU_STATE table
                     if s.getDbConnector().getDbName() == 'CHASSIS_STATE_DB':
                         # Don't update if this is a change for another DPU
@@ -1573,6 +1569,10 @@ class DpuStateManagerTask(ProcessTaskBase):
                                 update_required = False
                                 continue
                         self.logger.log_info(f"DPU_STATE change detected: operation={op}, key={key}")
+                    elif key:
+                        # If there is any change in the non-DPU_STATE table, we need to update the state
+                        update_required = True
+                        break
 
                 if update_required:
                     [self.current_dp_state, self.current_cp_state] = self.dpu_state_updater.update_state()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above --> 
#### Description <!-- Describe your changes in detail --> 
Main Logic Addition (sonic-chassisd/scripts/chassisd): Added a new condition check in the DpuStateManagerTask class The logic checks if there's a non-empty key AND the database is not 'CHASSIS_STATE_DB' When both conditions are true, it sets update_required = True and breaks out of the loop 
#### Motivation and Context <!-- Why is this change required? What problem does it solve? If this pull request closes/resolves an open Issue, make sure you include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here -->
When there is updates to multiple DBs at the same time, usually if there is update to CHASSIS_STATE_DB the update_required is set to false, this change is added to handle this case 
#### How Has This Been Tested? <!-- Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. --> 
``` tests/test_dpu_chassisd.py::test_dpu_state_manager_update_required_logic PASSED [100%] ``` 
Manual test to shutdown interface/service and confirm that the data plane/control plane interfaces are set to down 
#### Additional Information (Optional)