### PR TITLE
Fixes error during thermalctld initialization on multi-asic platforms

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -991,6 +991,10 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
         # Set minimum logging level to INFO
         self.set_min_log_priority_info()
 
+        if multi_asic.is_multi_asic():
+            # Load the namespace details first from the database_global.json file.
+            swsscommon.SonicDBConfig.initializeGlobalConfig()
+
         self.stop_event = threading.Event()
 
         self.wait_time = self.INTERVAL

--- a/sonic-thermalctld/tests/mocked_libs/swsscommon/__init__.py
+++ b/sonic-thermalctld/tests/mocked_libs/swsscommon/__init__.py
@@ -3,3 +3,4 @@
 '''
 
 from . import swsscommon
+from .swsscommon import SonicDBConfig

--- a/sonic-thermalctld/tests/mocked_libs/swsscommon/swsscommon.py
+++ b/sonic-thermalctld/tests/mocked_libs/swsscommon/swsscommon.py
@@ -4,6 +4,19 @@
 
 STATE_DB = ''
 
+
+class SonicDBConfig:
+    _global_init = False
+
+    @staticmethod
+    def initializeGlobalConfig(global_db_file_path=None):
+        SonicDBConfig._global_init = True
+
+    @staticmethod
+    def reset():
+        SonicDBConfig._global_init = False
+
+
 class ConfigDBConnector:
     """
     Mock ConfigDBConnector that avoids real Redis connections.

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -1389,3 +1389,29 @@ class TestThermalControlDaemon(object):
 
             # Clean up
             daemon_thermalctld.deinit()
+
+    @mock.patch('thermalctld.multi_asic.is_multi_asic')
+    def test_global_db_config_initialized_on_multi_asic(self, mock_is_multi_asic):
+        """Test that initializeGlobalConfig is called on multi-ASIC platforms"""
+        mock_is_multi_asic.return_value = True
+        swsscommon.SonicDBConfig.reset()
+
+        with mock.patch.object(swsscommon.SonicDBConfig, 'initializeGlobalConfig', wraps=swsscommon.SonicDBConfig.initializeGlobalConfig) as mock_init_global:
+            daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
+            mock_init_global.assert_called_once()
+            daemon_thermalctld.deinit()
+
+        swsscommon.SonicDBConfig.reset()
+
+    @mock.patch('thermalctld.multi_asic.is_multi_asic')
+    def test_global_db_config_not_initialized_on_single_asic(self, mock_is_multi_asic):
+        """Test that initializeGlobalConfig is not called on single-ASIC platforms"""
+        mock_is_multi_asic.return_value = False
+        swsscommon.SonicDBConfig.reset()
+
+        with mock.patch.object(swsscommon.SonicDBConfig, 'initializeGlobalConfig') as mock_init_global:
+            daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
+            mock_init_global.assert_not_called()
+            daemon_thermalctld.deinit()
+
+        swsscommon.SonicDBConfig.reset()


### PR DESCRIPTION


#### Description
`sonic-mgmt/tests/voq` tests on a multi-asic switch shows the following error:

ERR pmon#thermalctld: :- validateNamespace: Initialize global DB config using API SonicDBConfig::initializeGlobalConfig

#### How Has This Been Tested?

Running sonic-mgmt voq tests on a multi-asic switch. Before the change, `voq/test_voq_intfs.py::test_voq_intfs::test_cycle_voq_intf` test was failing with:

```
	 E               Failed: Got matched syslog in processes "analyze_logs--<MultiAsicSonicHost qzd544>" exit code:"1"
	 E               match: 9
	 E               expected_match: 0
	 E               expected_missing_match: 0
	 E
	 E               Match Messages:
	 E               2026 Aug 21 23:56:55.199330 qzd544 ERR syncd1#syncd: [03:00.0] SAI_API_SWITCH:_brcm_sai_remove_switch:1064 shutdown switch failed with error -1.
	 E
	 E               2026 Aug 21 23:56:55.943164 qzd544 ERR syncd0#syncd: [09:00.0] SAI_API_SWITCH:_brcm_sai_remove_switch:1064 shutdown switch failed with error -1.
	 E
	 E               2026 Aug 22 00:00:22.395653 qzd544 ERR pmon#thermalctld: :- validateNamespace: Initialize global DB config using API SonicDBConfig::initializeGlobalConfig
	 E
	 E               2026 Aug 22 00:02:46.553009 qzd544 ERR syncd0#syncd: [09:00.0] SAI_API_SWITCH:_brcm_sai_remove_switch:1064 shutdown switch failed with error -1.
	 E
	 E               2026 Aug 22 00:02:48.470780 qzd544 ERR syncd1#syncd: [03:00.0] SAI_API_SWITCH:_brcm_sai_remove_switch:1064 shutdown switch failed with error -1.
	 E
	 E               2026 Aug 22 00:06:16.836234 qzd544 ERR pmon#thermalctld: :- validateNamespace: Initialize global DB config using API SonicDBConfig::initializeGlobalConfig
	 E
	 E               2026 Aug 22 00:08:05.790225 qzd544 ERR syncd1#syncd: [03:00.0] SAI_API_SWITCH:_brcm_sai_remove_switch:1064 shutdown switch failed with error -1.
	 E
	 E               2026 Aug 22 00:08:07.742972 qzd544 ERR syncd0#syncd: [09:00.0] SAI_API_SWITCH:_brcm_sai_remove_switch:1064 shutdown switch failed with error -1.
	 E
	 E               2026 Aug 22 00:11:37.703693 qzd544 ERR pmon#thermalctld: :- validateNamespace: Initialize global DB config using API SonicDBConfig::initializeGlobalConfig
```

#### Additional Information (Optional)
