### PR TITLE
[chassisd] Prevent auto-recovery of DPUs without configured admin_status

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -1403,8 +1403,8 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
             # NPU kernel crash recovery: unconditionally power-cycle
             # admin-up DPUs to guarantee a known-good starting state.
             admin_status = self.get_module_admin_status(name)
-            if admin_status == 'down':
-                # Admin-down DPU; leave powered off.
+            if admin_status != 'up':
+                # Not admin-up DPU; leave powered off.
                 continue
             if not self._is_auto_recovery_enabled():
                 self.dpu_recovery_state[name]['state'] = DPU_STATE_MANUAL_INTERVENTION
@@ -1458,11 +1458,11 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
 
         all_up = (states.mp_state == 'up' and states.cp_state == 'up' and states.dp_state == 'up')
 
-        # DPU is administratively down — no automatic recovery; just
+        # DPU is not administratively up — no automatic recovery; just
         # reflect the offline state and wait for `module startup`.
         # This check must precede the Unrecoverable check so that an
         # operator can shut down an unrecoverable DPU and then restart it.
-        if admin_status == 'down':
+        if admin_status != 'up':
             if current_state != DPU_STATE_ADMIN_DOWN:
                 if current_state == DPU_STATE_UNRECOVERABLE:
                     recovery[WAS_UNRECOVERABLE_KEY] = True

--- a/sonic-chassisd/tests/test_dpu_auto_recovery.py
+++ b/sonic-chassisd/tests/test_dpu_auto_recovery.py
@@ -173,6 +173,7 @@ class TestInitDpuRecoveryState:
         updater.module_table.hset("DPU0", "oper_status", str(ModuleBase.MODULE_STATUS_ONLINE))
 
         with patch.object(updater, '_npu_crash_on_last_boot', return_value=True), \
+             patch.object(updater, 'get_module_admin_status', return_value='up'), \
              patch.object(updater, '_is_auto_recovery_enabled', return_value=False):
             updater.init_dpu_recovery_state()
 
@@ -2736,7 +2737,71 @@ class TestUpdateRecoveryStateIntegration:
         updater.device_metadata_table = mock_device_metadata_table
 
         with patch("os.path.isfile", return_value=True), \
-             patch("builtins.open", mock_open(read_data="kernel panic - not syncing")):
+             patch("builtins.open", mock_open(read_data="kernel panic - not syncing")), \
+             patch.object(updater, 'get_module_admin_status', return_value='up'):
             updater.init_dpu_recovery_state()
 
         assert updater.dpu_recovery_state["DPU0"]['state'] == DPU_STATE_MANUAL_INTERVENTION
+
+
+# ============================================================================
+# Test: Unconfigured (admin Empty) DPUs must never be auto-recovered
+# ============================================================================
+
+class TestUnconfiguredDpuNotRecovered:
+    """A DPU with no CHASSIS_MODULE entry in CONFIG_DB must never be powered on.
+
+    get_module_admin_status() returns MODULE_STATUS_EMPTY for such a DPU, and
+    set_initial_dpu_admin_state() powers it off at boot. The recovery FSM must
+    apply the same rule; treating Empty as "not admin-down" made chassisd
+    power on DPUs the operator had never started.
+    """
+
+    def test_boot_timeout_does_not_power_cycle_unconfigured_dpu(self):
+        """Boot timeout on an Empty-admin DPU must not reach the platform API.
+
+        No internal recovery method is stubbed, so this guards the
+        customer-visible symptom: an unconfigured DPU powering itself on.
+        """
+        chassis = create_chassis_with_dpus(1)
+        updater = create_updater(chassis)
+        updater.dpu_recovery_state["DPU0"]['state'] = DPU_STATE_BOOTING
+        updater.dpu_recovery_state["DPU0"]['boot_start_time'] = time.time() - 700
+
+        set_dpu_states(updater, "DPU0", mp='down', cp='down', dp='down')
+        updater.module_table.hset("DPU0", "oper_status", str(ModuleBase.MODULE_STATUS_OFFLINE))
+
+        module = chassis.module_list[0]
+        module.set_admin_state = MagicMock()
+
+        with patch.object(updater, '_is_auto_recovery_enabled', return_value=True), \
+             patch.object(updater, 'get_module_admin_status', return_value=ModuleBase.MODULE_STATUS_EMPTY):
+            # Several polls: the FSM must stay quiescent, not just skip once.
+            for _ in range(3):
+                updater.update_dpu_recovery_state()
+
+        module.set_admin_state.assert_not_called()
+        assert updater.dpu_recovery_state["DPU0"]['state'] == DPU_STATE_ADMIN_DOWN
+        assert updater.dpu_recovery_state["DPU0"]['reset_count'] == 0
+        assert get_dpu_state_field(updater, "DPU0", READY_STATUS) == 'false'
+
+    def test_npu_crash_does_not_power_cycle_unconfigured_dpu(self):
+        """NPU kernel-crash recovery must also skip never-configured DPUs.
+
+        init_dpu_recovery_state() calls _enter_power_cycle_or_unrecoverable()
+        directly, bypassing the FSM gate, so it needs its own allow-list check.
+        """
+        chassis = create_chassis_with_dpus(1)
+        updater = create_updater(chassis)
+        updater.module_table.hset("DPU0", "oper_status", str(ModuleBase.MODULE_STATUS_OFFLINE))
+
+        module = chassis.module_list[0]
+        module.set_admin_state = MagicMock()
+
+        with patch.object(updater, '_npu_crash_on_last_boot', return_value=True), \
+             patch.object(updater, '_is_auto_recovery_enabled', return_value=True), \
+             patch.object(updater, 'get_module_admin_status', return_value=ModuleBase.MODULE_STATUS_EMPTY):
+            updater.init_dpu_recovery_state()
+
+        module.set_admin_state.assert_not_called()
+        assert updater.dpu_recovery_state["DPU0"]['reset_count'] == 0

--- a/sonic-chassisd/tests/testbed/test_dpu_auto_recovery.py
+++ b/sonic-chassisd/tests/testbed/test_dpu_auto_recovery.py
@@ -405,7 +405,13 @@ def test_admin_down_marks_not_ready(results, dpu_name):
     logger.info(f"Test: admin-down marks {dpu_name} not-ready")
 
     # Save original admin status
-    original_admin = get_chassis_module_admin_status(dpu_name) or 'up'
+    original_admin = get_chassis_module_admin_status(dpu_name)
+    if original_admin != 'up':
+        results.skip(
+            f"admin_down_not_ready_{dpu_name}",
+            f"Requires configured admin_status=up, got '{original_admin}'"
+        )
+        return
 
     try:
         # Admin-down the DPU
@@ -885,7 +891,17 @@ def main():
             results.summary()
             sys.exit(0)
 
+        configured_dpus = []
         for dpu in target_dpus:
+            admin_status = get_chassis_module_admin_status(dpu)
+            if admin_status != 'up':
+                results.skip(
+                    f"configured_destructive_tests_{dpu}",
+                    f"Requires admin_status=up, got '{admin_status}'"
+                )
+                continue
+
+            configured_dpus.append(dpu)
             logger.info(f"\n--- Destructive tests for {dpu} ---")
             test_admin_down_marks_not_ready(results, dpu)
             test_enable_auto_recovery_feature(results, dpu)
@@ -896,7 +912,7 @@ def main():
 
         # --- Race condition tests ---
         logger.info("\n=== RACE CONDITION TESTS ===\n")
-        for dpu in target_dpus:
+        for dpu in configured_dpus:
             logger.info(f"\n--- Race condition tests for {dpu} ---")
             test_transition_lock_suppresses_recovery(results, dpu)
             test_recovery_type_does_not_suppress(results, dpu)


### PR DESCRIPTION
#### Why I did it
An unconfigured SmartSwitch DPU has no `CHASSIS_MODULE` entry, so its admin status is `Empty`.
Auto-recovery could treat it as recoverable and incorrectly power it on.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- Require `admin_status=up` before normal or NPU-crash recovery.
- Add unit regression coverage for an `Empty` admin status.
- Skip physical destructive/race tests unless admin status is explicitly `up`.

#### How to verify it
- `227` unit tests passed.
- On a SmartSwitch DUT, an unconfigured DPU stayed powered off beyond the boot timeout;
  `reset_count` stayed `0` and no power-cycle event was logged.
- Physical testbed script with a missing `CHASSIS_MODULE` entry: `12 passed, 0 failed`;
  destructive and race tests were skipped as expected.

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

#### Description for the changelog
Prevent DPU auto-recovery from powering on unconfigured DPUs