### PR TITLE
[ycabled][active-standby] Ignore transceiver updates for initialized MUX simulator.

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -1267,6 +1267,38 @@ class TestYCableScript(object):
             state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name, y_cable_presence)
         assert(rc == None)
 
+    @patch('os.path.exists', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    def test_is_initialized_simulated_y_cable(self):
+        simulated_port_instance = MagicMock()
+        simulated_port_instance._initialized = True
+        with patch.dict(
+                'ycable.ycable_utilities.y_cable_helper.y_cable_port_instances',
+                {0: simulated_port_instance}, clear=True):
+            assert is_initialized_simulated_y_cable("Ethernet0") is True
+
+    @patch('os.path.exists', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    def test_is_initialized_simulated_y_cable_without_instance(self):
+        with patch.dict(
+                'ycable.ycable_utilities.y_cable_helper.y_cable_port_instances',
+                {}, clear=True):
+            assert is_initialized_simulated_y_cable("Ethernet0") is False
+
+    @patch('os.path.exists', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    def test_is_initialized_simulated_y_cable_incomplete_instance(self):
+        simulated_port_instance = MagicMock()
+        simulated_port_instance._initialized = False
+        with patch.dict(
+                'ycable.ycable_utilities.y_cable_helper.y_cable_port_instances',
+                {0: simulated_port_instance}, clear=True):
+            assert is_initialized_simulated_y_cable("Ethernet0") is False
+
+    @patch('os.path.exists', MagicMock(return_value=False))
+    def test_is_initialized_simulated_y_cable_without_config(self):
+        assert is_initialized_simulated_y_cable("Ethernet0") is False
+
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))

--- a/sonic-ycabled/tests/test_ycable.py
+++ b/sonic-ycabled/tests/test_ycable.py
@@ -316,6 +316,55 @@ class TestYcableScript(object):
         rc = handle_state_update_task(op, port, fvp_dict, y_cable_presence, port_tbl, port_tbl_keys, loopback_tbl, loopback_keys, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, y_cable_tbl, static_tbl, mux_tbl, grpc_client, fwd_state_response_tbl, state_db, stopping_event)
         assert(rc == None)
 
+    def test_handle_state_update_task_ignores_update_for_initialized_simulator(self):
+        fvp_dict = {
+            'type': 'QSFP-DD',
+            'manufacturer': 'microsoft',
+            'active_apsel_hostlane1': '1',
+            'host_lane_count': '8',
+            'media_lane_count': '4',
+        }
+
+        with patch(
+                'ycable.ycable_utilities.y_cable_helper.is_initialized_simulated_y_cable',
+                return_value=True), patch(
+                'ycable.ycable_utilities.y_cable_helper.change_ports_status_for_y_cable_change_event') as change_status:
+            handle_state_update_task(
+                swsscommon.SET_COMMAND, "Ethernet0", fvp_dict, False,
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, None)
+
+        change_status.assert_not_called()
+
+    def test_handle_state_update_task_processes_update_for_uninitialized_simulator(self):
+        fvp_dict = {
+            'type': 'QSFP-DD',
+            'manufacturer': 'microsoft',
+            'active_apsel_hostlane1': '1',
+        }
+
+        with patch(
+                'ycable.ycable_utilities.y_cable_helper.is_initialized_simulated_y_cable',
+                return_value=False), patch(
+                'ycable.ycable_utilities.y_cable_helper.change_ports_status_for_y_cable_change_event') as change_status:
+            handle_state_update_task(
+                swsscommon.SET_COMMAND, "Ethernet0", fvp_dict, False,
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, None)
+
+        change_status.assert_called_once()
+
+    def test_handle_state_update_task_retries_cmis_update_after_failed_simulator_init(self):
+        fvp_dict = {'active_apsel_hostlane1': '1'}
+
+        with patch(
+                'ycable.ycable_utilities.y_cable_helper.is_initialized_simulated_y_cable',
+                return_value=False), patch(
+                'ycable.ycable_utilities.y_cable_helper.change_ports_status_for_y_cable_change_event') as change_status:
+            handle_state_update_task(
+                swsscommon.SET_COMMAND, "Ethernet0", fvp_dict, False,
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, None)
+
+        change_status.assert_called_once()
+
 
     @patch('ycable.ycable_utilities.y_cable_helper.change_ports_status_for_y_cable_change_event', MagicMock(return_value=0))
     def test_handle_state_update_task_with_delete(self):
@@ -482,4 +531,3 @@ class TestYcableActiveActiveHelper(object):
         rc = check_presence_for_active_active_cable_type(y_cable_tbl)
 
         assert(rc == True)
-

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -108,6 +108,10 @@ def handle_state_update_task(op, port, fvp_dict, y_cable_presence, port_tbl, por
 
     port_dict = {}
     if op == swsscommon.SET_COMMAND:
+        if y_cable_helper.is_initialized_simulated_y_cable(port):
+            helper_logger.log_debug(
+                "Ignoring transceiver info update for initialized simulated Y-cable port {}".format(port))
+            return
         port_dict[port] = SFP_STATUS_INSERTED
     elif op == swsscommon.DEL_COMMAND:
         port_dict[port] = SFP_STATUS_REMOVED

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -85,6 +85,8 @@ helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 SFP_STATUS_REMOVED = '0'
 SFP_STATUS_INSERTED = '1'
 
+MUX_SIMULATOR_CONFIG_FILE = "/etc/sonic/mux_simulator.json"
+
 # SFP error codes, stored as strings. Can add more as needed.
 SFP_STATUS_ERR_I2C_STUCK = '2'
 SFP_STATUS_ERR_BAD_EEPROM = '3'
@@ -273,6 +275,24 @@ def get_ycable_port_instance_from_logical_port(logical_port_name):
         helper_logger.log_warning(
             "Error: Retreived multiple ports for a Y cable table port {} while trying to toggle the mux".format(logical_port_name))
         return -1
+
+
+def is_initialized_simulated_y_cable(logical_port_name):
+    """Return True when a simulated Y-cable instance is ready for the port.
+
+    Failed or incomplete initialization must return False so a later SET can
+    retry normal discovery after the simulator configuration becomes available.
+    """
+    if not os.path.exists(MUX_SIMULATOR_CONFIG_FILE):
+        return False
+
+    physical_port_list = logical_port_name_to_physical_port_list(logical_port_name)
+    if len(physical_port_list) != 1:
+        return False
+
+    port_instance = y_cable_port_instances.get(physical_port_list[0])
+    return port_instance is not None and getattr(port_instance, '_initialized', False) is True
+
 
 def set_show_firmware_fields(port, mux_info_dict, xcvrd_show_fw_rsp_tbl):
     fvs = swsscommon.FieldValuePairs(


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

#### Description
TRANSCEIVER_INFO SET notifications contain the complete table row and are
 generated for both transceiver insertion and CMIS maintenance updates. After
a simulated Y-cable is initialized, treating every SET as an insertion causes
 ycabled to reread the simulator direction and publish stale HW MUX state.

Ignore SET notifications only when the simulator configuration exists and the
port already has a fully initialized simulated Y-cable instance. Continue to
 process initial discovery, failed-initialization retries, and DEL notifications.

Add unit tests for initialized, missing, incomplete, and unconfigured simulator
instances and for the corresponding state-update behavior.

#### Motivation and Context
### Problem

xcvrd publishes `TRANSCEIVER_INFO` `SET` notifications for CMIS maintenance updates during downlink admin-down. ycabled treats every `SET` as an SFP insertion. For an active-standby simulated Y-cable this rereads the simulator MUX direction and updates `STATE_HW_MUX_CABLE` with a direction that may lag linkmgrd's requested state. The stale update can cause active/standby MUX ping-pong and exceed the dual-ToR traffic disruption budget.

### Root cause

`SubscriberStateTable` returns the complete current table row for a `SET`, not only the changed fields. Consequently, filtering the event based on the fields present in the returned dictionary cannot reliably distinguish insertion from a CMIS-only update.

### Fix

For simulator-backed ports, treat a `SET` as an insertion only until the simulated Y-cable driver is fully initialized. Once the driver instance exists and `_initialized` is `True`, ignore subsequent `TRANSCEIVER_INFO` `SET` notifications.

The guard is deliberately limited to the MUX simulator by requiring `/etc/sonic/mux_simulator.json`. Physical Y-cable behavior remains unchanged. `DEL` notifications remain unchanged and remove the saved driver instance, so a later insertion can initialize again. Missing or partially initialized instances return `False`, allowing later notifications to retry initialization.

#### How Has This Been Tested?
- Initialized simulator suppresses repeated `SET` processing.
- Missing simulator instance permits initial discovery.
- Incomplete simulator instance permits retry.
- Missing simulator configuration preserves existing behavior.
- Removal processing remains unchanged through the existing `DEL` test.

The ycabled wheel build automatically ran the complete component test suite inside the SONiC build container:

```text
platform linux -- Python 3.13.5, pytest-8.3.5
collected 280 items
280 passed, 144 warnings in 6.75s
```

New tests recorded as passing:

```text
tests/test_y_cable_helper.py::TestYCableScript::test_is_initialized_simulated_y_cable PASSED
tests/test_y_cable_helper.py::TestYCableScript::test_is_initialized_simulated_y_cable_without_instance PASSED
tests/test_y_cable_helper.py::TestYCableScript::test_is_initialized_simulated_y_cable_incomplete_instance PASSED
tests/test_y_cable_helper.py::TestYCableScript::test_is_initialized_simulated_y_cable_without_config PASSED
tests/test_ycable.py::TestYcableScript::test_handle_state_update_task_ignores_update_for_initialized_simulator PASSED
tests/test_ycable.py::TestYcableScript::test_handle_state_update_task_processes_update_for_uninitialized_simulator PASSED
tests/test_ycable.py::TestYcableScript::test_handle_state_update_task_retries_cmis_update_after_failed_simulator_init PASSED

#### Additional Information (Optional)
