### PR TITLE
Add handler in bmcctld for RACK_MANAGER_DATA_TABLE for rack manager telemetry

### DIFF
--- a/sonic-bmcctld/scripts/bmcctld
+++ b/sonic-bmcctld/scripts/bmcctld
@@ -163,6 +163,17 @@ SYSTEM_LEAK_STATUS_TABLE = "SYSTEM_LEAK_STATUS"
 SYSTEM_LEAK_STATUS_KEY = "system"
 RACK_MANAGER_COMMAND_TABLE = "RACK_MANAGER_COMMAND"
 RACK_MANAGER_ALERT_TABLE = "RACK_MANAGER_ALERT"
+RACK_MANAGER_DATA_TABLE = "RACK_MANAGER_DATA"
+
+# Rack Manager telemetry (RACK_MANAGER_DATA) keys whose NORMAL reading clears the
+# matching RACK_MANAGER_ALERT. Mirrors CriticalEventChecker.ALERT_KEYS but is kept
+# separate so the telemetry-clear path can evolve independently of the alert list.
+RACK_MGR_TELEMETRY_KEYS = [
+    "Inlet_liquid_temperature",
+    "Inlet_liquid_flow_rate",
+    "Inlet_liquid_pressure",
+    "Rack_level_leak",
+]
 
 # Field names
 FIELD_POWER_ON_DELAY = "power_on_delay"
@@ -845,6 +856,8 @@ class BmcEventHandler(EventLogger):
             self.config_db, CHASSIS_MODULE_TABLE)
         self.rack_mgr_alert_sub = swsscommon.SubscriberStateTable(
             self.state_db, RACK_MANAGER_ALERT_TABLE)
+        self.rack_mgr_data_sub = swsscommon.SubscriberStateTable(
+            self.state_db, RACK_MANAGER_DATA_TABLE)
         self.system_leak_sub = swsscommon.SubscriberStateTable(
             self.state_db, SYSTEM_LEAK_STATUS_TABLE)
 
@@ -858,6 +871,7 @@ class BmcEventHandler(EventLogger):
             self.rack_mgr_cmd_sub.getFd():   (self.rack_mgr_cmd_sub,   self._handle_rack_mgr_command),
             self.chassis_module_sub.getFd(): (self.chassis_module_sub, self._handle_chassis_module),
             self.rack_mgr_alert_sub.getFd(): (self.rack_mgr_alert_sub, self._handle_rack_mgr_alert),
+            self.rack_mgr_data_sub.getFd():  (self.rack_mgr_data_sub,  self._handle_rack_mgr_data),
             self.system_leak_sub.getFd():    (self.system_leak_sub,    self._handle_system_leak),
         }
 
@@ -865,6 +879,7 @@ class BmcEventHandler(EventLogger):
         self.sel.addSelectable(self.rack_mgr_cmd_sub)
         self.sel.addSelectable(self.chassis_module_sub)
         self.sel.addSelectable(self.rack_mgr_alert_sub)
+        self.sel.addSelectable(self.rack_mgr_data_sub)
         self.sel.addSelectable(self.system_leak_sub)
 
     def seed_chassis_module_admin_status(self):
@@ -1046,6 +1061,39 @@ class BmcEventHandler(EventLogger):
             self._event_log.log_notice(
                 "RACK_MGR_ALERT handler done: key={} severity={} result=CLEARED (no action)".format(
                     key, severity))
+
+    def _handle_rack_mgr_data(self, key, fvs):
+        """Process a RACK_MANAGER_DATA (telemetry) change from Rack Manager.
+
+        Telemetry is pushed periodically and is used solely to clear a previously
+        raised RACK_MANAGER_ALERT: when a sensor's telemetry severity returns to
+        NORMAL, the matching RACK_MANAGER_ALERT|<key> row is deleted so the
+        power-on gate (has_critical_rack_mgr_alert) no longer treats it as active.
+        Telemetry never raises an alert or takes a power action; per design, on
+        clear no power action is taken (power-on stays under external/user control).
+        """
+        if key not in RACK_MGR_TELEMETRY_KEYS:
+            # Telemetry only maps to the supported alert keys; ignore anything else.
+            return
+
+        # severity field for temperature/flow/pressure; leak field for rack-level leak.
+        severity = str(fvs.get(FIELD_SEVERITY) or fvs.get(FIELD_LEAK, ALERT_SEVERITY_NORMAL)).upper()
+        if severity != ALERT_SEVERITY_NORMAL:
+            # Non-NORMAL telemetry is informational only; alerts are raised via the
+            # RACK_MANAGER_ALERT table, not here.
+            return
+
+        # NORMAL telemetry: clear the matching alert if one is currently active.
+        tbl = swsscommon.Table(self.state_db, RACK_MANAGER_ALERT_TABLE)
+        result = tbl.get(key)
+        if not (result and result[0]):
+            # No active alert for this key; nothing to clear (avoids per-cycle noise).
+            return
+
+        tbl._del(key)
+        self._last_rack_mgr_alert_severity.pop(key, None)
+        self._event_log.log_notice(
+            "RACK_MGR alert CLEARED by telemetry: key={} (RACK_MANAGER_DATA severity=NORMAL)".format(key))
 
     # ---- dispatch helpers ----
 

--- a/sonic-bmcctld/tests/test_bmcctld.py
+++ b/sonic-bmcctld/tests/test_bmcctld.py
@@ -893,6 +893,97 @@ class TestBmcEventHandlerRackMgrAlerts:
 
 
 # --------------------------------------------------------------------------
+# Tests: BmcEventHandler - Rack Manager telemetry (RACK_MANAGER_DATA)
+# --------------------------------------------------------------------------
+
+class TestBmcEventHandlerRackMgrData:
+
+    def test_data_subscriber_registered(self, event_handler):
+        """RACK_MANAGER_DATA is subscribed and routed to _handle_rack_mgr_data."""
+        fd = event_handler.rack_mgr_data_sub.getFd()
+        assert fd in event_handler._subscribers
+        assert event_handler._subscribers[fd][1] == event_handler._handle_rack_mgr_data
+
+    def test_normal_telemetry_clears_active_alert(self, event_handler):
+        """NORMAL telemetry deletes the matching RACK_MANAGER_ALERT row and resets dedup."""
+        tbl = Table(None, bmcctld.RACK_MANAGER_ALERT_TABLE)
+        _set_table_entry(tbl, "Inlet_liquid_temperature",
+                         {bmcctld.FIELD_SEVERITY: bmcctld.ALERT_SEVERITY_CRITICAL})
+        event_handler._last_rack_mgr_alert_severity["Inlet_liquid_temperature"] = \
+            bmcctld.ALERT_SEVERITY_CRITICAL
+        with patch.object(bmcctld.swsscommon, 'Table', return_value=tbl):
+            event_handler._handle_rack_mgr_data(
+                "Inlet_liquid_temperature",
+                {bmcctld.FIELD_SEVERITY: bmcctld.ALERT_SEVERITY_NORMAL},
+            )
+        assert "Inlet_liquid_temperature" not in tbl.mock_dict
+        assert "Inlet_liquid_temperature" not in event_handler._last_rack_mgr_alert_severity
+
+    def test_normal_telemetry_no_active_alert_is_noop(self, event_handler):
+        """NORMAL telemetry with no active alert does nothing (no error, no delete)."""
+        tbl = Table(None, bmcctld.RACK_MANAGER_ALERT_TABLE)
+        with patch.object(bmcctld.swsscommon, 'Table', return_value=tbl):
+            event_handler._handle_rack_mgr_data(
+                "Inlet_liquid_pressure",
+                {bmcctld.FIELD_SEVERITY: bmcctld.ALERT_SEVERITY_NORMAL},
+            )
+        assert tbl.mock_dict == {}
+
+    def test_non_normal_telemetry_leaves_alert(self, event_handler):
+        """Non-NORMAL telemetry never clears an alert (alerts are raised via ALERT table)."""
+        tbl = Table(None, bmcctld.RACK_MANAGER_ALERT_TABLE)
+        _set_table_entry(tbl, "Inlet_liquid_flow_rate",
+                         {bmcctld.FIELD_SEVERITY: bmcctld.ALERT_SEVERITY_CRITICAL})
+        event_handler._last_rack_mgr_alert_severity["Inlet_liquid_flow_rate"] = \
+            bmcctld.ALERT_SEVERITY_CRITICAL
+        with patch.object(bmcctld.swsscommon, 'Table', return_value=tbl):
+            event_handler._handle_rack_mgr_data(
+                "Inlet_liquid_flow_rate",
+                {bmcctld.FIELD_SEVERITY: bmcctld.ALERT_SEVERITY_MINOR},
+            )
+        assert "Inlet_liquid_flow_rate" in tbl.mock_dict
+        assert event_handler._last_rack_mgr_alert_severity["Inlet_liquid_flow_rate"] == \
+            bmcctld.ALERT_SEVERITY_CRITICAL
+
+    def test_rack_level_leak_telemetry_clears_via_leak_field(self, event_handler):
+        """Rack_level_leak telemetry reports NORMAL via the 'leak' field and clears the alert."""
+        tbl = Table(None, bmcctld.RACK_MANAGER_ALERT_TABLE)
+        _set_table_entry(tbl, "Rack_level_leak",
+                         {bmcctld.FIELD_LEAK: bmcctld.ALERT_SEVERITY_CRITICAL})
+        with patch.object(bmcctld.swsscommon, 'Table', return_value=tbl):
+            event_handler._handle_rack_mgr_data(
+                "Rack_level_leak",
+                {bmcctld.FIELD_LEAK: bmcctld.ALERT_SEVERITY_NORMAL},
+            )
+        assert "Rack_level_leak" not in tbl.mock_dict
+
+    def test_mixed_case_normal_clears(self, event_handler):
+        """A mixed-case 'Normal' telemetry severity still clears the alert."""
+        tbl = Table(None, bmcctld.RACK_MANAGER_ALERT_TABLE)
+        _set_table_entry(tbl, "Inlet_liquid_pressure",
+                         {bmcctld.FIELD_SEVERITY: bmcctld.ALERT_SEVERITY_CRITICAL})
+        with patch.object(bmcctld.swsscommon, 'Table', return_value=tbl):
+            event_handler._handle_rack_mgr_data(
+                "Inlet_liquid_pressure",
+                {bmcctld.FIELD_SEVERITY: "Normal"},
+            )
+        assert "Inlet_liquid_pressure" not in tbl.mock_dict
+
+    def test_unknown_telemetry_key_ignored(self, event_handler):
+        """Telemetry under a key outside ALERT_KEYS is ignored (no table access, no error)."""
+        tbl = Table(None, bmcctld.RACK_MANAGER_ALERT_TABLE)
+        _set_table_entry(tbl, "Inlet_liquid_temperature",
+                         {bmcctld.FIELD_SEVERITY: bmcctld.ALERT_SEVERITY_CRITICAL})
+        with patch.object(bmcctld.swsscommon, 'Table', return_value=tbl):
+            event_handler._handle_rack_mgr_data(
+                "Some_unexpected_key",
+                {bmcctld.FIELD_SEVERITY: bmcctld.ALERT_SEVERITY_NORMAL},
+            )
+        # Unrelated active alert must be untouched.
+        assert "Inlet_liquid_temperature" in tbl.mock_dict
+
+
+# --------------------------------------------------------------------------
 # Tests: BmcctldDaemon - action loop
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
#### Description
bmcctld now subscribes to RACK_MANAGER_ALERT and gates Switch-Host power-on while any alert reads CRITICAL (has_critical_rack_mgr_alert). Because Rack Manager only writes deviations (CRITICAL/MAJOR/MINOR) to RACK_MANAGER_ALERT and never writes NORMAL, a raised alert never clears itself.

Per the pmon-bmc-design document, Rack Manager also publishes periodic telemetry to a separate STATE_DB table, RACK_MANAGER_DATA, whose purpose is to signal when a critical alert has cleared. This PR adds a handler that consumes that telemetry. When a sensor's telemetry severity returns to NORMAL, the corresponding RACK_MANAGER_ALERT entry is deleted so the power-on gate no longer treats it as active.
REF : https://github.com/sonic-net/SONiC/blob/master/doc/bmc/sonicBMC/pmon-bmc-design.md#2121-db-schema

#### Motivation and Context

  -- Add RACK_MANAGER_DATA subscriber and integrate it into the select loop and file-descriptor-to-handler dispatch map.
  -- Add _handle_rack_mgr_data(key, fvs):
  -- Read severity from: 
             severity field for temperature, flow, and pressure telemetry.
             leak field for Rack_level_leak.
   -- Treat non-NORMAL telemetry as informational only; no action is taken. 
        Alerts continue to be raised via RACK_MANAGER_ALERT.
   -- On NORMAL: Delete only the matching RACK_MANAGER_ALERT|<key> entry (per-key scope).
        Clear the cached last-severity value for that key.
        Log a notice.
        No-op if no active alert exists for that key.

Add RACK_MGR_TELEMETRY_KEYS module constant containing the four supported telemetry sensors:
     Inlet_liquid_temperature
     Inlet_liquid_flow_rate
     Inlet_liquid_pressure
     Rack_level_leak



#### How Has This Been Tested?
Following unit tests are added 
```
   1. test_data_subscriber_registered - the rack-manager data subscriber is registered and routed to _handle_rack_mgr_data.               ┃
   2. test_normal_telemetry_clears_active_alert - NORMAL telemetry deletes the matching alert row and resets dedup state.                 ┃
   3. test_normal_telemetry_no_active_alert_is_noop - NORMAL telemetry with no active alert does nothing.                                 ┃
   4. test_non_normal_telemetry_leaves_alert - non-NORMAL telemetry never clears an alert.                                                ┃
   5. test_rack_level_leak_telemetry_clears_via_leak_field - Rack_level_leak reports NORMAL via the 'leak' field and clears the alert.    ┃
   6. test_mixed_case_normal_clears - a mixed-case "Normal" severity still clears the alert (case-insensitive).                           ┃
   7. test_unknown_telemetry_key_ignored - telemetry under a key outside ALERT_KEYS is ignored.       
```


#### Additional Information (Optional)
