### PR TITLE
Populating chassis_serial_number to state_db DEVICE_METADATA Table

### DIFF
--- a/sonic-chassisd/scripts/chassis_db_init
+++ b/sonic-chassisd/scripts/chassis_db_init
@@ -35,6 +35,10 @@ CHASSIS_INFO_MODEL_FIELD = 'model'
 CHASSIS_INFO_REV_FIELD = 'revision'
 CHASSIS_INFO_SWITCH_HOST_SERIAL_FIELD = 'switch_host_serial'
 
+DEVICE_METADATA_TABLE = 'DEVICE_METADATA'
+DEVICE_METADATA_KEY = 'localhost'
+DEVICE_METADATA_SERIAL_FIELD = 'chassis_serial_number'
+
 CHASSIS_LOAD_ERROR = 1
 
 NOT_AVAILABLE = 'N/A'
@@ -71,6 +75,7 @@ def provision_db(platform_chassis, log):
     # Init state db connection
     state_db = daemon_base.db_connect("STATE_DB")
     chassis_table = swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
+    device_metadata_table = swsscommon.Table(state_db, DEVICE_METADATA_TABLE)
 
     # Determine switch host serial number
     switch_host_serial = NOT_AVAILABLE
@@ -82,14 +87,21 @@ def provision_db(platform_chassis, log):
             raise RuntimeError("Switch Host Module must be present in the BMC chassis module at index 0")
         switch_host_serial = switch_host_mod.get_serial()
 
+    chassis_serial_num = try_get(platform_chassis.get_serial)
     # Populate DB with chassis hardware info
     fvs = swsscommon.FieldValuePairs([
-                                        (CHASSIS_INFO_SERIAL_FIELD, try_get(platform_chassis.get_serial)),
+                                        (CHASSIS_INFO_SERIAL_FIELD, chassis_serial_num),
                                         (CHASSIS_INFO_MODEL_FIELD, try_get(platform_chassis.get_model)),
                                         (CHASSIS_INFO_REV_FIELD, try_get(platform_chassis.get_revision)),
                                         (CHASSIS_INFO_SWITCH_HOST_SERIAL_FIELD, switch_host_serial)
                                     ])
     chassis_table.set(CHASSIS_INFO_KEY_TEMPLATE.format(1), fvs)
+
+    fvs = swsscommon.FieldValuePairs([
+        (DEVICE_METADATA_SERIAL_FIELD, chassis_serial_num)
+    ])
+    device_metadata_table.set(DEVICE_METADATA_KEY, fvs)
+
     log.log_info("STATE_DB provisioned with chassis info.")
 
     return chassis_table


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Populating `chassis_serial_number` into STATE_DB/DEVICE_METADATA/localhost/chassis_serial_number

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

The `DEVICE_METADATA` table is currently populated by snmp startup script. However, if we decide to shutdown snmp container service and rely on telemetry only, there is no way to easily fetch serial number from database. So, adding into Platform daemon in the same function where we save it in `CHASSIS_INFO` table.


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Verified changes and checked Redis to verify the data population on one of the platforms.

#### Additional Information (Optional)
