### PR TITLE
[BMC] Thermalctld hardening and fixes

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -726,17 +726,25 @@ class LiquidCoolingUpdater(threading.Thread, logger.Logger):
             if not sensor_is_ok:
                 if sensor_name not in self.faulty_sensors:
                     self.faulty_sensors[sensor_name] = now
-                    self.log_error('Liquid cooling leakage sensor {} reported faulty'.format(sensor_name))
+                    self.event_logger.log_error('Liquid cooling leakage sensor {} reported faulty'.format(sensor_name))
             else:
                 if sensor_name in self.faulty_sensors:
                     del self.faulty_sensors[sensor_name]
-                    self.log_notice('Liquid cooling leaking sensor {} recovered from fault'.format(sensor_name))
+                    self.event_logger.log_notice('Liquid cooling leaking sensor {} recovered from fault'.format(sensor_name))
 
             if sensor_is_ok:
                 if sensor_is_leak:
                     if sensor_name not in self.leaking_sensors:
                         self.leaking_sensors[sensor_name] = now
                         self.log_error('Liquid cooling leakage sensor {} reported leaking'.format(sensor_name))
+
+                    # A healthy sensor that is leaking must report a severity. A None here
+                    # is a platform-plugin contract violation; surface it to the event log
+                    # so it can be flagged via syslog alerting.
+                    if sensor_leak_severity is None:
+                        self.event_logger.log_error(
+                            'Liquid cooling leakage sensor {} is leaking but reported no severity (None)'.format(
+                                sensor_name))
 
                     # Upgrade minor leaks to critical if the time threshold has been exceeded.
                     escalated_to_critical = False
@@ -854,7 +862,12 @@ class LiquidCoolingUpdater(threading.Thread, logger.Logger):
         while not stopping_event.is_set():
             self.log_debug("Start liquid cooling updating")
 
-            self.update()
+            try:
+                self.update()
+            except Exception as e:
+                # A platform-plugin error in a single cycle must not permanently kill
+                # the leak-monitoring thread; log and retry on the next interval.
+                self.log_error('Error during liquid cooling update cycle: {}'.format(repr(e)))
 
             self.log_debug("End liquid cooling updating")
 

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -780,13 +780,11 @@ class LiquidCoolingUpdater(threading.Thread, logger.Logger):
                         self.event_logger.log_error(msg)
                         self.critical_sensors.add(sensor_name)
 
-                    # System severity is the highest per-sensor severity. Multiple
-                    # concurrent leaks do NOT by themselves escalate to CRITICAL;
-                    # escalation comes only from a sensor's own CRITICAL severity or
-                    # the time-based MINOR->CRITICAL upgrade handled above.
-                    if sensor_leak_severity == LeakSeverity.CRITICAL:
+                    if status is not None:
+                        # Multiple leaks (any severity) are critical.
                         status = LeakSeverity.CRITICAL
-                    elif status is None:
+                    else:
+                        # Else, severity is whatever this sensor's severity is.
                         status = sensor_leak_severity
                 else:
                     if sensor_name in self.leaking_sensors:

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -610,6 +610,9 @@ class LiquidCoolingUpdater(threading.Thread, logger.Logger):
         self.leaking_sensors: Dict[str, datetime] = {}
         self.faulty_sensors: Dict[str, datetime] = {}
         self.critical_sensors: set = set()
+        # Sensors whose CRITICAL was restored across a restart; latched CRITICAL while
+        # still leaking so a lower live severity does not transiently downgrade them.
+        self.latched_critical_sensors: set = set()
         self.interval = liquid_cooling_update_interval
         self.last_leak_status = None
         self.last_sensor_fvs: Dict[str, tuple] = {}
@@ -636,6 +639,63 @@ class LiquidCoolingUpdater(threading.Thread, logger.Logger):
                 ('device_leak_status', 'None'),
                 ('timestamp', datetime.now().strftime('%Y%m%d %H:%M:%S')),
             ]))
+
+        # Rebuild in-memory leak tracking so an ongoing leak survives a restart.
+        self._restore_state_from_db()
+
+    @staticmethod
+    def _row_to_dict(row):
+        """Normalise a Table.get() result to a field dict (or None).
+
+        Real swsscommon returns (found, fvs); the unit-test mock returns a plain dict.
+        """
+        if not row:
+            return None
+        if isinstance(row, dict):
+            return dict(row)
+        found, fvs = row[0], row[1]
+        return dict(fvs) if found else None
+
+    def _restore_state_from_db(self):
+        """Rebuild in-memory leak-tracking state from STATE_DB after a restart.
+
+        The escalation clock (leaking_sensors), critical set and last_leak_status live
+        only in memory; a restart would otherwise reset the MINOR timer and downgrade a
+        CRITICAL back to MINOR, transiently unblocking power-on gating. For each sensor
+        still recorded as leaking: seed the escalation clock from its recorded timestamp
+        (a MINOR sensor resumes its countdown) and latch a recorded CRITICAL so it stays
+        CRITICAL while leaking. A physical no-leak on the next refresh still clears it.
+        """
+        existing = self._row_to_dict(self.system_table.get('system'))
+        if existing:
+            try:
+                self.last_leak_status = LeakSeverity(existing.get('device_leak_status'))
+            except ValueError:
+                self.last_leak_status = None
+
+        for sensor_name in self.sensor_table.getKeys():
+            fields = self._row_to_dict(self.sensor_table.get(sensor_name))
+            if not fields or fields.get('leaking') != 'Yes':
+                continue
+            # Resume the escalation countdown from the recorded leak timestamp.
+            try:
+                leak_start = datetime.strptime(fields.get('timestamp', ''), '%Y%m%d %H:%M:%S')
+            except (TypeError, ValueError):
+                leak_start = datetime.now()
+            self.leaking_sensors[sensor_name] = leak_start
+            if fields.get('leak_severity') == LeakSeverity.CRITICAL.value:
+                self.critical_sensors.add(sensor_name)
+                self.latched_critical_sensors.add(sensor_name)
+            # Seed write-dedup so an unchanged row is not rewritten on first refresh.
+            self.last_sensor_fvs[sensor_name] = (
+                ('name', fields.get('name', sensor_name)),
+                ('leaking', fields.get('leaking', '')),
+                ('leak_status', fields.get('leak_status', '')),
+                ('leak_sensor_status', fields.get('leak_sensor_status', '')),
+                ('type', fields.get('type', '')),
+                ('location', fields.get('location', '')),
+                ('leak_severity', fields.get('leak_severity', '')),
+            )
 
     def __del__(self):
         try:
@@ -692,6 +752,11 @@ class LiquidCoolingUpdater(threading.Thread, logger.Logger):
                                 sensor_leak_severity = LeakSeverity.CRITICAL
                                 escalated_to_critical = True
 
+                    # Latch a CRITICAL restored across a restart: keep it CRITICAL while
+                    # the sensor is still leaking, even if the platform now reports lower.
+                    if sensor_name in self.latched_critical_sensors:
+                        sensor_leak_severity = LeakSeverity.CRITICAL
+
                     # If the platform downgrades a CRITICAL sensor (and our time-based
                     # escalation didn't immediately re-bump it), prune it from
                     # critical_sensors so a subsequent re-CRITICAL is logged once.
@@ -724,6 +789,7 @@ class LiquidCoolingUpdater(threading.Thread, logger.Logger):
                 else:
                     if sensor_name in self.leaking_sensors:
                         del self.leaking_sensors[sensor_name]
+                        self.latched_critical_sensors.discard(sensor_name)
                         if sensor_name in self.critical_sensors:
                             self.critical_sensors.discard(sensor_name)
                             self.event_logger.log_notice(

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -780,11 +780,13 @@ class LiquidCoolingUpdater(threading.Thread, logger.Logger):
                         self.event_logger.log_error(msg)
                         self.critical_sensors.add(sensor_name)
 
-                    if status is not None:
-                        # Multiple leaks (any severity) are critical.
+                    # System severity is the highest per-sensor severity. Multiple
+                    # concurrent leaks do NOT by themselves escalate to CRITICAL;
+                    # escalation comes only from a sensor's own CRITICAL severity or
+                    # the time-based MINOR->CRITICAL upgrade handled above.
+                    if sensor_leak_severity == LeakSeverity.CRITICAL:
                         status = LeakSeverity.CRITICAL
-                    else:
-                        # Else, severity is whatever this sensor's severity is.
+                    elif status is None:
                         status = sensor_leak_severity
                 else:
                     if sensor_name in self.leaking_sensors:

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -1293,6 +1293,81 @@ class TestLiquidCoolingUpdater(object):
 
         assert mock_sleep.call_count == 0
 
+    @mock.patch('time.sleep')
+    def test_task_worker_survives_update_exception(self, mock_sleep):
+        """A platform error in update() is caught so the monitoring thread stays alive."""
+        mock_chassis = MockChassis()
+        liquid_cooling_updater = thermalctld.LiquidCoolingUpdater(mock_chassis, 0.5)
+
+        liquid_cooling_updater.log_debug = mock.MagicMock()
+        liquid_cooling_updater.log_error = mock.MagicMock()
+        liquid_cooling_updater.update = mock.MagicMock(
+            side_effect=Exception("boom from platform plugin"))
+
+        stopping_event = threading.Event()
+
+        def side_effect_sleep(interval):
+            stopping_event.set()
+
+        mock_sleep.side_effect = side_effect_sleep
+
+        # Must not raise, must complete one cycle and go back to sleep (thread alive).
+        liquid_cooling_updater.task_worker(stopping_event)
+
+        assert liquid_cooling_updater.update.call_count == 1
+        assert liquid_cooling_updater.log_error.call_count == 1
+        assert 'Error during liquid cooling update cycle' in \
+            liquid_cooling_updater.log_error.call_args[0][0]
+        assert mock_sleep.call_count == 1
+        assert liquid_cooling_updater.exc is None
+        assert not liquid_cooling_updater.task_stopping_event.is_set()
+
+    @mock.patch('thermalctld.try_get')
+    def test_faulty_sensor_logged_to_event_log(self, mock_try_get):
+        """A faulty leak sensor and its recovery are recorded to the durable event log."""
+        mock_chassis = MockChassis()
+        mock_chassis.get_liquid_cooling().leakage_sensors[0].is_leak_sensor_ok = \
+            mock.MagicMock(return_value=False)
+
+        liquid_cooling_updater = thermalctld.LiquidCoolingUpdater(mock_chassis, 0.5)
+        liquid_cooling_updater.event_logger = mock.MagicMock()
+        liquid_cooling_updater.sensor_table = mock.MagicMock()
+        liquid_cooling_updater.system_table = mock.MagicMock()
+        mock_try_get.side_effect = lambda func, default: func()
+
+        liquid_cooling_updater._refresh_leak_status()
+
+        liquid_cooling_updater.event_logger.log_error.assert_any_call(
+            'Liquid cooling leakage sensor leakage1 reported faulty')
+
+        # Recovery is also written to the event log.
+        mock_chassis.get_liquid_cooling().leakage_sensors[0].is_leak_sensor_ok = \
+            mock.MagicMock(return_value=True)
+        liquid_cooling_updater._refresh_leak_status()
+
+        liquid_cooling_updater.event_logger.log_notice.assert_any_call(
+            'Liquid cooling leaking sensor leakage1 recovered from fault')
+
+    @mock.patch('thermalctld.try_get')
+    def test_leaking_without_severity_logs_event_error(self, mock_try_get):
+        """A leaking healthy sensor reporting no severity logs an error to the event log."""
+        mock_chassis = MockChassis()
+        mock_chassis.get_liquid_cooling().make_sensor_leak(0)
+        mock_chassis.get_liquid_cooling().leakage_sensors[0].get_leak_severity = \
+            mock.MagicMock(return_value=None)
+
+        liquid_cooling_updater = thermalctld.LiquidCoolingUpdater(mock_chassis, 0.5)
+        liquid_cooling_updater.event_logger = mock.MagicMock()
+        liquid_cooling_updater.log_error = mock.MagicMock()
+        liquid_cooling_updater.sensor_table = mock.MagicMock()
+        liquid_cooling_updater.system_table = mock.MagicMock()
+        mock_try_get.side_effect = lambda func, default: func()
+
+        liquid_cooling_updater._refresh_leak_status()
+
+        liquid_cooling_updater.event_logger.log_error.assert_any_call(
+            'Liquid cooling leakage sensor leakage1 is leaking but reported no severity (None)')
+
 
 class TestThermalMonitor(object):
     """

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -738,26 +738,24 @@ class TestLiquidCoolingUpdater(object):
 
         liquid_cooling_updater._refresh_leak_status()
 
-        # Two self.log_error calls (one per sensor leak detection). Multiple
-        # concurrent leaks no longer auto-escalate to CRITICAL, so there is NO
-        # event_logger.log_error for a system CRITICAL transition and the system
-        # severity stays MINOR.
+        # Two self.log_error calls (one per sensor leak detection) plus one
+        # event_logger.log_error for the system CRITICAL transition.
         assert liquid_cooling_updater.log_error.call_count == 2
-        assert liquid_cooling_updater.event_logger.log_error.call_count == 0
+        assert liquid_cooling_updater.event_logger.log_error.call_count == 1
         assert len(liquid_cooling_updater.leaking_sensors) == 2
         assert "leakage1" in liquid_cooling_updater.leaking_sensors
         assert "leakage2" in liquid_cooling_updater.leaking_sensors
         assert len(liquid_cooling_updater.faulty_sensors) == 0
-        assert liquid_cooling_updater.last_leak_status == LeakSeverity.MINOR
+        assert liquid_cooling_updater.last_leak_status == LeakSeverity.CRITICAL
 
-        # System status only written on the initial None->MINOR transition; the
-        # second MINOR leak does not change the aggregate severity, so no
-        # additional write occurs.
         calls_sys = liquid_cooling_updater.system_table.set.call_args_list
-        assert len(calls_sys) == 1
-        scope_name, fvp = calls_sys[0][0]
-        assert scope_name == "system"
-        assert fvp.fv_dict['device_leak_status'] == 'MINOR'
+        for index, call in enumerate(calls_sys):
+            scope_name, fvp = call[0]
+            assert scope_name == "system"
+            if index == 0:
+                assert fvp.fv_dict['device_leak_status'] == 'MINOR'
+            elif index == 1:
+                assert fvp.fv_dict['device_leak_status'] == 'CRITICAL'
 
     @mock.patch('thermalctld.try_get')
     def test_refresh_status_minor_no_escalation_when_duration_zero(self, mock_try_get):

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -738,24 +738,26 @@ class TestLiquidCoolingUpdater(object):
 
         liquid_cooling_updater._refresh_leak_status()
 
-        # Two self.log_error calls (one per sensor leak detection) plus one
-        # event_logger.log_error for the system CRITICAL transition.
+        # Two self.log_error calls (one per sensor leak detection). Multiple
+        # concurrent leaks no longer auto-escalate to CRITICAL, so there is NO
+        # event_logger.log_error for a system CRITICAL transition and the system
+        # severity stays MINOR.
         assert liquid_cooling_updater.log_error.call_count == 2
-        assert liquid_cooling_updater.event_logger.log_error.call_count == 1
+        assert liquid_cooling_updater.event_logger.log_error.call_count == 0
         assert len(liquid_cooling_updater.leaking_sensors) == 2
         assert "leakage1" in liquid_cooling_updater.leaking_sensors
         assert "leakage2" in liquid_cooling_updater.leaking_sensors
         assert len(liquid_cooling_updater.faulty_sensors) == 0
-        assert liquid_cooling_updater.last_leak_status == LeakSeverity.CRITICAL
+        assert liquid_cooling_updater.last_leak_status == LeakSeverity.MINOR
 
+        # System status only written on the initial None->MINOR transition; the
+        # second MINOR leak does not change the aggregate severity, so no
+        # additional write occurs.
         calls_sys = liquid_cooling_updater.system_table.set.call_args_list
-        for index, call in enumerate(calls_sys):
-            scope_name, fvp = call[0]
-            assert scope_name == "system"
-            if index == 0:
-                assert fvp.fv_dict['device_leak_status'] == 'MINOR'
-            elif index == 1:
-                assert fvp.fv_dict['device_leak_status'] == 'CRITICAL'
+        assert len(calls_sys) == 1
+        scope_name, fvp = calls_sys[0][0]
+        assert scope_name == "system"
+        assert fvp.fv_dict['device_leak_status'] == 'MINOR'
 
     @mock.patch('thermalctld.try_get')
     def test_refresh_status_minor_no_escalation_when_duration_zero(self, mock_try_get):

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -37,6 +37,7 @@ assert(os.path.samefile(swsscommon.__path__[0], os.path.join(mocked_libs_path, '
 
 from sonic_py_common import daemon_base, device_info
 from sonic_platform_base.liquid_cooling_base import LeakSeverity
+from datetime import datetime, timedelta
 
 from .mock_platform import MockChassis, MockFan, MockFanDrawer, MockModule, MockPsu, MockThermal
 from .mock_swsscommon import Table
@@ -579,6 +580,127 @@ class TestLiquidCoolingUpdater(object):
             assert scope_name == "system"
             assert fvp.fv_dict['device_leak_status'] == 'CRITICAL'
 
+    def test_restore_state_from_db(self):
+        """_restore_state_from_db rebuilds the escalation clock, latch and status."""
+        updater = thermalctld.LiquidCoolingUpdater(MockChassis(), 0.5)
+        updater.system_table.set('system', thermalctld.swsscommon.FieldValuePairs([
+            ('device_leak_status', 'CRITICAL'),
+            ('timestamp', '20250101 00:05:00'),
+        ]))
+        updater.sensor_table.set('leakage1', thermalctld.swsscommon.FieldValuePairs([
+            ('name', 'leakage1'), ('leaking', 'Yes'), ('leak_status', 'Yes'),
+            ('leak_sensor_status', 'Good'), ('type', 'mock_sensor'), ('location', 'unknown'),
+            ('leak_severity', 'CRITICAL'), ('timestamp', '20250101 00:05:00'),
+        ]))
+        # Simulate a fresh restart: in-memory state is empty.
+        updater.leaking_sensors = {}
+        updater.critical_sensors = set()
+        updater.latched_critical_sensors = set()
+        updater.last_leak_status = None
+
+        updater._restore_state_from_db()
+
+        assert updater.last_leak_status == LeakSeverity.CRITICAL
+        # Escalation clock resumed from the recorded row timestamp.
+        assert updater.leaking_sensors['leakage1'] == datetime(2025, 1, 1, 0, 5, 0)
+        # A recorded CRITICAL is latched so it is not transiently downgraded.
+        assert 'leakage1' in updater.critical_sensors
+        assert 'leakage1' in updater.latched_critical_sensors
+        # Dedup cache seeded so the unchanged row is not rewritten on first refresh.
+        assert 'leakage1' in updater.last_sensor_fvs
+
+    @mock.patch('thermalctld.try_get')
+    def test_restart_latches_critical_even_if_platform_reads_minor(self, mock_try_get):
+        """A restored CRITICAL stays CRITICAL after restart even if the platform reads MINOR."""
+        mock_chassis = MockChassis()
+        lc = mock_chassis.get_liquid_cooling()
+        lc.make_sensor_leak(0)
+        # Platform now reports MINOR natively, but it was recorded CRITICAL.
+        lc.leakage_sensors[0].leak_severity = LeakSeverity.MINOR
+        updater = thermalctld.LiquidCoolingUpdater(mock_chassis, 0.5)
+        updater.event_logger = mock.MagicMock()
+        mock_try_get.side_effect = lambda func, default: func()
+
+        now_str = datetime.now().strftime('%Y%m%d %H:%M:%S')
+        updater.system_table.set('system', thermalctld.swsscommon.FieldValuePairs([
+            ('device_leak_status', 'CRITICAL'), ('timestamp', now_str)]))
+        updater.sensor_table.set('leakage1', thermalctld.swsscommon.FieldValuePairs([
+            ('name', 'leakage1'), ('leaking', 'Yes'), ('leak_status', 'Yes'),
+            ('leak_sensor_status', 'Good'), ('type', 'mock_sensor'), ('location', 'unknown'),
+            ('leak_severity', 'CRITICAL'), ('timestamp', now_str)]))
+        updater.leaking_sensors = {}
+        updater.critical_sensors = set()
+        updater.latched_critical_sensors = set()
+        updater.last_leak_status = None
+
+        updater._restore_state_from_db()
+        updater._refresh_leak_status()
+
+        # The latch keeps it CRITICAL despite the live MINOR reading.
+        assert updater.system_table.get('system')['device_leak_status'] == 'CRITICAL'
+        assert updater.last_leak_status == LeakSeverity.CRITICAL
+
+    @mock.patch('thermalctld.try_get')
+    def test_restart_resumes_minor_timer_and_escalates(self, mock_try_get):
+        """A recorded MINOR whose window has elapsed escalates immediately after restart."""
+        mock_chassis = MockChassis()
+        lc = mock_chassis.get_liquid_cooling()
+        lc.make_sensor_leak(0)
+        lc.leakage_sensors[0].leak_severity = LeakSeverity.MINOR
+        updater = thermalctld.LiquidCoolingUpdater(mock_chassis, 0.5)
+        updater.event_logger = mock.MagicMock()
+        mock_try_get.side_effect = lambda func, default: func()
+
+        # Recorded leak-start well beyond the mock max_minor_duration (1s).
+        old_start = (datetime.now() - timedelta(seconds=3600)).strftime('%Y%m%d %H:%M:%S')
+        updater.system_table.set('system', thermalctld.swsscommon.FieldValuePairs([
+            ('device_leak_status', 'MINOR'), ('timestamp', old_start)]))
+        updater.sensor_table.set('leakage1', thermalctld.swsscommon.FieldValuePairs([
+            ('name', 'leakage1'), ('leaking', 'Yes'), ('leak_status', 'Yes'),
+            ('leak_sensor_status', 'Good'), ('type', 'mock_sensor'), ('location', 'unknown'),
+            ('leak_severity', 'MINOR'), ('timestamp', old_start)]))
+        updater.leaking_sensors = {}
+        updater.critical_sensors = set()
+        updater.latched_critical_sensors = set()
+        updater.last_leak_status = None
+
+        updater._restore_state_from_db()
+        # No latch for a recorded MINOR; escalation is purely time-based.
+        assert 'leakage1' not in updater.latched_critical_sensors
+        updater._refresh_leak_status()
+
+        assert updater.system_table.get('system')['device_leak_status'] == 'CRITICAL'
+
+    @mock.patch('thermalctld.try_get')
+    def test_restart_clears_when_sensor_reads_no_leak(self, mock_try_get):
+        """A recorded CRITICAL clears if the sensor physically reads no-leak after restart."""
+        mock_chassis = MockChassis()
+        lc = mock_chassis.get_liquid_cooling()
+        # Sensor physically NOT leaking now (default make_sensor_leak not called).
+        updater = thermalctld.LiquidCoolingUpdater(mock_chassis, 0.5)
+        updater.event_logger = mock.MagicMock()
+        mock_try_get.side_effect = lambda func, default: func()
+
+        now_str = datetime.now().strftime('%Y%m%d %H:%M:%S')
+        updater.system_table.set('system', thermalctld.swsscommon.FieldValuePairs([
+            ('device_leak_status', 'CRITICAL'), ('timestamp', now_str)]))
+        updater.sensor_table.set('leakage1', thermalctld.swsscommon.FieldValuePairs([
+            ('name', 'leakage1'), ('leaking', 'Yes'), ('leak_status', 'Yes'),
+            ('leak_sensor_status', 'Good'), ('type', 'mock_sensor'), ('location', 'unknown'),
+            ('leak_severity', 'CRITICAL'), ('timestamp', now_str)]))
+        updater.leaking_sensors = {}
+        updater.critical_sensors = set()
+        updater.latched_critical_sensors = set()
+        updater.last_leak_status = None
+
+        updater._restore_state_from_db()
+        updater._refresh_leak_status()
+
+        # Physical no-leak wins: state clears despite the recorded CRITICAL.
+        assert updater.system_table.get('system')['device_leak_status'] == 'None'
+        assert 'leakage1' not in updater.leaking_sensors
+        assert 'leakage1' not in updater.latched_critical_sensors
+
     @mock.patch('thermalctld.try_get')
     def test_refresh_status_with_multiple_leaks(self, mock_try_get):
         """Test _refresh_leak_status when multiple sensors are leaking"""
@@ -971,7 +1093,7 @@ class TestLiquidCoolingUpdater(object):
 
         liquid_cooling_updater.log_error = mock.MagicMock()
         liquid_cooling_updater.log_notice = mock.MagicMock()
-        liquid_cooling_updater.leaking_sensors = []
+        liquid_cooling_updater.leaking_sensors = {}
         db_tables = _mock_liquid_cooling_db_tables(liquid_cooling_updater)
 
         mock_try_get.side_effect = lambda func, default: func()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
#### Motivation and Context

This PR is for hardening thermalctld 
1. In case there is a thermalctld restart preserve the escallation path logic, so that the leak sensors which had moved from Minor --> Critical won't be affected
2. Add a try-except condition for leak sensor update
3. Error log case when sensor goes faulty - place it int the persistent /host/event.log file
4. Error log case when a leak sensor tell it is leaking but Severity is None


#### How Has This Been Tested?
Added the following Unit tests 
```
   1. test_restore_state_from_db - _restore_state_from_db rebuilds the escalation clock, latch, and last status from STATE_DB at startup.                                         ┃
   2. test_restart_latches_critical_even_if_platform_reads_minor - a restored CRITICAL stays CRITICAL after restart even if the platform now reads MINOR.                         ┃
   3. test_restart_resumes_minor_timer_and_escalates - a recorded MINOR whose window has elapsed escalates immediately after restart.                                             ┃
   4. test_restart_clears_when_sensor_reads_no_leak - restored state clears if the sensor now reads no leak.                                                                      ┃
   5. test_task_worker_survives_update_exception - a platform error in update() is caught so the monitoring thread stays alive and retries next cycle.                            ┃
   6. test_faulty_sensor_logged_to_event_log - a faulty leak sensor and its recovery are written to the durable event log.                                                        ┃
   7. test_leaking_without_severity_logs_event_error - a leaking healthy sensor reporting no severity logs an error to the event log.    
```
#### Additional Information (Optional)
