### PR TITLE
[xcvrd] Replace dom_* configuration flags with XcvrdConfig resolver

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -582,7 +582,7 @@ class TestXcvrdThreadException(object):
         mock_init.return_value = PortMapping()
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
         xcvrd.enable_sff_mgr = True
-        xcvrd.dom_temperature_poll_interval = 10
+        xcvrd.config.dom_temperature_poll_interval = 10
         xcvrd.load_feature_flags = MagicMock()
         xcvrd.stop_event.wait = MagicMock()
         xcvrd.run()
@@ -6942,27 +6942,26 @@ class TestXcvrdScript(object):
         # Test 5: Verify that DEFAULT_DOM_INFO_UPDATE_PERIOD_SECS is not modified
         assert DomInfoUpdateTask.DEFAULT_DOM_INFO_UPDATE_PERIOD_SECS == 60
 
-    def test_DaemonXcvrd_dom_update_interval_parameter(self):
-        """Test that DaemonXcvrd correctly handles and passes dom_update_interval parameter"""
-        # Test 1: When dom_update_interval is None
-        daemon = DaemonXcvrd(SYSLOG_IDENTIFIER, skip_cmis_mgr=False, enable_sff_mgr=False,
-                            dom_temperature_poll_interval=None, dom_update_interval=None)
-        assert daemon.dom_update_interval is None
+    def test_DaemonXcvrd_resolves_config(self):
+        """DaemonXcvrd populates self.config from XcvrdConfig.resolve().
 
-        # Test 2: When dom_update_interval is 0
-        daemon = DaemonXcvrd(SYSLOG_IDENTIFIER, skip_cmis_mgr=False, enable_sff_mgr=False,
-                            dom_temperature_poll_interval=None, dom_update_interval=0)
-        assert daemon.dom_update_interval == 0
+        The resolution logic itself (platform-file layering, coercion, defaults)
+        is covered in tests/test_xcvrd_config.py; here we only verify the wiring.
+        """
+        resolved = MagicMock(dom_temperature_poll_interval=5, dom_update_interval=30)
+        with patch('xcvrd.xcvrd.XcvrdConfig.resolve', return_value=resolved) as mock_resolve:
+            daemon = DaemonXcvrd(SYSLOG_IDENTIFIER, skip_cmis_mgr=False, enable_sff_mgr=False)
+        mock_resolve.assert_called_once()
+        assert daemon.config is resolved
+        assert daemon.config.dom_temperature_poll_interval == 5
+        assert daemon.config.dom_update_interval == 30
 
-        # Test 3: When dom_update_interval is a custom value
-        daemon = DaemonXcvrd(SYSLOG_IDENTIFIER, skip_cmis_mgr=False, enable_sff_mgr=False,
-                            dom_temperature_poll_interval=None, dom_update_interval=120)
-        assert daemon.dom_update_interval == 120
-
-        # Test 4: When dom_update_interval is 1000
-        daemon = DaemonXcvrd(SYSLOG_IDENTIFIER, skip_cmis_mgr=False, enable_sff_mgr=False,
-                            dom_temperature_poll_interval=None, dom_update_interval=1000)
-        assert daemon.dom_update_interval == 1000
+    def test_DaemonXcvrd_config_defaults(self):
+        """With no platform overrides, dom_* tunables fall back to None defaults."""
+        with patch('xcvrd.xcvrd.XcvrdConfig.resolve', return_value=XcvrdConfig()):
+            daemon = DaemonXcvrd(SYSLOG_IDENTIFIER)
+        assert daemon.config.dom_temperature_poll_interval is None
+        assert daemon.config.dom_update_interval is None
 
 def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
     wait_time = 0

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -580,7 +580,7 @@ class TestXcvrdThreadException(object):
         mock_init.return_value = PortMapping()
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
         xcvrd.enable_sff_mgr = True
-        xcvrd.config.dom_temperature_poll_interval = 10
+        xcvrd.config.dom.temperature_poll_interval = 10
         xcvrd.load_feature_flags = MagicMock()
         xcvrd.stop_event.wait = MagicMock()
         # init() is mocked out, so populate the pluggable port dict directly.
@@ -6964,25 +6964,36 @@ class TestXcvrdScript(object):
         assert DomInfoUpdateTask.DEFAULT_DOM_INFO_UPDATE_PERIOD_SECS == 60
 
     def test_DaemonXcvrd_resolves_config(self):
-        """DaemonXcvrd populates self.config from XcvrdConfig.resolve().
+        """DaemonXcvrd populates self.config from XcvrdConfig.resolve() and
+        derives the manager toggles from it.
 
         The resolution logic itself (platform-file layering, coercion, defaults)
         is covered in tests/test_xcvrd_config.py; here we only verify the wiring.
         """
-        resolved = MagicMock(dom_temperature_poll_interval=5, dom_update_interval=30)
+        resolved = XcvrdConfig()
+        resolved.dom.temperature_poll_interval = 5
+        resolved.dom.update_interval = 30
         with patch('xcvrd.xcvrd.XcvrdConfig.resolve', return_value=resolved) as mock_resolve:
-            daemon = DaemonXcvrd(SYSLOG_IDENTIFIER, skip_cmis_mgr=False, enable_sff_mgr=False)
+            daemon = DaemonXcvrd(SYSLOG_IDENTIFIER)
         mock_resolve.assert_called_once()
         assert daemon.config is resolved
-        assert daemon.config.dom_temperature_poll_interval == 5
-        assert daemon.config.dom_update_interval == 30
+        assert daemon.config.dom.temperature_poll_interval == 5
+        assert daemon.config.dom.update_interval == 30
+        # Manager toggles are derived from the resolved config's defaults:
+        # cmis_mgr/cpo_mgr enabled, sff_mgr disabled.
+        assert daemon.skip_cmis_mgr is False
+        assert daemon.skip_cpo_mgr is False
+        assert daemon.enable_sff_mgr is False
 
     def test_DaemonXcvrd_config_defaults(self):
-        """With no platform overrides, dom_* tunables fall back to None defaults."""
+        """With no platform overrides, tunables fall back to built-in defaults."""
         with patch('xcvrd.xcvrd.XcvrdConfig.resolve', return_value=XcvrdConfig()):
             daemon = DaemonXcvrd(SYSLOG_IDENTIFIER)
-        assert daemon.config.dom_temperature_poll_interval is None
-        assert daemon.config.dom_update_interval is None
+        assert daemon.config.dom.temperature_poll_interval is None
+        assert daemon.config.dom.update_interval is None
+        assert daemon.config.cmis_mgr.enabled is True
+        assert daemon.config.sff_mgr.enabled is False
+        assert daemon.config.cpo_mgr.enabled is True
 
 def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
     wait_time = 0

--- a/sonic-xcvrd/tests/test_xcvrd_config.py
+++ b/sonic-xcvrd/tests/test_xcvrd_config.py
@@ -1,0 +1,176 @@
+"""
+Unit tests for XcvrdConfig: the layered resolver for xcvrd's dom_* tunables.
+
+Precedence under test (highest wins):
+  1. "xcvrd" section of pmon_daemon_control.json (hwsku file over platform file)
+  2. built-in dataclass defaults
+"""
+import json
+import os
+import sys
+
+from unittest.mock import patch
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, modules_path)
+
+from xcvrd.xcvrd_utilities.xcvrd_config import XcvrdConfig, PMON_DAEMON_CONTROL_FILE
+
+# Path patched in _read_platform_section's module so no real device dir is touched.
+PATHS_FN = "xcvrd.xcvrd_utilities.xcvrd_config.device_info.get_paths_to_platform_and_hwsku_dirs"
+
+
+def write_control_file(directory, payload):
+    """Write a pmon_daemon_control.json with the given dict into directory."""
+    os.makedirs(directory, exist_ok=True)
+    path = os.path.join(directory, PMON_DAEMON_CONTROL_FILE)
+    with open(path, "w") as f:
+        json.dump(payload, f)
+    return path
+
+
+class TestXcvrdConfigDefaults:
+    def test_defaults_when_no_overrides(self):
+        cfg = XcvrdConfig.resolve(platform_section={})
+        assert cfg.dom_temperature_poll_interval is None
+        assert cfg.dom_update_interval is None
+
+    def test_bare_construction_matches_defaults(self):
+        # Legacy path: DaemonXcvrd builds XcvrdConfig() directly.
+        cfg = XcvrdConfig()
+        assert cfg.dom_temperature_poll_interval is None
+        assert cfg.dom_update_interval is None
+
+
+class TestXcvrdConfigMerge:
+    def test_platform_section_overrides_defaults(self):
+        cfg = XcvrdConfig.resolve(platform_section={
+            "dom_temperature_poll_interval": 5,
+            "dom_update_interval": 30,
+        })
+        assert cfg.dom_temperature_poll_interval == 5
+        assert cfg.dom_update_interval == 30
+
+    def test_partial_section_leaves_other_field_at_default(self):
+        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": 30})
+        assert cfg.dom_update_interval == 30
+        assert cfg.dom_temperature_poll_interval is None
+
+    def test_none_value_does_not_override(self):
+        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": None})
+        assert cfg.dom_update_interval is None
+
+    def test_zero_is_preserved(self):
+        # 0 is a meaningful value (continuous polling) and must not be dropped.
+        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": 0})
+        assert cfg.dom_update_interval == 0
+
+    def test_string_value_is_coerced_to_int(self):
+        # JSON could carry a stringified number; mirror the old argparse type=int.
+        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": "30"})
+        assert cfg.dom_update_interval == 30
+        assert isinstance(cfg.dom_update_interval, int)
+
+    def test_invalid_value_is_ignored_and_keeps_default(self):
+        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": "not-a-number"})
+        assert cfg.dom_update_interval is None
+
+    def test_unknown_key_is_ignored(self):
+        cfg = XcvrdConfig.resolve(platform_section={
+            "dom_update_interval": 30,
+            "some_future_unknown_key": 99,
+        })
+        assert cfg.dom_update_interval == 30
+        assert not hasattr(cfg, "some_future_unknown_key")
+
+
+class TestReadPlatformSection:
+    def test_missing_files_yield_empty(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        hwsku_dir = str(tmp_path / "hwsku")
+        with patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
+            assert XcvrdConfig._read_platform_section() == {}
+
+    def test_reads_platform_file_when_no_hwsku_file(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        hwsku_dir = str(tmp_path / "hwsku")
+        write_control_file(platform_dir, {"xcvrd": {"dom_update_interval": 30}})
+        with patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
+            assert XcvrdConfig._read_platform_section() == {"dom_update_interval": 30}
+
+    def test_hwsku_file_takes_precedence_over_platform_file(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        hwsku_dir = str(tmp_path / "hwsku")
+        write_control_file(platform_dir, {"xcvrd": {"dom_update_interval": 30}})
+        write_control_file(hwsku_dir, {"xcvrd": {"dom_update_interval": 99}})
+        with patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
+            # Mirrors docker_init: the hwsku file wins; no cross-file merge.
+            assert XcvrdConfig._read_platform_section() == {"dom_update_interval": 99}
+
+    def test_hwsku_file_without_xcvrd_section_does_not_fall_back(self, tmp_path):
+        # docker_init consults only the first existing file; if the hwsku file
+        # exists but lacks an "xcvrd" section, we do not read the platform file.
+        platform_dir = str(tmp_path / "platform")
+        hwsku_dir = str(tmp_path / "hwsku")
+        write_control_file(platform_dir, {"xcvrd": {"dom_update_interval": 30}})
+        write_control_file(hwsku_dir, {"skip_xcvrd": False})
+        with patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
+            assert XcvrdConfig._read_platform_section() == {}
+
+    def test_no_xcvrd_section_yields_empty(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        hwsku_dir = str(tmp_path / "hwsku")
+        write_control_file(platform_dir, {"skip_ledd": True})
+        with patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
+            assert XcvrdConfig._read_platform_section() == {}
+
+    def test_malformed_json_yields_empty(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        hwsku_dir = str(tmp_path / "hwsku")
+        os.makedirs(platform_dir)
+        with open(os.path.join(platform_dir, PMON_DAEMON_CONTROL_FILE), "w") as f:
+            f.write("{ this is not valid json")
+        with patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
+            assert XcvrdConfig._read_platform_section() == {}
+
+    def test_non_dict_xcvrd_section_yields_empty(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        hwsku_dir = str(tmp_path / "hwsku")
+        write_control_file(platform_dir, {"xcvrd": "oops-not-an-object"})
+        with patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
+            assert XcvrdConfig._read_platform_section() == {}
+
+    def test_device_info_failure_yields_empty(self):
+        with patch(PATHS_FN, side_effect=RuntimeError("platform undetermined")):
+            assert XcvrdConfig._read_platform_section() == {}
+
+    def test_empty_dir_path_is_skipped(self, tmp_path):
+        # get_paths_to_platform_and_hwsku_dirs may return an empty hwsku path;
+        # that entry is skipped rather than joined into a bogus path.
+        platform_dir = str(tmp_path / "platform")
+        write_control_file(platform_dir, {"xcvrd": {"dom_update_interval": 30}})
+        with patch(PATHS_FN, return_value=(platform_dir, "")):
+            assert XcvrdConfig._read_platform_section() == {"dom_update_interval": 30}
+
+
+class TestResolveEndToEnd:
+    def test_resolve_reads_from_disk(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        hwsku_dir = str(tmp_path / "hwsku")
+        write_control_file(platform_dir, {"xcvrd": {
+            "dom_temperature_poll_interval": 5,
+            "dom_update_interval": 30,
+        }})
+        with patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
+            cfg = XcvrdConfig.resolve()
+        assert cfg.dom_temperature_poll_interval == 5
+        assert cfg.dom_update_interval == 30
+
+    def test_resolve_defaults_when_nothing_on_disk(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        hwsku_dir = str(tmp_path / "hwsku")
+        with patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
+            cfg = XcvrdConfig.resolve()
+        assert cfg.dom_temperature_poll_interval is None
+        assert cfg.dom_update_interval is None

--- a/sonic-xcvrd/tests/test_xcvrd_config.py
+++ b/sonic-xcvrd/tests/test_xcvrd_config.py
@@ -15,10 +15,12 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
-from xcvrd.xcvrd_utilities.xcvrd_config import XcvrdConfig, PMON_DAEMON_CONTROL_FILE
+from sonic_py_common.pmon_daemon_config import PMON_DAEMON_CONTROL_FILE
+from xcvrd.xcvrd_utilities.xcvrd_config import XcvrdConfig, MAX_INTERVAL_SECS
 
-# Path patched in _read_platform_section's module so no real device dir is touched.
-PATHS_FN = "xcvrd.xcvrd_utilities.xcvrd_config.device_info.get_paths_to_platform_and_hwsku_dirs"
+# Path patched in _read_platform_section's module so no real device dir is
+# touched. The read lives in the shared base, not in xcvrd's schema module.
+PATHS_FN = "sonic_py_common.pmon_daemon_config.device_info.get_paths_to_platform_and_hwsku_dirs"
 
 
 def write_control_file(directory, payload):
@@ -174,3 +176,59 @@ class TestResolveEndToEnd:
             cfg = XcvrdConfig.resolve()
         assert cfg.dom_temperature_poll_interval is None
         assert cfg.dom_update_interval is None
+
+
+class TestRangeValidation:
+    """Values that coerce cleanly but are not valid configuration are rejected.
+
+    A rejected value keeps the built-in default and logs a warning; it never
+    stops xcvrd from starting.
+    """
+
+    def test_negative_dom_temperature_poll_interval_keeps_default(self):
+        # This is the case the range check exists for: DomThermalInfoUpdateTask
+        # never validated poll_interval, so a negative value left its next-poll
+        # time permanently in the past and the sweep ran back-to-back instead of
+        # once a minute. Default None means the thermal thread is not started.
+        cfg = XcvrdConfig.resolve(platform_section={"dom_temperature_poll_interval": -60})
+        assert cfg.dom_temperature_poll_interval is None
+
+    def test_negative_dom_update_interval_keeps_default(self):
+        # DomInfoUpdateTask already guarded against this one and fell back to its
+        # 60s default; the check now happens once, before the value is handed out.
+        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": -1})
+        assert cfg.dom_update_interval is None
+
+    def test_negative_interval_as_string_keeps_default(self):
+        # Validation runs after coercion, so the stringified form is caught too.
+        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": "-1"})
+        assert cfg.dom_update_interval is None
+
+    def test_interval_above_maximum_keeps_default(self):
+        cfg = XcvrdConfig.resolve(platform_section={
+            "dom_update_interval": MAX_INTERVAL_SECS + 1})
+        assert cfg.dom_update_interval is None
+
+    def test_interval_boundaries_are_accepted(self):
+        # Bounds are inclusive; 0 stays meaningful (continuous polling).
+        assert XcvrdConfig.resolve(
+            platform_section={"dom_update_interval": 0}).dom_update_interval == 0
+        assert XcvrdConfig.resolve(
+            platform_section={"dom_update_interval": MAX_INTERVAL_SECS}
+        ).dom_update_interval == MAX_INTERVAL_SECS
+
+    def test_both_fields_are_bounded(self):
+        cfg = XcvrdConfig.resolve(platform_section={
+            "dom_temperature_poll_interval": MAX_INTERVAL_SECS + 1,
+            "dom_update_interval": MAX_INTERVAL_SECS + 1,
+        })
+        assert cfg.dom_temperature_poll_interval is None
+        assert cfg.dom_update_interval is None
+
+    def test_one_rejected_field_does_not_drop_the_others(self):
+        cfg = XcvrdConfig.resolve(platform_section={
+            "dom_update_interval": -1,
+            "dom_temperature_poll_interval": 5,
+        })
+        assert cfg.dom_update_interval is None
+        assert cfg.dom_temperature_poll_interval == 5

--- a/sonic-xcvrd/tests/test_xcvrd_config.py
+++ b/sonic-xcvrd/tests/test_xcvrd_config.py
@@ -1,25 +1,30 @@
 """
-Unit tests for XcvrdConfig: the layered resolver for xcvrd's dom_* tunables.
+Unit tests for XcvrdConfig: the layered resolver for xcvrd's tunables.
 
 Precedence under test (highest wins):
-  1. "xcvrd" section of pmon_daemon_control.json (hwsku file over platform file)
-  2. built-in dataclass defaults
+  1. nested keys in the "xcvrd" section of pmon_daemon_control.json
+     (xcvrd.dom.*, xcvrd.cmis_mgr.enabled, ...)
+  2. legacy aliases - deprecated flat dom_* keys and the top-level
+     skip_xcvrd_cmis_mgr / enable_xcvrd_sff_mgr keys
+  3. built-in dataclass defaults
 """
 import json
 import os
 import sys
 
+from unittest import mock
 from unittest.mock import patch
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
+from sonic_py_common import pmon_daemon_config
 from sonic_py_common.pmon_daemon_config import PMON_DAEMON_CONTROL_FILE
 from xcvrd.xcvrd_utilities.xcvrd_config import XcvrdConfig, MAX_INTERVAL_SECS
 
-# Path patched in _read_platform_section's module so no real device dir is
-# touched. The read lives in the shared base, not in xcvrd's schema module.
+# Path patched in the shared base's module so no real device dir is touched; the
+# read lives in sonic_py_common, not in xcvrd's schema module.
 PATHS_FN = "sonic_py_common.pmon_daemon_config.device_info.get_paths_to_platform_and_hwsku_dirs"
 
 
@@ -35,56 +40,212 @@ def write_control_file(directory, payload):
 class TestXcvrdConfigDefaults:
     def test_defaults_when_no_overrides(self):
         cfg = XcvrdConfig.resolve(platform_section={})
-        assert cfg.dom_temperature_poll_interval is None
-        assert cfg.dom_update_interval is None
+        assert cfg.dom.temperature_poll_interval is None
+        assert cfg.dom.update_interval is None
+        assert cfg.cmis_mgr.enabled is True
+        assert cfg.sff_mgr.enabled is False
+        assert cfg.cpo_mgr.enabled is True
 
     def test_bare_construction_matches_defaults(self):
         # Legacy path: DaemonXcvrd builds XcvrdConfig() directly.
         cfg = XcvrdConfig()
-        assert cfg.dom_temperature_poll_interval is None
-        assert cfg.dom_update_interval is None
+        assert cfg.dom.temperature_poll_interval is None
+        assert cfg.dom.update_interval is None
+        assert cfg.cmis_mgr.enabled is True
+        assert cfg.sff_mgr.enabled is False
+        assert cfg.cpo_mgr.enabled is True
 
 
-class TestXcvrdConfigMerge:
-    def test_platform_section_overrides_defaults(self):
+class TestDomSubsection:
+    def test_dom_overrides_defaults(self):
         cfg = XcvrdConfig.resolve(platform_section={
-            "dom_temperature_poll_interval": 5,
-            "dom_update_interval": 30,
-        })
-        assert cfg.dom_temperature_poll_interval == 5
-        assert cfg.dom_update_interval == 30
+            "dom": {"temperature_poll_interval": 5, "update_interval": 30}})
+        assert cfg.dom.temperature_poll_interval == 5
+        assert cfg.dom.update_interval == 30
 
-    def test_partial_section_leaves_other_field_at_default(self):
-        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": 30})
-        assert cfg.dom_update_interval == 30
-        assert cfg.dom_temperature_poll_interval is None
+    def test_partial_dom_leaves_other_field_at_default(self):
+        cfg = XcvrdConfig.resolve(platform_section={"dom": {"update_interval": 30}})
+        assert cfg.dom.update_interval == 30
+        assert cfg.dom.temperature_poll_interval is None
 
     def test_none_value_does_not_override(self):
-        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": None})
-        assert cfg.dom_update_interval is None
+        cfg = XcvrdConfig.resolve(platform_section={"dom": {"update_interval": None}})
+        assert cfg.dom.update_interval is None
 
     def test_zero_is_preserved(self):
         # 0 is a meaningful value (continuous polling) and must not be dropped.
-        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": 0})
-        assert cfg.dom_update_interval == 0
+        cfg = XcvrdConfig.resolve(platform_section={"dom": {"update_interval": 0}})
+        assert cfg.dom.update_interval == 0
 
     def test_string_value_is_coerced_to_int(self):
-        # JSON could carry a stringified number; mirror the old argparse type=int.
-        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": "30"})
-        assert cfg.dom_update_interval == 30
-        assert isinstance(cfg.dom_update_interval, int)
+        cfg = XcvrdConfig.resolve(platform_section={"dom": {"update_interval": "30"}})
+        assert cfg.dom.update_interval == 30
+        assert isinstance(cfg.dom.update_interval, int)
 
     def test_invalid_value_is_ignored_and_keeps_default(self):
-        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": "not-a-number"})
-        assert cfg.dom_update_interval is None
+        cfg = XcvrdConfig.resolve(platform_section={"dom": {"update_interval": "not-a-number"}})
+        assert cfg.dom.update_interval is None
 
-    def test_unknown_key_is_ignored(self):
+    def test_unknown_key_in_dom_is_ignored(self):
         cfg = XcvrdConfig.resolve(platform_section={
-            "dom_update_interval": 30,
-            "some_future_unknown_key": 99,
-        })
-        assert cfg.dom_update_interval == 30
+            "dom": {"update_interval": 30, "some_future_key": 99}})
+        assert cfg.dom.update_interval == 30
+        assert not hasattr(cfg.dom, "some_future_key")
+
+    def test_unknown_top_level_key_is_ignored(self):
+        cfg = XcvrdConfig.resolve(platform_section={
+            "dom": {"update_interval": 30}, "some_future_unknown_key": 99})
+        assert cfg.dom.update_interval == 30
         assert not hasattr(cfg, "some_future_unknown_key")
+
+    def test_non_dict_dom_keeps_defaults(self):
+        cfg = XcvrdConfig.resolve(platform_section={"dom": "oops-not-an-object"})
+        assert cfg.dom.update_interval is None
+        assert cfg.dom.temperature_poll_interval is None
+
+
+class TestManagerToggles:
+    def test_cmis_mgr_disabled_via_nested(self):
+        cfg = XcvrdConfig.resolve(platform_section={"cmis_mgr": {"enabled": False}})
+        assert cfg.cmis_mgr.enabled is False
+
+    def test_sff_mgr_enabled_via_nested(self):
+        cfg = XcvrdConfig.resolve(platform_section={"sff_mgr": {"enabled": True}})
+        assert cfg.sff_mgr.enabled is True
+
+    def test_enabled_parses_via_to_bool(self):
+        # bool("false") is True in Python; to_bool must resolve it to False.
+        cfg = XcvrdConfig.resolve(platform_section={"cmis_mgr": {"enabled": "false"}})
+        assert cfg.cmis_mgr.enabled is False
+
+    def test_cpo_mgr_toggle(self):
+        cfg = XcvrdConfig.resolve(platform_section={"cpo_mgr": {"enabled": False}})
+        assert cfg.cpo_mgr.enabled is False
+
+    def test_unset_managers_keep_defaults(self):
+        cfg = XcvrdConfig.resolve(platform_section={"cmis_mgr": {"enabled": False}})
+        assert cfg.sff_mgr.enabled is False
+        assert cfg.cpo_mgr.enabled is True
+
+
+class TestRangeValidation:
+    """Values that coerce cleanly but are not valid configuration are rejected.
+
+    A rejected value keeps the built-in default and logs a warning; it never
+    stops xcvrd from starting.
+    """
+
+    def test_negative_temperature_poll_interval_keeps_default(self):
+        # DomThermalInfoUpdateTask never validated poll_interval, so a negative
+        # value left its next-poll time in the past and the sweep ran back-to-back.
+        cfg = XcvrdConfig.resolve(platform_section={"dom": {"temperature_poll_interval": -60}})
+        assert cfg.dom.temperature_poll_interval is None
+
+    def test_negative_update_interval_keeps_default(self):
+        cfg = XcvrdConfig.resolve(platform_section={"dom": {"update_interval": -1}})
+        assert cfg.dom.update_interval is None
+
+    def test_negative_interval_as_string_keeps_default(self):
+        # Validation runs after coercion, so the stringified form is caught too.
+        cfg = XcvrdConfig.resolve(platform_section={"dom": {"update_interval": "-1"}})
+        assert cfg.dom.update_interval is None
+
+    def test_interval_above_maximum_keeps_default(self):
+        cfg = XcvrdConfig.resolve(platform_section={"dom": {"update_interval": MAX_INTERVAL_SECS + 1}})
+        assert cfg.dom.update_interval is None
+
+    def test_interval_boundaries_are_accepted(self):
+        # Bounds are inclusive; 0 stays meaningful (continuous polling).
+        assert XcvrdConfig.resolve(
+            platform_section={"dom": {"update_interval": 0}}).dom.update_interval == 0
+        assert XcvrdConfig.resolve(
+            platform_section={"dom": {"update_interval": MAX_INTERVAL_SECS}}
+        ).dom.update_interval == MAX_INTERVAL_SECS
+
+    def test_both_fields_are_bounded(self):
+        cfg = XcvrdConfig.resolve(platform_section={"dom": {
+            "temperature_poll_interval": MAX_INTERVAL_SECS + 1,
+            "update_interval": MAX_INTERVAL_SECS + 1}})
+        assert cfg.dom.temperature_poll_interval is None
+        assert cfg.dom.update_interval is None
+
+    def test_one_rejected_field_does_not_drop_the_others(self):
+        cfg = XcvrdConfig.resolve(platform_section={"dom": {
+            "update_interval": -1, "temperature_poll_interval": 5}})
+        assert cfg.dom.update_interval is None
+        assert cfg.dom.temperature_poll_interval == 5
+
+
+class TestLegacyAliases:
+    """Deprecated flat dom_* keys and top-level manager keys still take effect."""
+
+    def test_flat_dom_update_interval_alias(self):
+        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": 30})
+        assert cfg.dom.update_interval == 30
+
+    def test_flat_dom_temperature_poll_interval_alias(self):
+        cfg = XcvrdConfig.resolve(platform_section={"dom_temperature_poll_interval": 5})
+        assert cfg.dom.temperature_poll_interval == 5
+
+    def test_flat_alias_out_of_range_keeps_default(self):
+        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": -1})
+        assert cfg.dom.update_interval is None
+
+    def test_flat_dom_update_interval_zero_falls_back_to_default(self):
+        # Master's template gated the flag with a truthy check, so a flat 0 was
+        # never emitted and the daemon used its own default. The `v or None`
+        # transform preserves that: flat 0 -> unset -> default (None here).
+        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": 0})
+        assert cfg.dom.update_interval is None
+
+    def test_flat_dom_temperature_poll_interval_zero_falls_back_to_default(self):
+        # Same truthy-gate parity: a flat 0 never started the thermal thread on
+        # master, so it must resolve to the default (None) here, not to 0.
+        cfg = XcvrdConfig.resolve(platform_section={"dom_temperature_poll_interval": 0})
+        assert cfg.dom.temperature_poll_interval is None
+
+    def test_nested_zero_wins_over_flat_zero(self):
+        # The nested form is the new explicit API where 0 means continuous
+        # polling; it must be honored even when the flat alias is also 0.
+        cfg = XcvrdConfig.resolve(platform_section={
+            "dom_update_interval": 0, "dom": {"update_interval": 0}})
+        assert cfg.dom.update_interval == 0
+
+    def test_flat_string_zero_inherits_master_truthy_quirk(self):
+        # Jinja treated the string "0" as truthy (flag emitted) while int 0 was
+        # falsy; `v or None` reproduces that quirk faithfully, so a flat "0"
+        # coerces through to int 0 (continuous) rather than the default.
+        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": "0"})
+        assert cfg.dom.update_interval == 0
+
+    def test_skip_xcvrd_cmis_mgr_file_alias_inverts(self):
+        # Top-level skip_xcvrd_cmis_mgr=True inverts to cmis_mgr.enabled=False.
+        cfg = XcvrdConfig.resolve(platform_section={},
+                                  platform_file={"skip_xcvrd_cmis_mgr": True})
+        assert cfg.cmis_mgr.enabled is False
+
+    def test_enable_xcvrd_sff_mgr_file_alias(self):
+        cfg = XcvrdConfig.resolve(platform_section={},
+                                  platform_file={"enable_xcvrd_sff_mgr": True})
+        assert cfg.sff_mgr.enabled is True
+
+    def test_nested_form_wins_over_flat_alias(self):
+        cfg = XcvrdConfig.resolve(platform_section={
+            "dom_update_interval": 30, "dom": {"update_interval": 60}})
+        assert cfg.dom.update_interval == 60
+
+    def test_nested_form_wins_over_file_alias(self):
+        cfg = XcvrdConfig.resolve(platform_section={"cmis_mgr": {"enabled": True}},
+                                  platform_file={"skip_xcvrd_cmis_mgr": True})
+        assert cfg.cmis_mgr.enabled is True
+
+    def test_using_an_alias_logs_a_deprecation_warning(self):
+        logger = mock.MagicMock()
+        with mock.patch.object(pmon_daemon_config, 'get_config_logger', return_value=logger):
+            XcvrdConfig.resolve(platform_section={"dom_update_interval": 30})
+        assert logger.log_warning.called
+        assert any("deprecated" in call.args[0]
+                   for call in logger.log_warning.call_args_list)
 
 
 class TestReadPlatformSection:
@@ -97,25 +258,23 @@ class TestReadPlatformSection:
     def test_reads_platform_file_when_no_hwsku_file(self, tmp_path):
         platform_dir = str(tmp_path / "platform")
         hwsku_dir = str(tmp_path / "hwsku")
-        write_control_file(platform_dir, {"xcvrd": {"dom_update_interval": 30}})
+        write_control_file(platform_dir, {"xcvrd": {"dom": {"update_interval": 30}}})
         with patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
-            assert XcvrdConfig._read_platform_section() == {"dom_update_interval": 30}
+            assert XcvrdConfig._read_platform_section() == {"dom": {"update_interval": 30}}
 
     def test_hwsku_file_takes_precedence_over_platform_file(self, tmp_path):
         platform_dir = str(tmp_path / "platform")
         hwsku_dir = str(tmp_path / "hwsku")
-        write_control_file(platform_dir, {"xcvrd": {"dom_update_interval": 30}})
-        write_control_file(hwsku_dir, {"xcvrd": {"dom_update_interval": 99}})
+        write_control_file(platform_dir, {"xcvrd": {"dom": {"update_interval": 30}}})
+        write_control_file(hwsku_dir, {"xcvrd": {"dom": {"update_interval": 99}}})
         with patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
             # Mirrors docker_init: the hwsku file wins; no cross-file merge.
-            assert XcvrdConfig._read_platform_section() == {"dom_update_interval": 99}
+            assert XcvrdConfig._read_platform_section() == {"dom": {"update_interval": 99}}
 
     def test_hwsku_file_without_xcvrd_section_does_not_fall_back(self, tmp_path):
-        # docker_init consults only the first existing file; if the hwsku file
-        # exists but lacks an "xcvrd" section, we do not read the platform file.
         platform_dir = str(tmp_path / "platform")
         hwsku_dir = str(tmp_path / "hwsku")
-        write_control_file(platform_dir, {"xcvrd": {"dom_update_interval": 30}})
+        write_control_file(platform_dir, {"xcvrd": {"dom": {"update_interval": 30}}})
         write_control_file(hwsku_dir, {"skip_xcvrd": False})
         with patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
             assert XcvrdConfig._read_platform_section() == {}
@@ -151,9 +310,19 @@ class TestReadPlatformSection:
         # get_paths_to_platform_and_hwsku_dirs may return an empty hwsku path;
         # that entry is skipped rather than joined into a bogus path.
         platform_dir = str(tmp_path / "platform")
-        write_control_file(platform_dir, {"xcvrd": {"dom_update_interval": 30}})
+        write_control_file(platform_dir, {"xcvrd": {"dom": {"update_interval": 30}}})
         with patch(PATHS_FN, return_value=(platform_dir, "")):
-            assert XcvrdConfig._read_platform_section() == {"dom_update_interval": 30}
+            assert XcvrdConfig._read_platform_section() == {"dom": {"update_interval": 30}}
+
+    def test_read_platform_control_returns_whole_file(self, tmp_path):
+        # scope='file' aliases need the sibling top-level keys, not just section.
+        platform_dir = str(tmp_path / "platform")
+        write_control_file(platform_dir, {
+            "skip_xcvrd_cmis_mgr": True, "xcvrd": {"dom": {"update_interval": 30}}})
+        with patch(PATHS_FN, return_value=(platform_dir, "")):
+            section, whole = XcvrdConfig._read_platform_control()
+        assert section == {"dom": {"update_interval": 30}}
+        assert whole["skip_xcvrd_cmis_mgr"] is True
 
 
 class TestResolveEndToEnd:
@@ -161,74 +330,26 @@ class TestResolveEndToEnd:
         platform_dir = str(tmp_path / "platform")
         hwsku_dir = str(tmp_path / "hwsku")
         write_control_file(platform_dir, {"xcvrd": {
-            "dom_temperature_poll_interval": 5,
-            "dom_update_interval": 30,
-        }})
+            "dom": {"temperature_poll_interval": 5, "update_interval": 30},
+            "cmis_mgr": {"enabled": False}}})
         with patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
             cfg = XcvrdConfig.resolve()
-        assert cfg.dom_temperature_poll_interval == 5
-        assert cfg.dom_update_interval == 30
+        assert cfg.dom.temperature_poll_interval == 5
+        assert cfg.dom.update_interval == 30
+        assert cfg.cmis_mgr.enabled is False
 
     def test_resolve_defaults_when_nothing_on_disk(self, tmp_path):
         platform_dir = str(tmp_path / "platform")
         hwsku_dir = str(tmp_path / "hwsku")
         with patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
             cfg = XcvrdConfig.resolve()
-        assert cfg.dom_temperature_poll_interval is None
-        assert cfg.dom_update_interval is None
+        assert cfg.dom.temperature_poll_interval is None
+        assert cfg.dom.update_interval is None
+        assert cfg.cmis_mgr.enabled is True
 
-
-class TestRangeValidation:
-    """Values that coerce cleanly but are not valid configuration are rejected.
-
-    A rejected value keeps the built-in default and logs a warning; it never
-    stops xcvrd from starting.
-    """
-
-    def test_negative_dom_temperature_poll_interval_keeps_default(self):
-        # This is the case the range check exists for: DomThermalInfoUpdateTask
-        # never validated poll_interval, so a negative value left its next-poll
-        # time permanently in the past and the sweep ran back-to-back instead of
-        # once a minute. Default None means the thermal thread is not started.
-        cfg = XcvrdConfig.resolve(platform_section={"dom_temperature_poll_interval": -60})
-        assert cfg.dom_temperature_poll_interval is None
-
-    def test_negative_dom_update_interval_keeps_default(self):
-        # DomInfoUpdateTask already guarded against this one and fell back to its
-        # 60s default; the check now happens once, before the value is handed out.
-        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": -1})
-        assert cfg.dom_update_interval is None
-
-    def test_negative_interval_as_string_keeps_default(self):
-        # Validation runs after coercion, so the stringified form is caught too.
-        cfg = XcvrdConfig.resolve(platform_section={"dom_update_interval": "-1"})
-        assert cfg.dom_update_interval is None
-
-    def test_interval_above_maximum_keeps_default(self):
-        cfg = XcvrdConfig.resolve(platform_section={
-            "dom_update_interval": MAX_INTERVAL_SECS + 1})
-        assert cfg.dom_update_interval is None
-
-    def test_interval_boundaries_are_accepted(self):
-        # Bounds are inclusive; 0 stays meaningful (continuous polling).
-        assert XcvrdConfig.resolve(
-            platform_section={"dom_update_interval": 0}).dom_update_interval == 0
-        assert XcvrdConfig.resolve(
-            platform_section={"dom_update_interval": MAX_INTERVAL_SECS}
-        ).dom_update_interval == MAX_INTERVAL_SECS
-
-    def test_both_fields_are_bounded(self):
-        cfg = XcvrdConfig.resolve(platform_section={
-            "dom_temperature_poll_interval": MAX_INTERVAL_SECS + 1,
-            "dom_update_interval": MAX_INTERVAL_SECS + 1,
-        })
-        assert cfg.dom_temperature_poll_interval is None
-        assert cfg.dom_update_interval is None
-
-    def test_one_rejected_field_does_not_drop_the_others(self):
-        cfg = XcvrdConfig.resolve(platform_section={
-            "dom_update_interval": -1,
-            "dom_temperature_poll_interval": 5,
-        })
-        assert cfg.dom_update_interval is None
-        assert cfg.dom_temperature_poll_interval == 5
+    def test_resolve_applies_file_scope_alias_from_disk(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        write_control_file(platform_dir, {"skip_xcvrd_cmis_mgr": True, "xcvrd": {}})
+        with patch(PATHS_FN, return_value=(platform_dir, "")):
+            cfg = XcvrdConfig.resolve()
+        assert cfg.cmis_mgr.enabled is False

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -36,6 +36,7 @@ try:
     from .xcvrd_utilities import media_settings_parser
     from .xcvrd_utilities import optics_si_parser
     from .xcvrd_utilities import common
+    from .xcvrd_utilities.xcvrd_config import XcvrdConfig
     from xcvrd.dom.utilities.dom_sensor.db_utils import DOMDBUtils
     from xcvrd.dom.utilities.vdm.db_utils import VDMDBUtils
     
@@ -875,14 +876,16 @@ class SfpStateUpdateTask(threading.Thread):
 
 
 class DaemonXcvrd(daemon_base.DaemonBase):
-    def __init__(self, log_identifier, skip_cmis_mgr=False, enable_sff_mgr=False, dom_temperature_poll_interval=None, dom_update_interval=None):
+    def __init__(self, log_identifier, skip_cmis_mgr=False, enable_sff_mgr=False):
         super(DaemonXcvrd, self).__init__(log_identifier, enable_runtime_log_config=True)
         self.stop_event = threading.Event()
         self.sfp_error_event = threading.Event()
         self.skip_cmis_mgr = skip_cmis_mgr
         self.enable_sff_mgr = enable_sff_mgr
-        self.dom_temperature_poll_interval = dom_temperature_poll_interval
-        self.dom_update_interval = dom_update_interval
+        # Resolve dom_* tunables from the "xcvrd" section of the per-platform
+        # pmon_daemon_control.json (see XcvrdConfig). Degrades to built-in
+        # defaults when the file/section is absent or unreadable.
+        self.config = XcvrdConfig.resolve()
         self.namespaces = ['']
         self.threads = []
         self.sfp_obj_dict = {}
@@ -1162,15 +1165,15 @@ class DaemonXcvrd(daemon_base.DaemonBase):
             self.threads.append(cmis_manager)
 
         # Start the dom sensor info update thread
-        dom_info_update = DomInfoUpdateTask(self.namespaces, port_mapping_data, self.sfp_obj_dict, self.stop_event, self.skip_cmis_mgr, self.dom_update_interval)
+        dom_info_update = DomInfoUpdateTask(self.namespaces, port_mapping_data, self.sfp_obj_dict, self.stop_event, self.skip_cmis_mgr, self.config.dom_update_interval)
         dom_info_update.start()
         self.threads.append(dom_info_update)
 
         # Start the dom thermal sensor info update thread
         dom_thermal_info_update = None
-        if self.dom_temperature_poll_interval is not None:
+        if self.config.dom_temperature_poll_interval is not None:
             dom_thermal_info_update = DomThermalInfoUpdateTask(self.namespaces, port_mapping_data, self.sfp_obj_dict, self.stop_event,
-                                                               self.dom_temperature_poll_interval)
+                                                               self.config.dom_temperature_poll_interval)
             dom_thermal_info_update.start()
             self.threads.append(dom_thermal_info_update)
 
@@ -1246,12 +1249,9 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--skip_cmis_mgr', action='store_true')
     parser.add_argument('--enable_sff_mgr', action='store_true')
-    parser.add_argument('--dom_temperature_poll_interval', default=None, type=int)
-    parser.add_argument('--dom_update_interval', default=None, type=int)
 
     args = parser.parse_args()
-    xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER, args.skip_cmis_mgr, args.enable_sff_mgr,
-                        args.dom_temperature_poll_interval, args.dom_update_interval)
+    xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER, args.skip_cmis_mgr, args.enable_sff_mgr)
     xcvrd.run()
 
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -16,7 +16,6 @@ try:
     import time
     import datetime
     import subprocess
-    import argparse
     import re
     import traceback
     import ctypes
@@ -891,17 +890,22 @@ class SfpStateUpdateTask(threading.Thread):
 
 
 class DaemonXcvrd(daemon_base.DaemonBase):
-    def __init__(self, log_identifier, skip_cmis_mgr=False, enable_sff_mgr=False, skip_cpo_mgr=False):
+    def __init__(self, log_identifier):
         super(DaemonXcvrd, self).__init__(log_identifier, enable_runtime_log_config=True)
         self.stop_event = threading.Event()
         self.sfp_error_event = threading.Event()
-        self.skip_cmis_mgr = skip_cmis_mgr
-        self.skip_cpo_mgr = skip_cpo_mgr
-        self.enable_sff_mgr = enable_sff_mgr
-        # Resolve dom_* tunables from the "xcvrd" section of the per-platform
-        # pmon_daemon_control.json (see XcvrdConfig). Degrades to built-in
-        # defaults when the file/section is absent or unreadable.
+        # Resolve xcvrd tunables from the "xcvrd" section of the per-platform
+        # pmon_daemon_control.json (see XcvrdConfig). The manager toggles and the
+        # dom_* cadences are read from the resolved config; an absent or
+        # unreadable file/section degrades to built-in defaults.
         self.config = XcvrdConfig.resolve()
+        # self.config is authoritative; the booleans below are convenience views
+        # derived from it once for signature compatibility with the manager task
+        # constructors. Do not mutate them independently - re-derive from
+        # self.config if a toggle ever needs to change.
+        self.skip_cmis_mgr = not self.config.cmis_mgr.enabled
+        self.skip_cpo_mgr = not self.config.cpo_mgr.enabled
+        self.enable_sff_mgr = self.config.sff_mgr.enabled
         self.namespaces = ['']
         self.threads = []
         self.sfp_obj_dict = {}
@@ -1165,22 +1169,22 @@ class DaemonXcvrd(daemon_base.DaemonBase):
             self.threads.append(cpo_manager)
 
         # Start the dom sensor info update thread
-        dom_info_update = DomInfoUpdateTask(self.namespaces, port_mapping_data, self.sfp_obj_dict, self.stop_event, self.skip_cmis_mgr, self.config.dom_update_interval)
+        dom_info_update = DomInfoUpdateTask(self.namespaces, port_mapping_data, self.sfp_obj_dict, self.stop_event, self.skip_cmis_mgr, self.config.dom.update_interval)
         dom_info_update.start()
         self.threads.append(dom_info_update)
 
         # Start the CPO dom sensor info update thread
         cpo_dom_info_update = None
         if self.cpo_obj_dict:
-            cpo_dom_info_update = CpoDomInfoUpdateTask(self.namespaces, port_mapping_data, self.cpo_obj_dict, self.stop_event, False, self.config.dom_update_interval)
+            cpo_dom_info_update = CpoDomInfoUpdateTask(self.namespaces, port_mapping_data, self.cpo_obj_dict, self.stop_event, False, self.config.dom.update_interval)
             cpo_dom_info_update.start()
             self.threads.append(cpo_dom_info_update)
 
         # Start the dom thermal sensor info update thread
         dom_thermal_info_update = None
-        if self.config.dom_temperature_poll_interval is not None:
+        if self.config.dom.temperature_poll_interval is not None:
             dom_thermal_info_update = DomThermalInfoUpdateTask(self.namespaces, port_mapping_data, self.sfp_obj_dict, self.stop_event,
-                                                               self.config.dom_temperature_poll_interval)
+                                                               self.config.dom.temperature_poll_interval)
             dom_thermal_info_update.start()
             self.threads.append(dom_thermal_info_update)
 
@@ -1277,14 +1281,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--skip_cmis_mgr', action='store_true')
-    parser.add_argument('--skip_cpo_mgr', action='store_true')
-    parser.add_argument('--enable_sff_mgr', action='store_true')
-
-    args = parser.parse_args()
-    xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER, args.skip_cmis_mgr, args.enable_sff_mgr,
-                        args.skip_cpo_mgr)
+    xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
     xcvrd.run()
 
 

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvrd_config.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvrd_config.py
@@ -1,0 +1,123 @@
+"""
+Resolves xcvrd runtime tunables from the per-platform daemon control file so
+that adding a new knob no longer requires threading a new command-line flag
+through the supervisord template, argparse, and the daemon constructor.
+
+Precedence, highest wins:
+  1. Per-platform / per-hwsku file - the "xcvrd" section of pmon_daemon_control.json
+  2. Built-in defaults            - the dataclass field defaults below
+
+The per-platform file is read from the same device directories (and with the
+same hwsku-over-platform precedence) that docker_init.j2 uses and that the
+existing media_settings.json / optics_si_settings.json parsers already read.
+
+A new tunable is added by declaring one field on XcvrdConfig (and, if it needs
+type coercion, one entry in _FIELD_CASTERS). Platform owners set it in the
+"xcvrd" section they already maintain; no template or constructor change.
+"""
+
+import json
+import os
+
+from dataclasses import dataclass, fields
+from typing import Optional
+
+from sonic_py_common import device_info, syslogger
+
+SYSLOG_IDENTIFIER = "xcvrd_config"
+helper_logger = syslogger.SysLogger(SYSLOG_IDENTIFIER, enable_runtime_config=True)
+
+# Per-platform daemon control file; xcvrd tunables live under the "xcvrd" key.
+PMON_DAEMON_CONTROL_FILE = "pmon_daemon_control.json"
+XCVRD_SECTION = "xcvrd"
+
+# Coercion applied to file values before they are stored. JSON numbers already
+# arrive as the right type; this guards against a value given as a string
+# (e.g. "20") and mirrors the int parsing the old --flag arguments did. None
+# values are never coerced or stored - they mean "no override".
+_FIELD_CASTERS = {
+    'dom_temperature_poll_interval': int,
+    'dom_update_interval': int,
+}
+
+
+@dataclass
+class XcvrdConfig:
+    # Built-in defaults (lowest precedence). None is meaningful and must be
+    # preserved: downstream a None dom_temperature_poll_interval disables the
+    # thermal poll thread, and a None dom_update_interval lets DomInfoUpdateTask
+    # fall back to its own DEFAULT_DOM_INFO_UPDATE_PERIOD_SECS.
+    dom_temperature_poll_interval: Optional[int] = None
+    dom_update_interval: Optional[int] = None
+
+    @classmethod
+    def resolve(cls, platform_section=None):
+        """Build a config by layering the platform file over the built-in defaults.
+
+        platform_section is exposed for tests so the merge logic can be exercised
+        without touching the filesystem; in production it is read from disk.
+        """
+        cfg = cls()
+        if platform_section is None:
+            platform_section = cls._read_platform_section()
+        cfg._merge(platform_section)
+        return cfg
+
+    def _merge(self, overrides):
+        valid = {f.name for f in fields(self)}
+        for key, value in overrides.items():
+            if key not in valid:
+                helper_logger.log_notice(
+                    "xcvrd config: ignoring unknown key '{}' in {}".format(
+                        key, PMON_DAEMON_CONTROL_FILE))
+                continue
+            if value is None:
+                # An absent override never clobbers the default.
+                continue
+            caster = _FIELD_CASTERS.get(key)
+            if caster is not None:
+                try:
+                    value = caster(value)
+                except (TypeError, ValueError):
+                    helper_logger.log_warning(
+                        "xcvrd config: invalid value {!r} for '{}' in {}; keeping "
+                        "default".format(value, key, PMON_DAEMON_CONTROL_FILE))
+                    continue
+            setattr(self, key, value)
+
+    @staticmethod
+    def _read_platform_section():
+        """Return the "xcvrd" dict from pmon_daemon_control.json, or {} if absent.
+
+        Mirrors docker_init.j2: the hwsku file takes precedence over the platform
+        file, and only the first existing file is consulted (no cross-file merge).
+        Any failure degrades to {} so xcvrd always starts on its built-in defaults.
+        """
+        try:
+            platform_path, hwsku_path = device_info.get_paths_to_platform_and_hwsku_dirs()
+        except Exception as exc:  # device_info can raise if platform is undetermined
+            helper_logger.log_warning(
+                "xcvrd config: unable to determine platform/hwsku dirs: {}".format(exc))
+            return {}
+
+        for directory in (hwsku_path, platform_path):
+            if not directory:
+                continue
+            path = os.path.join(directory, PMON_DAEMON_CONTROL_FILE)
+            if not os.path.isfile(path):
+                continue
+            try:
+                with open(path) as control_file:
+                    data = json.load(control_file)
+            except (OSError, ValueError) as exc:
+                helper_logger.log_warning(
+                    "xcvrd config: failed to read {}: {}".format(path, exc))
+                return {}
+            section = data.get(XCVRD_SECTION, {})
+            if not isinstance(section, dict):
+                helper_logger.log_warning(
+                    "xcvrd config: '{}' section in {} is not an object; ignoring".format(
+                        XCVRD_SECTION, path))
+                return {}
+            return section
+        return {}

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvrd_config.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvrd_config.py
@@ -8,23 +8,30 @@ sonic_py_common.pmon_daemon_config and is shared with the other pmon daemons.
 This module only declares what xcvrd accepts.
 
 Precedence, highest wins:
-  1. Per-platform / per-hwsku file - the "xcvrd" section of pmon_daemon_control.json
-  2. Built-in defaults            - the dataclass field defaults below
+  1. Nested keys in the "xcvrd" section of pmon_daemon_control.json
+     (e.g. xcvrd.dom.update_interval, xcvrd.cmis_mgr.enabled)
+  2. Legacy aliases - the deprecated flat dom_* keys and the top-level
+     skip_xcvrd_cmis_mgr / enable_xcvrd_sff_mgr keys, honored for a
+     compatibility window with a deprecation warning
+  3. Built-in defaults - the dataclass field defaults below
 
 The per-platform file is read from the same device directories (and with the
 same hwsku-over-platform precedence) that docker_init.j2 uses and that the
 existing media_settings.json / optics_si_settings.json parsers already read.
 
-A new tunable is added by declaring one field on XcvrdConfig plus one
-_FIELD_SPECS entry giving its type coercion and valid range. Platform owners set
-it in the "xcvrd" section they already maintain; no template, argparse, or
-constructor change.
+xcvrd's tunables are grouped into one-level-deep subsections: dom holds the
+cadence tunables and cmis_mgr / sff_mgr / cpo_mgr each hold a single enabled
+toggle. A new tunable is added by declaring one field on the relevant subsection
+schema plus one FIELD_SPECS entry giving its coercion and valid range; platform
+owners set it in the "xcvrd" section they already maintain, with no template,
+argparse, or constructor change.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
-from sonic_py_common.pmon_daemon_config import FieldSpec, PmonDaemonConfig
+from sonic_py_common.pmon_daemon_config import (
+    FieldSpec, LegacyAlias, PmonDaemonConfig, to_bool)
 
 XCVRD_SECTION = "xcvrd"
 
@@ -34,28 +41,73 @@ XCVRD_SECTION = "xcvrd"
 # so it is rejected rather than obeyed. Not a functional limit.
 MAX_INTERVAL_SECS = 86400
 
-# Coercion and validation applied to file values before they are stored. JSON
-# numbers already arrive as the right type; the caster guards against a value
-# given as a string (e.g. "20") and mirrors the int parsing the old --flag
-# arguments did. The bounds then reject values that coerce cleanly but are not
-# valid configuration - notably a negative cadence, which DomThermalInfoUpdateTask
-# would otherwise turn into an undelayed poll loop. A rejected value keeps the
-# built-in default and logs a warning; it never stops xcvrd from starting. None
-# values are never coerced or stored - they mean "no override".
-_FIELD_SPECS = {
-    'dom_temperature_poll_interval': FieldSpec(caster=int, minimum=0, maximum=MAX_INTERVAL_SECS),
-    'dom_update_interval': FieldSpec(caster=int, minimum=0, maximum=MAX_INTERVAL_SECS),
-}
+
+@dataclass
+class DomConfig(PmonDaemonConfig):
+    """The "dom" subsection: transceiver DOM polling cadence tunables.
+
+    None is meaningful and must be preserved: a None temperature_poll_interval
+    disables the DOM thermal poll thread, and a None update_interval lets
+    DomInfoUpdateTask fall back to its own DEFAULT_DOM_INFO_UPDATE_PERIOD_SECS.
+    The bounds reject values that coerce cleanly but are not valid configuration
+    - notably a negative cadence, which DomThermalInfoUpdateTask would otherwise
+    turn into an undelayed poll loop.
+    """
+
+    SECTION_NAME = 'dom'
+    FIELD_SPECS = {
+        'temperature_poll_interval': FieldSpec(caster=int, minimum=0, maximum=MAX_INTERVAL_SECS),
+        'update_interval': FieldSpec(caster=int, minimum=0, maximum=MAX_INTERVAL_SECS),
+    }
+
+    temperature_poll_interval: Optional[int] = None
+    update_interval: Optional[int] = None
+
+
+@dataclass
+class MgrConfig(PmonDaemonConfig):
+    """Reused for cmis_mgr / sff_mgr / cpo_mgr - a single enabled toggle.
+
+    to_bool (not bool) is the caster because bool("false") is True; a platform
+    writing the string "false" must disable, not silently enable, the manager.
+    """
+
+    FIELD_SPECS = {'enabled': FieldSpec(caster=to_bool)}
+
+    enabled: Optional[bool] = None
 
 
 @dataclass
 class XcvrdConfig(PmonDaemonConfig):
     SECTION_NAME = XCVRD_SECTION
-    FIELD_SPECS = _FIELD_SPECS
+    SUBSECTIONS = {
+        'dom': DomConfig,
+        'cmis_mgr': MgrConfig,
+        'sff_mgr': MgrConfig,
+        'cpo_mgr': MgrConfig,
+    }
+    LEGACY_ALIASES = {
+        # Flat dom_* keys that used to live directly in the xcvrd section. The
+        # `v or None` transform reproduces the old Jinja truthy gate
+        # ({% if xcvrd.dom_update_interval %}) exactly: a flat 0 (or empty
+        # value) was never emitted as a flag, so the daemon fell back to its
+        # default. Mapping falsy -> None keeps that parity for the deprecated
+        # flat form, while the nested dom.* form treats 0 as a real value
+        # (continuous polling), the intended new semantics.
+        'dom_temperature_poll_interval': LegacyAlias('dom.temperature_poll_interval',
+                                                     transform=lambda v: v or None),
+        'dom_update_interval': LegacyAlias('dom.update_interval',
+                                           transform=lambda v: v or None),
+        # Top-level capability keys (scope='file'); skip_* inverts to enabled.
+        'skip_xcvrd_cmis_mgr': LegacyAlias('cmis_mgr.enabled', scope='file',
+                                           transform=lambda v: not to_bool(v)),
+        'enable_xcvrd_sff_mgr': LegacyAlias('sff_mgr.enabled', scope='file'),
+    }
 
-    # Built-in defaults (lowest precedence). None is meaningful and must be
-    # preserved: downstream a None dom_temperature_poll_interval disables the
-    # thermal poll thread, and a None dom_update_interval lets DomInfoUpdateTask
-    # fall back to its own DEFAULT_DOM_INFO_UPDATE_PERIOD_SECS.
-    dom_temperature_poll_interval: Optional[int] = None
-    dom_update_interval: Optional[int] = None
+    # Built-in defaults (lowest precedence) preserve today's behavior for a
+    # platform that overrides nothing: CMIS and CPO managers enabled, SFF
+    # manager disabled.
+    dom: DomConfig = field(default_factory=DomConfig)
+    cmis_mgr: MgrConfig = field(default_factory=lambda: MgrConfig(enabled=True))
+    sff_mgr: MgrConfig = field(default_factory=lambda: MgrConfig(enabled=False))
+    cpo_mgr: MgrConfig = field(default_factory=lambda: MgrConfig(enabled=True))

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvrd_config.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvrd_config.py
@@ -1,7 +1,11 @@
 """
-Resolves xcvrd runtime tunables from the per-platform daemon control file so
-that adding a new knob no longer requires threading a new command-line flag
-through the supervisord template, argparse, and the daemon constructor.
+xcvrd's schema for the shared pmon daemon configuration resolver.
+
+The mechanism - locating pmon_daemon_control.json, extracting a daemon's
+section, layering it over the built-in defaults, coercing types, validating
+ranges, and degrading safely on any error - lives in
+sonic_py_common.pmon_daemon_config and is shared with the other pmon daemons.
+This module only declares what xcvrd accepts.
 
 Precedence, highest wins:
   1. Per-platform / per-hwsku file - the "xcvrd" section of pmon_daemon_control.json
@@ -11,113 +15,47 @@ The per-platform file is read from the same device directories (and with the
 same hwsku-over-platform precedence) that docker_init.j2 uses and that the
 existing media_settings.json / optics_si_settings.json parsers already read.
 
-A new tunable is added by declaring one field on XcvrdConfig (and, if it needs
-type coercion, one entry in _FIELD_CASTERS). Platform owners set it in the
-"xcvrd" section they already maintain; no template or constructor change.
+A new tunable is added by declaring one field on XcvrdConfig plus one
+_FIELD_SPECS entry giving its type coercion and valid range. Platform owners set
+it in the "xcvrd" section they already maintain; no template, argparse, or
+constructor change.
 """
 
-import json
-import os
-
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Optional
 
-from sonic_py_common import device_info, syslogger
+from sonic_py_common.pmon_daemon_config import FieldSpec, PmonDaemonConfig
 
-SYSLOG_IDENTIFIER = "xcvrd_config"
-helper_logger = syslogger.SysLogger(SYSLOG_IDENTIFIER, enable_runtime_config=True)
-
-# Per-platform daemon control file; xcvrd tunables live under the "xcvrd" key.
-PMON_DAEMON_CONTROL_FILE = "pmon_daemon_control.json"
 XCVRD_SECTION = "xcvrd"
 
-# Coercion applied to file values before they are stored. JSON numbers already
-# arrive as the right type; this guards against a value given as a string
-# (e.g. "20") and mirrors the int parsing the old --flag arguments did. None
+# Shared upper bound for the cadence tunables. A poll interval longer than a day
+# is operationally indistinguishable from "disabled" and is far more likely a
+# units mistake (milliseconds entered where seconds are expected) than an intent,
+# so it is rejected rather than obeyed. Not a functional limit.
+MAX_INTERVAL_SECS = 86400
+
+# Coercion and validation applied to file values before they are stored. JSON
+# numbers already arrive as the right type; the caster guards against a value
+# given as a string (e.g. "20") and mirrors the int parsing the old --flag
+# arguments did. The bounds then reject values that coerce cleanly but are not
+# valid configuration - notably a negative cadence, which DomThermalInfoUpdateTask
+# would otherwise turn into an undelayed poll loop. A rejected value keeps the
+# built-in default and logs a warning; it never stops xcvrd from starting. None
 # values are never coerced or stored - they mean "no override".
-_FIELD_CASTERS = {
-    'dom_temperature_poll_interval': int,
-    'dom_update_interval': int,
+_FIELD_SPECS = {
+    'dom_temperature_poll_interval': FieldSpec(caster=int, minimum=0, maximum=MAX_INTERVAL_SECS),
+    'dom_update_interval': FieldSpec(caster=int, minimum=0, maximum=MAX_INTERVAL_SECS),
 }
 
 
 @dataclass
-class XcvrdConfig:
+class XcvrdConfig(PmonDaemonConfig):
+    SECTION_NAME = XCVRD_SECTION
+    FIELD_SPECS = _FIELD_SPECS
+
     # Built-in defaults (lowest precedence). None is meaningful and must be
     # preserved: downstream a None dom_temperature_poll_interval disables the
     # thermal poll thread, and a None dom_update_interval lets DomInfoUpdateTask
     # fall back to its own DEFAULT_DOM_INFO_UPDATE_PERIOD_SECS.
     dom_temperature_poll_interval: Optional[int] = None
     dom_update_interval: Optional[int] = None
-
-    @classmethod
-    def resolve(cls, platform_section=None):
-        """Build a config by layering the platform file over the built-in defaults.
-
-        platform_section is exposed for tests so the merge logic can be exercised
-        without touching the filesystem; in production it is read from disk.
-        """
-        cfg = cls()
-        if platform_section is None:
-            platform_section = cls._read_platform_section()
-        cfg._merge(platform_section)
-        return cfg
-
-    def _merge(self, overrides):
-        valid = {f.name for f in fields(self)}
-        for key, value in overrides.items():
-            if key not in valid:
-                helper_logger.log_notice(
-                    "xcvrd config: ignoring unknown key '{}' in {}".format(
-                        key, PMON_DAEMON_CONTROL_FILE))
-                continue
-            if value is None:
-                # An absent override never clobbers the default.
-                continue
-            caster = _FIELD_CASTERS.get(key)
-            if caster is not None:
-                try:
-                    value = caster(value)
-                except (TypeError, ValueError):
-                    helper_logger.log_warning(
-                        "xcvrd config: invalid value {!r} for '{}' in {}; keeping "
-                        "default".format(value, key, PMON_DAEMON_CONTROL_FILE))
-                    continue
-            setattr(self, key, value)
-
-    @staticmethod
-    def _read_platform_section():
-        """Return the "xcvrd" dict from pmon_daemon_control.json, or {} if absent.
-
-        Mirrors docker_init.j2: the hwsku file takes precedence over the platform
-        file, and only the first existing file is consulted (no cross-file merge).
-        Any failure degrades to {} so xcvrd always starts on its built-in defaults.
-        """
-        try:
-            platform_path, hwsku_path = device_info.get_paths_to_platform_and_hwsku_dirs()
-        except Exception as exc:  # device_info can raise if platform is undetermined
-            helper_logger.log_warning(
-                "xcvrd config: unable to determine platform/hwsku dirs: {}".format(exc))
-            return {}
-
-        for directory in (hwsku_path, platform_path):
-            if not directory:
-                continue
-            path = os.path.join(directory, PMON_DAEMON_CONTROL_FILE)
-            if not os.path.isfile(path):
-                continue
-            try:
-                with open(path) as control_file:
-                    data = json.load(control_file)
-            except (OSError, ValueError) as exc:
-                helper_logger.log_warning(
-                    "xcvrd config: failed to read {}: {}".format(path, exc))
-                return {}
-            section = data.get(XCVRD_SECTION, {})
-            if not isinstance(section, dict):
-                helper_logger.log_warning(
-                    "xcvrd config: '{}' section in {} is not an object; ignoring".format(
-                        XCVRD_SECTION, path))
-                return {}
-            return section
-        return {}


### PR DESCRIPTION
#### Description
[HLD Link](https://github.com/sonic-net/SONiC/pull/2362)

Adds `XcvrdConfig`, which resolves `dom_temperature_poll_interval` and `dom_update_interval` from the `"xcvrd"` section of `pmon_daemon_control.json` (hwsku file takes precedence over platform file, no cross-file merge — mirrors `docker_init.j2`), falling back to built-in defaults (`None`) when unset.

`DaemonXcvrd` now builds `self.config = XcvrdConfig()` (resolved via `XcvrdConfig.resolve()`) instead of taking `dom_temperature_poll_interval`/`dom_update_interval` as constructor args; call sites read from `self.config` instead of instance attributes.

#### Motivation and Context
Previously, adding a new xcvrd tunable required threading a new `--flag` through argparse, the supervisord template, and the `DaemonXcvrd` constructor. Moving tunables into the per-platform `pmon_daemon_control.json` file (which platform owners already maintain for other daemons) means a new knob only requires a new dataclass field on `XcvrdConfig` — no template or constructor changes.

#### How Has This Been Tested?
Ran the full `sonic-xcvrd` pytest suite (`tests/test_xcvrd_config.py`, `tests/test_xcvrd.py`) inside the SONiC build slave container:

```
420 passed, 3 warnings in 10.83s
xcvrd/xcvrd_utilities/xcvrd_config.py   88 stmts, 99% coverage
```

New tests in `tests/test_xcvrd_config.py` cover: default values, platform-section overrides, partial overrides, `None`/`0` handling, string-to-int coercion, invalid/unknown keys, hwsku-vs-platform file precedence, missing/malformed files, and end-to-end `resolve()`.

`tests/test_xcvrd.py` updated to verify `DaemonXcvrd` wires `self.config` from `XcvrdConfig.resolve()`.

#### Additional Information (Optional)
After this PR merges, https://github.com/sonic-net/sonic-buildimage/pull/28306 removes the no longer necessary lines from the Jinja template.