### PR TITLE
[Thermalctld] Add condtion before print error log for missing event.log on Non-BMC platform

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -49,7 +49,12 @@ class EventLogger(logger.Logger):
         py_name = "{}.{}".format(syslog_identifier,
                                  os.path.basename(log_file).replace(".", "_"))
         self._file_logger = logging.getLogger(py_name)
-        if not self._file_logger.handlers and os.getenv("THERMALCTLD_UNIT_TESTING") != "1":
+        # /host/bmc/event.log is only created on Switch-BMC (rc.local +
+        # switch_bmc=1). Skip the file tee elsewhere so non-BMC platforms
+        # do not spam open-failure errors; syslog still works via Logger.
+        if (not self._file_logger.handlers
+                and os.getenv("THERMALCTLD_UNIT_TESTING") != "1"
+                and device_info.is_switch_bmc()):
             try:
                 handler = logging.FileHandler(log_file)
                 handler.setFormatter(logging.Formatter(

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 import threading
@@ -2452,12 +2453,14 @@ class TestThermalMonitorSwitchHostCritical(object):
         with tempfile.NamedTemporaryFile(suffix='.log', delete=False) as f:
             tmp_log = f.name
         try:
-            # Clear the THERMALCTLD_UNIT_TESTING gate so the file handler is
-            # actually attached for this test, then restore on exit.
+            # Clear the THERMALCTLD_UNIT_TESTING gate and pretend Switch-BMC
+            # so the file handler is actually attached; restore on exit.
             prev = os.environ.pop('THERMALCTLD_UNIT_TESTING', None)
             try:
-                tm._sw_host_thermal_event_logger = thermalctld.EventLogger(
-                    'thermalctld-test', log_file=tmp_log)
+                with mock.patch.object(thermalctld.device_info, 'is_switch_bmc',
+                                       return_value=True):
+                    tm._sw_host_thermal_event_logger = thermalctld.EventLogger(
+                        'thermalctld-test', log_file=tmp_log)
             finally:
                 if prev is not None:
                     os.environ['THERMALCTLD_UNIT_TESTING'] = prev
@@ -2478,3 +2481,25 @@ class TestThermalMonitorSwitchHostCritical(object):
             assert '110.0' in contents
         finally:
             os.unlink(tmp_log)
+
+    def test_event_logger_skips_file_tee_when_not_switch_bmc(self):
+        """Non-Switch-BMC must not attach FileHandler or log open failures."""
+        # Path whose parent does not exist so FileHandler would fail without the guard.
+        missing_log = '/tmp/thermalctld-no-such-dir/event.log'
+        logger_name = 'thermalctld-non-bmc-test.event_log'
+        logging.getLogger(logger_name).handlers.clear()
+
+        prev = os.environ.pop('THERMALCTLD_UNIT_TESTING', None)
+        try:
+            with mock.patch.object(thermalctld.device_info, 'is_switch_bmc',
+                                   return_value=False), \
+                 mock.patch.object(thermalctld.EventLogger, 'log_error') as mock_log_error:
+                event_logger = thermalctld.EventLogger(
+                    'thermalctld-non-bmc-test', log_file=missing_log)
+
+            assert event_logger._file_logger.handlers == []
+            mock_log_error.assert_not_called()
+        finally:
+            if prev is not None:
+                os.environ['THERMALCTLD_UNIT_TESTING'] = prev
+            logging.getLogger(logger_name).handlers.clear()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Gate EventLogger file tee on device_info.is_switch_bmc() so thermalctld only opens /host/bmc/event.log on Switch-BMC platforms. Non-BMC platforms keep syslog logging and no longer attempt to create that file handler which triggers unnecessary error message.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
/host/bmc/event.log is only set up on Switch-BMC. On other platforms, attaching a FileHandler fails and triggers error logs about the missing file. Skipping the file tee outside Switch-BMC removes that noise without changing syslog behavior.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Updated thermalctld unit tests: Switch-BMC still tees to the event log, and non-Switch-BMC skips the file handler without calling log_error when the path is missing.

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

#### Additional Information (Optional)
