### PR TITLE
[CPO] Add CpoStateUpdateTask

### DIFF
--- a/sonic-xcvrd/tests/test_cpo.py
+++ b/sonic-xcvrd/tests/test_cpo.py
@@ -1,9 +1,19 @@
 import contextlib
+import threading
 
+import pytest
 from unittest.mock import MagicMock, patch
 
-from sonic_py_common import device_info
+from sonic_py_common import daemon_base, device_info
+from swsscommon import swsscommon
+from xcvrd.cpo import cpo_state_task
+from xcvrd.cpo.cpo_state_task import CpoStateUpdateTask
+from xcvrd.cpo.db_utils import CPODOMDBUtils, CPOVDMDBUtils
+from xcvrd.xcvrd import PHYSICAL_PORT_NOT_EXIST, SFP_EEPROM_NOT_READY
 from xcvrd.xcvrd_utilities import common
+from xcvrd.xcvrd_utilities.port_event_helper import PortChangeEvent, PortMapping
+
+DEFAULT_NAMESPACE = ['']
 
 
 class TestPortDeviceResolver:
@@ -176,3 +186,196 @@ class TestCpoTopology:
             assert common.get_oe_sibling_pports(1) == {1}
             assert common.get_elsfp_sibling_pports(1) == {1}
 
+
+class TestCpoStateUpdateTask:
+    OE_INFO = {'manufacturer': 'FAKE_MANUFACTURER', 'model': 'FAKE_MODEL', 'host_lane_count': 8}
+    ELSFP_INFO = {'type': 'OIF-ELSP', 'serial': 'SN0123456789', 'max_optical_power': 10.0}
+
+    @contextlib.contextmanager
+    def mocked_db_tables(self):
+        def new_table(*args, **kwargs):
+            return MagicMock()
+
+        with patch.object(daemon_base, 'db_connect', MagicMock()), \
+             patch.object(swsscommon, 'Table', MagicMock(side_effect=new_table)), \
+             patch.object(swsscommon, 'ProducerStateTable', MagicMock(side_effect=new_table)):
+            yield
+
+    def make_port_mapping(self, logical_port='Ethernet0', physical_port=1, asic_id=0):
+        port_mapping = PortMapping()
+        port_mapping.handle_port_change_event(
+            PortChangeEvent(logical_port, physical_port, asic_id, PortChangeEvent.PORT_ADD))
+        return port_mapping
+
+    def make_task(self, port_mapping=None, port_obj_dict=None):
+        with self.mocked_db_tables():
+            return CpoStateUpdateTask(DEFAULT_NAMESPACE,
+                                      self.make_port_mapping() if port_mapping is None else port_mapping,
+                                      {} if port_obj_dict is None else port_obj_dict,
+                                      threading.Event(), threading.Event())
+
+    def make_cpo_device(self, oe_info=None, elsfp_info=None, is_replaceable=True):
+        device = MagicMock()
+        device.oe.get_api.return_value.get_transceiver_info.return_value = oe_info
+        device.elsfp.get_api.return_value.get_elsfp_info.return_value = elsfp_info
+        device.is_replaceable.return_value = is_replaceable
+        return device
+
+    def published_info(self, info, is_replaceable):
+        """The field/value pairs the task is expected to publish for the given info dict."""
+        published = {field: str(value) for field, value in info.items()}
+        published['is_replaceable'] = str(is_replaceable)
+        return published
+
+    def test_get_port_change_event_reads_elsfp_events(self):
+        task = self.make_task()
+        chassis = MagicMock()
+        chassis.get_elsfp_change_event.return_value = (True, {'elsfp': {'1': '1'},
+                                                              'elsfp_error': {'2': '4'}})
+        with patch.object(cpo_state_task, 'platform_chassis', chassis):
+            status, events, errors = task._get_port_change_event(1000)
+        chassis.get_elsfp_change_event.assert_called_once_with(1000)
+        assert (status, events, errors) == (True, {'1': '1'}, {'2': '4'})
+
+    def test_get_port_change_event_without_events(self):
+        task = self.make_task()
+        chassis = MagicMock()
+        chassis.get_elsfp_change_event.return_value = (False, {'elsfp': {}})
+        with patch.object(cpo_state_task, 'platform_chassis', chassis):
+            assert task._get_port_change_event(0) == (False, {}, None)
+
+    def test_get_port_error_description(self):
+        task = self.make_task()
+        device = MagicMock()
+        device.oe.get_api.return_value.get_error_description.return_value = 'Blocking Error|High Temp'
+        with patch.object(common, 'get_port_device', return_value=device) as mock_get_port_device:
+            assert task._get_port_error_description(1) == 'Blocking Error|High Temp'
+        mock_get_port_device.assert_called_once_with(1)
+
+    @pytest.mark.parametrize('is_replaceable', [True, False])
+    def test_wrapper_is_replaceable(self, is_replaceable):
+        task = self.make_task()
+        device = self.make_cpo_device(is_replaceable=is_replaceable)
+        with patch.object(common, 'get_port_device', return_value=device):
+            assert task._wrapper_is_replaceable(1) is is_replaceable
+        device.is_replaceable.assert_called_once_with()
+
+    def test_post_port_info_to_db(self):
+        port_mapping = self.make_port_mapping()
+        task = self.make_task(port_mapping)
+        device = self.make_cpo_device(self.OE_INFO, self.ELSFP_INFO, is_replaceable=True)
+        intf_tbl = MagicMock()
+        transceiver_dict = {}
+
+        with patch.object(common, '_wrapper_get_presence', return_value=True), \
+             patch.object(common, 'get_port_device', return_value=device):
+            assert task.post_port_info_to_db('Ethernet0', port_mapping, intf_tbl, transceiver_dict) is None
+
+        # The OE goes to the caller-supplied table, and is never reported as replaceable
+        intf_tbl.set.assert_called_once()
+        port_name, fvs = intf_tbl.set.call_args.args
+        assert port_name == 'Ethernet0'
+        assert dict(fvs) == self.published_info(self.OE_INFO, False)
+
+        # The ELSFP goes to the ELS info table of the port's asic, with its real replaceability
+        els_tbl = task.xcvr_table_helper.get_els_info_tbl(0)
+        els_tbl.set.assert_called_once()
+        port_name, fvs = els_tbl.set.call_args.args
+        assert port_name == 'Ethernet0'
+        assert dict(fvs) == self.published_info(self.ELSFP_INFO, True)
+
+        # The freshly read OE info is cached for the caller's next logical port
+        assert transceiver_dict == {1: self.OE_INFO}
+
+    def test_cached_oe_info_is_reused(self):
+        port_mapping = self.make_port_mapping()
+        task = self.make_task(port_mapping)
+        device = self.make_cpo_device(self.OE_INFO, self.ELSFP_INFO)
+        cached_oe_info = {'model': 'FAKE_CACHED_MODEL'}
+        intf_tbl = MagicMock()
+
+        with patch.object(common, '_wrapper_get_presence', return_value=True), \
+             patch.object(common, 'get_port_device', return_value=device):
+            task.post_port_info_to_db('Ethernet0', port_mapping, intf_tbl, {1: cached_oe_info})
+
+        device.oe.get_api.return_value.get_transceiver_info.assert_not_called()
+        assert dict(intf_tbl.set.call_args.args[1]) == self.published_info(cached_oe_info, False)
+
+    def test_no_physical_port(self):
+        port_mapping = self.make_port_mapping()
+        port_mapping.logical_port_name_to_physical_port_list = MagicMock(return_value=None)
+        task = self.make_task(port_mapping)
+        intf_tbl = MagicMock()
+
+        assert task.post_port_info_to_db('Ethernet0', port_mapping, intf_tbl, {}) == PHYSICAL_PORT_NOT_EXIST
+        intf_tbl.set.assert_not_called()
+
+    def test_ganged_ports_are_rejected(self):
+        port_mapping = self.make_port_mapping()
+        port_mapping.logical_port_name_to_physical_port_list = MagicMock(return_value=[1, 2])
+        task = self.make_task(port_mapping)
+
+        with pytest.raises(AssertionError, match='Ganged ports are not yet supported'):
+            task.post_port_info_to_db('Ethernet0', port_mapping, MagicMock(), {})
+
+    def test_non_present_elsfp_is_skipped(self):
+        port_mapping = self.make_port_mapping()
+        task = self.make_task(port_mapping)
+        intf_tbl = MagicMock()
+        transceiver_dict = {}
+
+        with patch.object(common, '_wrapper_get_presence', return_value=False) as mock_get_presence, \
+             patch.object(common, 'get_port_device') as mock_get_port_device:
+            assert task.post_port_info_to_db('Ethernet0', port_mapping, intf_tbl, transceiver_dict) is None
+
+        mock_get_presence.assert_called_once_with(1)
+        mock_get_port_device.assert_not_called()
+        intf_tbl.set.assert_not_called()
+        task.xcvr_table_helper.get_els_info_tbl(0).set.assert_not_called()
+        assert transceiver_dict == {}
+
+    def test_post_port_info_set_stop_event_publishes_nothing(self):
+        port_mapping = self.make_port_mapping()
+        task = self.make_task(port_mapping)
+        intf_tbl = MagicMock()
+        stop_event = threading.Event()
+        stop_event.set()
+
+        with patch.object(common, '_wrapper_get_presence') as mock_get_presence:
+            assert task.post_port_info_to_db('Ethernet0', port_mapping, intf_tbl, {}, stop_event) is None
+
+        mock_get_presence.assert_not_called()
+        intf_tbl.set.assert_not_called()
+
+    @pytest.mark.parametrize('oe_info, elsfp_info', [
+        (None, ELSFP_INFO),
+        (OE_INFO, None),
+        (None, None),
+    ])
+    def test_post_port_info_unreadable_eeprom(self, oe_info, elsfp_info):
+        port_mapping = self.make_port_mapping()
+        task = self.make_task(port_mapping)
+        device = self.make_cpo_device(oe_info, elsfp_info)
+        intf_tbl = MagicMock()
+
+        with patch.object(common, '_wrapper_get_presence', return_value=True), \
+             patch.object(common, 'get_port_device', return_value=device):
+            assert task.post_port_info_to_db('Ethernet0', port_mapping,
+                                             intf_tbl, {}) == SFP_EEPROM_NOT_READY
+
+        intf_tbl.set.assert_not_called()
+        task.xcvr_table_helper.get_els_info_tbl(0).set.assert_not_called()
+
+    def test_post_port_thresholds_to_db(self):
+        task = self.make_task()
+        task.dom_db_utils = MagicMock()
+        task.vdm_db_utils = MagicMock()
+        dom_db_cache = {1: {'temperature': '30.0'}}
+        vdm_db_cache = {1: {'laser_temperature': '40.0'}}
+
+        task.post_port_thresholds_to_db('Ethernet0', dom_db_cache=dom_db_cache, vdm_db_cache=vdm_db_cache)
+
+        task.dom_db_utils.post_port_dom_thresholds_to_db.assert_called_once_with(
+            'Ethernet0', db_cache=dom_db_cache)
+        task.vdm_db_utils.post_port_vdm_thresholds_to_db.assert_called_once_with(
+            'Ethernet0', db_cache=vdm_db_cache)

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -5911,8 +5911,8 @@ class TestXcvrdScript(object):
         mock_post_sfp_info.assert_called_with('Ethernet0', task.port_mapping, int_tbl, {})
         assert task.dom_db_utils.post_port_dom_thresholds_to_db.call_count == 1
         assert task.vdm_db_utils.post_port_vdm_thresholds_to_db.call_count == 1
-        task.dom_db_utils.post_port_dom_thresholds_to_db.assert_called_with('Ethernet0')
-        task.vdm_db_utils.post_port_vdm_thresholds_to_db.assert_called_with('Ethernet0')
+        task.dom_db_utils.post_port_dom_thresholds_to_db.assert_called_with('Ethernet0', db_cache=None)
+        task.vdm_db_utils.post_port_vdm_thresholds_to_db.assert_called_with('Ethernet0', db_cache=None)
         assert mock_update_media_setting.call_count == 1
         assert 'Ethernet0' not in task.retry_eeprom_set
 

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -6649,6 +6649,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd_utilities.port_event_helper.subscribe_port_config_change', MagicMock(return_value=(None, None)))
     @patch('xcvrd.xcvrd_utilities.port_event_helper.handle_port_config_change', MagicMock())
     @patch('xcvrd.xcvrd.SfpStateUpdateTask.init', MagicMock())
+    @patch('xcvrd.xcvrd_utilities.common.get_port_device')
     @patch('os.kill')
     @patch('xcvrd.xcvrd.SfpStateUpdateTask._mapping_event_from_change_event')
     @patch('xcvrd.xcvrd.SfpStateUpdateTask._get_port_change_event')
@@ -6657,14 +6658,14 @@ class TestXcvrdScript(object):
     @patch('xcvrd.dom.dom_mgr.DomInfoUpdateTask.post_port_sfp_firmware_info_to_db')
     @patch('xcvrd.xcvrd.SfpStateUpdateTask.post_port_info_to_db')
     @patch('xcvrd.xcvrd_utilities.common.update_port_transceiver_status_table_sw')
-    @patch('xcvrd.xcvrd.platform_chassis')
-    def test_sfp_removal_from_dict(self, mock_platform_chassis, mock_update_status, mock_post_sfp_info,
+    def test_sfp_removal_from_dict(self, mock_update_status, mock_post_sfp_info,
                                             mock_post_firmware_info, mock_update_media_setting,
-                                            mock_del_dom, mock_change_event, mock_mapping_event, mock_os_kill):
+                                            mock_del_dom, mock_change_event, mock_mapping_event, mock_os_kill,
+                                            mock_get_port_device):
         port_mapping = PortMapping()
         mock_sfp = MagicMock()
         mock_sfp.remove_xcvr_api = MagicMock(return_value=None)
-        mock_platform_chassis.get_sfp.return_value = mock_sfp
+        mock_get_port_device.return_value = mock_sfp
         mock_sfp_obj_dict = MagicMock()
         stop_event = threading.Event()
         sfp_error_event = threading.Event()

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1466,23 +1466,29 @@ class TestXcvrdScript(object):
                                                                                 'supported_min_tx_power': -15.0,
                                                                                 'supported_max_laser_freq': 196100,
                                                                                 'supported_min_laser_freq': 191300}))
-    def test_post_port_sfp_info_to_db(self):
+    def test_post_port_info_to_db(self):
         logical_port_name = "Ethernet0"
         port_mapping = PortMapping()
+        mock_sfp_obj_dict = MagicMock()
         stop_event = threading.Event()
+        sfp_error_event = threading.Event()
         dom_tbl = Table("STATE_DB", TRANSCEIVER_DOM_SENSOR_TABLE)
         transceiver_dict = {}
-        post_port_sfp_info_to_db(logical_port_name, port_mapping, dom_tbl, transceiver_dict, stop_event)
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, mock_sfp_obj_dict, stop_event, sfp_error_event)
+        task.post_port_info_to_db(logical_port_name, port_mapping, dom_tbl, transceiver_dict, stop_event)
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=False))
-    def test_post_port_sfp_info_to_db_with_sfp_not_present(self):
+    def test_post_port_info_to_db_with_sfp_not_present(self):
         logical_port_name = "Ethernet0"
         port_mapping = PortMapping()
+        mock_sfp_obj_dict = MagicMock()
         stop_event = threading.Event()
+        sfp_error_event = threading.Event()
         intf_tbl = Table("STATE_DB", TRANSCEIVER_INFO_TABLE)
         transceiver_dict = {}
-        post_port_sfp_info_to_db(logical_port_name, port_mapping, intf_tbl , transceiver_dict, stop_event)
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, mock_sfp_obj_dict, stop_event, sfp_error_event)
+        task.post_port_info_to_db(logical_port_name, port_mapping, intf_tbl , transceiver_dict, stop_event)
         assert common._wrapper_get_presence.call_count == 1
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -5645,7 +5651,7 @@ class TestXcvrdScript(object):
             assert wait_until(5, 1, lambda: task.is_alive() is False)
 
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
-    @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')
+    @patch('xcvrd.xcvrd.SfpStateUpdateTask.post_port_info_to_db')
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_cfg_port_tbl', MagicMock())
     def test_SfpStateUpdateTask_retry_eeprom_reading(self, mock_post_sfp_info):
         mock_table = MagicMock()
@@ -5742,7 +5748,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd_utilities.common.del_port_sfp_dom_info_from_db')
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.notify_media_setting')
     @patch('xcvrd.dom.dom_mgr.DomInfoUpdateTask.post_port_sfp_firmware_info_to_db')
-    @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')
+    @patch('xcvrd.xcvrd.SfpStateUpdateTask.post_port_info_to_db')
     @patch('xcvrd.xcvrd_utilities.common.update_port_transceiver_status_table_sw')
     def test_SfpStateUpdateTask_task_worker(self, mock_update_status, mock_post_sfp_info,
                                             mock_post_firmware_info, mock_update_media_setting,
@@ -5840,7 +5846,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.XcvrTableHelper')
     @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence')
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.notify_media_setting')
-    @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')
+    @patch('xcvrd.xcvrd.SfpStateUpdateTask.post_port_info_to_db')
     @patch('xcvrd.xcvrd_utilities.common.update_port_transceiver_status_table_sw')
     def test_SfpStateUpdateTask_on_add_logical_port(self, mock_update_status, mock_post_sfp_info,
             mock_update_media_setting, mock_get_presence, mock_table_helper):
@@ -6641,7 +6647,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd_utilities.common.del_port_sfp_dom_info_from_db')
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.notify_media_setting')
     @patch('xcvrd.dom.dom_mgr.DomInfoUpdateTask.post_port_sfp_firmware_info_to_db')
-    @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')
+    @patch('xcvrd.xcvrd.SfpStateUpdateTask.post_port_info_to_db')
     @patch('xcvrd.xcvrd_utilities.common.update_port_transceiver_status_table_sw')
     @patch('xcvrd.xcvrd.platform_chassis')
     def test_sfp_removal_from_dict(self, mock_platform_chassis, mock_update_status, mock_post_sfp_info,

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1424,7 +1424,7 @@ class TestXcvrdScript(object):
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
-    @patch('xcvrd.xcvrd._wrapper_is_replaceable', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd.SfpStateUpdateTask._wrapper_is_replaceable', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd._wrapper_get_transceiver_info', MagicMock(return_value={'type': '22.75',
                                                                                 'vendor_rev': '0.5',
                                                                                 'serial': '0.7',
@@ -1494,7 +1494,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd.platform_sfputil', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
-    @patch('xcvrd.xcvrd._wrapper_is_replaceable', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd.SfpStateUpdateTask._wrapper_is_replaceable', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     @patch('xcvrd.xcvrd._wrapper_get_transceiver_info', MagicMock(return_value={'type': '22.75',
                                                                                 'vendor_rev': '0.5',
@@ -1529,7 +1529,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd.platform_sfputil', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
-    @patch('xcvrd.xcvrd._wrapper_is_replaceable', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd.SfpStateUpdateTask._wrapper_is_replaceable', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     def test_init_port_sfp_status_sw_tbl(self):
         port_mapping = PortMapping()
@@ -5979,17 +5979,18 @@ class TestXcvrdScript(object):
 
     @patch('xcvrd.xcvrd.platform_chassis')
     def test_wrapper_is_replaceable(self, mock_chassis):
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, PortMapping(), MagicMock(),
+                                  threading.Event(), threading.Event())
         mock_object = MagicMock()
         mock_object.is_replaceable = MagicMock(return_value=True)
         mock_chassis.get_sfp = MagicMock(return_value=mock_object)
-        from xcvrd.xcvrd import _wrapper_is_replaceable
-        assert _wrapper_is_replaceable(1)
+        assert task._wrapper_is_replaceable(1)
 
         mock_object.is_replaceable = MagicMock(return_value=False)
-        assert not _wrapper_is_replaceable(1)
+        assert not task._wrapper_is_replaceable(1)
 
         mock_chassis.get_sfp = MagicMock(side_effect=NotImplementedError)
-        assert not _wrapper_is_replaceable(1)
+        assert not task._wrapper_is_replaceable(1)
 
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd.platform_sfputil')

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -6257,15 +6257,20 @@ class TestXcvrdScript(object):
         assert not _wrapper_get_sfp_type(1)
 
     @patch('xcvrd.xcvrd.platform_chassis')
-    def test_wrapper_get_sfp_error_description(self, mock_chassis):
+    def test_get_port_error_description(self, mock_chassis):
+        port_mapping = PortMapping()
+        mock_sfp_obj_dict = MagicMock()
+        stop_event = threading.Event()
+        sfp_error_event = threading.Event()
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, mock_sfp_obj_dict, stop_event, sfp_error_event)
+
         mock_object = MagicMock()
         mock_object.get_error_description = MagicMock(return_value='N/A')
         mock_chassis.get_sfp = MagicMock(return_value=mock_object)
-        from xcvrd.xcvrd import _wrapper_get_sfp_error_description
-        assert _wrapper_get_sfp_error_description(1) == 'N/A'
+        assert task._get_port_error_description(1) == 'N/A'
 
         mock_chassis.get_sfp = MagicMock(side_effect=NotImplementedError)
-        assert not _wrapper_get_sfp_error_description(1)
+        assert not task._get_port_error_description(1)
 
     @patch('xcvrd.xcvrd_utilities.common.platform_chassis')
     def test_wrapper_is_flat_memory(self, mock_chassis):

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -5744,7 +5744,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.SfpStateUpdateTask.init', MagicMock())
     @patch('os.kill')
     @patch('xcvrd.xcvrd.SfpStateUpdateTask._mapping_event_from_change_event')
-    @patch('xcvrd.xcvrd._wrapper_get_transceiver_change_event')
+    @patch('xcvrd.xcvrd.SfpStateUpdateTask._get_port_change_event')
     @patch('xcvrd.xcvrd_utilities.common.del_port_sfp_dom_info_from_db')
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.notify_media_setting')
     @patch('xcvrd.dom.dom_mgr.DomInfoUpdateTask.post_port_sfp_firmware_info_to_db')
@@ -6235,15 +6235,17 @@ class TestXcvrdScript(object):
 
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd.platform_sfputil')
-    def test_wrapper_get_transceiver_change_event(self, mock_sfputil, mock_chassis):
+    def test_get_port_change_event(self, mock_sfputil, mock_chassis):
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, PortMapping(), MagicMock(),
+                                  threading.Event(), threading.Event())
+
         mock_chassis.get_change_event = MagicMock(return_value=(True, {'sfp': 1, 'sfp_error': 'N/A'}))
-        from xcvrd.xcvrd import _wrapper_get_transceiver_change_event
-        assert _wrapper_get_transceiver_change_event(0) == (True, 1, 'N/A')
+        assert task._get_port_change_event(0) == (True, 1, 'N/A')
 
         mock_chassis.get_change_event = MagicMock(side_effect=NotImplementedError)
         mock_sfputil.get_transceiver_change_event = MagicMock(return_value=(True, 1))
 
-        assert _wrapper_get_transceiver_change_event(0) == (True, 1, None)
+        assert task._get_port_change_event(0) == (True, 1, None)
 
     @patch('xcvrd.xcvrd.platform_chassis')
     def test_wrapper_get_sfp_type(self, mock_chassis):
@@ -6648,7 +6650,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.SfpStateUpdateTask.init', MagicMock())
     @patch('os.kill')
     @patch('xcvrd.xcvrd.SfpStateUpdateTask._mapping_event_from_change_event')
-    @patch('xcvrd.xcvrd._wrapper_get_transceiver_change_event')
+    @patch('xcvrd.xcvrd.SfpStateUpdateTask._get_port_change_event')
     @patch('xcvrd.xcvrd_utilities.common.del_port_sfp_dom_info_from_db')
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.notify_media_setting')
     @patch('xcvrd.dom.dom_mgr.DomInfoUpdateTask.post_port_sfp_firmware_info_to_db')

--- a/sonic-xcvrd/xcvrd/cpo/cpo_state_task.py
+++ b/sonic-xcvrd/xcvrd/cpo/cpo_state_task.py
@@ -7,6 +7,7 @@ try:
     from ..xcvrd import (SfpStateUpdateTask, helper_logger,
                          PHYSICAL_PORT_NOT_EXIST, SFP_EEPROM_NOT_READY)
     from ..xcvrd_utilities import common
+    from ..xcvrd_utilities.xcvr_table_helper import VDM_THRESHOLD_TYPES
     from .db_utils import CPODOMDBUtils, CPOVDMDBUtils
 except ImportError as e:
     raise ImportError(str(e) + " - required module not found")
@@ -90,3 +91,17 @@ class CpoStateUpdateTask(SfpStateUpdateTask):
     def post_port_thresholds_to_db(self, logical_port_name, dom_db_cache=None, vdm_db_cache=None):
         self.dom_db_utils.post_port_dom_thresholds_to_db(logical_port_name, db_cache=dom_db_cache)
         self.vdm_db_utils.post_port_vdm_thresholds_to_db(logical_port_name, db_cache=vdm_db_cache)
+
+    def delete_port_data_from_db(self, logical_port_name, asic_index,
+                                 delete_intf_tbl=False, delete_status_sw_tbl=False):
+        super().delete_port_data_from_db(logical_port_name, asic_index,
+                                         delete_intf_tbl=delete_intf_tbl,
+                                         delete_status_sw_tbl=delete_status_sw_tbl)
+
+        tbl_to_del_list = [
+            self.xcvr_table_helper.get_els_dom_threshold_tbl(asic_index),
+            *[self.xcvr_table_helper.get_els_vdm_threshold_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
+        ]
+        if delete_intf_tbl:
+            tbl_to_del_list.append(self.xcvr_table_helper.get_els_info_tbl(asic_index))
+        common.del_port_sfp_dom_info_from_db(logical_port_name, self.port_mapping, tbl_to_del_list)

--- a/sonic-xcvrd/xcvrd/cpo/cpo_state_task.py
+++ b/sonic-xcvrd/xcvrd/cpo/cpo_state_task.py
@@ -1,12 +1,92 @@
 #!/usr/bin/env python3
 
+import threading
+
 try:
-    from ..xcvrd import SfpStateUpdateTask
+    from swsscommon import swsscommon
+    from ..xcvrd import (SfpStateUpdateTask, helper_logger,
+                         PHYSICAL_PORT_NOT_EXIST, SFP_EEPROM_NOT_READY)
+    from ..xcvrd_utilities import common
+    from .db_utils import CPODOMDBUtils, CPOVDMDBUtils
 except ImportError as e:
     raise ImportError(str(e) + " - required module not found")
+
+platform_chassis = None
 
 
 class CpoStateUpdateTask(SfpStateUpdateTask):
     def __init__(self, namespaces, port_mapping, port_obj_dict, main_thread_stop_event, sfp_error_event):
         super().__init__(namespaces, port_mapping, port_obj_dict, main_thread_stop_event, sfp_error_event)
         self.name = "CpoStateUpdateTask"
+        # Replace the pluggable-transceiver DB utils installed by the base class with the CPO ones
+        self.dom_db_utils = CPODOMDBUtils(port_obj_dict, self.port_mapping, self.xcvr_table_helper,
+                                          self.task_stopping_event, self.logger)
+        self.vdm_db_utils = CPOVDMDBUtils(port_obj_dict, self.port_mapping, self.xcvr_table_helper,
+                                          self.task_stopping_event, self.logger)
+
+    def _get_port_change_event(self, timeout):
+        status, events = platform_chassis.get_elsfp_change_event(timeout)
+        elsfp_events = events.get('elsfp')
+        elsfp_errors = events.get('elsfp_error')
+        return status, elsfp_events, elsfp_errors
+
+    def _get_port_error_description(self, physical_port):
+        port_device = common.get_port_device(physical_port)
+        oe_api = port_device.oe.get_api()
+        return oe_api.get_error_description()
+
+    def _wrapper_is_replaceable(self, physical_port):
+        port_device = common.get_port_device(physical_port)
+        return port_device.is_replaceable()
+
+    def post_port_info_to_db(self, logical_port_name, port_mapping, table, transceiver_dict,
+                             stop_event=threading.Event()):
+        physical_port_list = port_mapping.logical_port_name_to_physical_port_list(logical_port_name)
+        if physical_port_list is None:
+            helper_logger.log_error("No physical ports found for logical port '{}'".format(logical_port_name))
+            return PHYSICAL_PORT_NOT_EXIST
+
+        assert len(physical_port_list) == 1, "Ganged ports are not yet supported on CPO"
+
+        for physical_port in physical_port_list:
+            if stop_event.is_set():
+                break
+
+            if not common._wrapper_get_presence(physical_port):
+                helper_logger.log_notice("Transceiver not present in port {}".format(logical_port_name))
+                continue
+
+            port_name = common.get_physical_port_name(logical_port_name, physical_port, False)
+
+            port_device = common.get_port_device(physical_port)
+            if physical_port in transceiver_dict:
+                oe_info = transceiver_dict[physical_port]
+            else:
+                oe_info = port_device.oe.get_api().get_transceiver_info()
+                transceiver_dict[physical_port] = oe_info
+            elsfp_info = port_device.elsfp.get_api().get_elsfp_info()
+
+            if oe_info is None or elsfp_info is None:
+                return SFP_EEPROM_NOT_READY
+
+            # Publish OE info
+            fvs = swsscommon.FieldValuePairs(
+                [(field, str(value)) for field, value in oe_info.items()] +
+                [('is_replaceable', str(False))]
+            )
+            table.set(port_name, fvs)
+
+            # Publish ELSFP info
+            is_replaceable = self._wrapper_is_replaceable(physical_port)
+            asic_index = port_mapping.get_asic_id_for_logical_port(logical_port_name)
+            els_tbl = self.xcvr_table_helper.get_els_info_tbl(asic_index)
+            fvs = swsscommon.FieldValuePairs(
+                [(field, str(value)) for field, value in elsfp_info.items()] +
+                [('is_replaceable', str(is_replaceable))]
+            )
+            els_tbl.set(port_name, fvs)
+
+
+    def post_port_thresholds_to_db(self, logical_port_name, dom_db_cache=None, vdm_db_cache=None):
+        self.dom_db_utils.post_port_dom_thresholds_to_db(logical_port_name, db_cache=dom_db_cache)
+        self.vdm_db_utils.post_port_vdm_thresholds_to_db(logical_port_name, db_cache=vdm_db_cache)

--- a/sonic-xcvrd/xcvrd/cpo/db_utils.py
+++ b/sonic-xcvrd/xcvrd/cpo/db_utils.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+try:
+    from ..dom.utilities.db.utils import DBUtils
+    from ..dom.utilities.dom_sensor.beautify import DOMBeautifyMixin
+except ImportError as e:
+    raise ImportError(str(e) + " - required module not found")
+
+
+class CPODOMDBUtils(DOMBeautifyMixin, DBUtils):
+    """
+    This class provides utility functions for managing DB operations
+    related to DOM on CPO (co-packaged optics) modules.
+    """
+
+    def __init__(self, port_obj_dict, port_mapping, xcvr_table_helper, task_stopping_event, logger):
+        super().__init__(port_obj_dict, port_mapping, task_stopping_event, logger)
+        self.xcvr_table_helper = xcvr_table_helper
+        self.logger = logger
+
+    def post_port_dom_thresholds_to_db(self, logical_port_name, db_cache=None):
+        asic_index = self.port_mapping.get_asic_id_for_logical_port(logical_port_name)
+        if asic_index is None:
+            self.logger.log_error(f"CPO: Post port dom thresholds to db failed for {logical_port_name} "
+                                  "as no asic index found")
+            return
+
+        physical_port = self._validate_and_get_physical_port(logical_port_name)
+        if physical_port is None:
+            return
+
+        # Read OE thresholds and publish to DB
+        oe_dom_thresholds = self.port_obj_dict[physical_port].oe.get_api().get_transceiver_threshold_info()
+        self.post_diagnostic_values_from_dict_to_db(logical_port_name,
+                                                    self.xcvr_table_helper.get_dom_threshold_tbl(asic_index),
+                                                    oe_dom_thresholds,
+                                                    beautify_func=self._beautify_dom_info_dict)
+        # Read ELSFP thresholds and publish to DB
+        elsfp_dom_thresholds = self.port_obj_dict[physical_port].elsfp.get_api().get_elsfp_threshold_info()
+        self.post_diagnostic_values_from_dict_to_db(logical_port_name,
+                                                    self.xcvr_table_helper.get_els_dom_threshold_tbl(asic_index),
+                                                    elsfp_dom_thresholds,
+                                                    beautify_func=self._beautify_dom_info_dict)
+
+
+class CPOVDMDBUtils(DBUtils):
+    """
+    This class provides utility functions for managing DB operations
+    related to VDM on CPO (co-packaged optics) modules.
+    """
+
+    def __init__(self, port_obj_dict, port_mapping, xcvr_table_helper, task_stopping_event, logger):
+        super().__init__(port_obj_dict, port_mapping, task_stopping_event, logger)
+        self.xcvr_table_helper = xcvr_table_helper
+        self.logger = logger
+
+    def post_port_vdm_thresholds_to_db(self, logical_port_name, db_cache=None):
+        pass

--- a/sonic-xcvrd/xcvrd/dom/utilities/db/utils.py
+++ b/sonic-xcvrd/xcvrd/dom/utilities/db/utils.py
@@ -46,18 +46,93 @@ class DBUtils:
                 if not diagnostic_values_dict:
                     return
 
-                # Use the provided beautify function or default to self.beautify_info_dict
-                (beautify_func or self.beautify_info_dict)(diagnostic_values_dict)
-                fvs = swsscommon.FieldValuePairs(
-                    [(k, v) for k, v in diagnostic_values_dict.items()] +
-                    [("last_update_time", self.get_current_time())]
-                )
-                table.set(logical_port_name, fvs)
+                self._write_values_to_table(table, logical_port_name, diagnostic_values_dict,
+                                            beautify_func=beautify_func)
 
         except NotImplementedError:
             self.logger.log_error(f"Post port diagnostic values to db failed for {logical_port_name} "
                                          "as functionality is not implemented")
             return
+
+    def post_flag_values_to_db(self, logical_port_name, get_values_func,
+                               flag_tbl, flag_change_count_tbl, flag_set_time_tbl, flag_clear_time_tbl,
+                               log_context, db_cache=None, beautify_func=None,
+                               enable_flat_memory_check=False):
+        """
+        Posts the flag values to the database and updates the corresponding flag metadata tables.
+
+        This differs from post_diagnostic_values_to_db in that the metadata tables (change count,
+        last set time, last clear time) must be updated before flag_tbl is overwritten, since
+        _update_flag_metadata_tables diffs the newly read values against the ones already in
+        flag_tbl. The metadata update also has to run on the raw values, before beautification
+        turns booleans into strings (a beautified False is truthy and would be recorded as a set).
+
+        Args:
+            logical_port_name (str): Logical port name.
+            get_values_func (function): Function to get the flag values.
+            flag_tbl (swsscommon.Table): Table containing flag values.
+            flag_change_count_tbl (swsscommon.Table): Table for change counts.
+            flag_set_time_tbl (swsscommon.Table): Table for last set times.
+            flag_clear_time_tbl (swsscommon.Table): Table for last clear times.
+            log_context (str): Name of the flags for logging purposes.
+            db_cache (dict, optional): Cache for flag values.
+            beautify_func (function, optional): Function to beautify the flag values. Defaults to self.beautify_info_dict.
+            enable_flat_memory_check (bool, optional): Flag to check for flat memory support. Defaults to False.
+        """
+        physical_port = self._validate_and_get_physical_port(logical_port_name, enable_flat_memory_check)
+        if physical_port is None:
+            return
+
+        try:
+            if db_cache is not None and physical_port in db_cache:
+                # If cache is enabled and flag values are in cache, just read from cache, no need read from EEPROM
+                flags_dict = db_cache[physical_port]
+            else:
+                # Reading from the EEPROM as the cache is empty
+                flags_dict = get_values_func(physical_port)
+                if flags_dict is None:
+                    self.logger.log_error(f"Post {log_context} to db failed for {logical_port_name} "
+                                          "as no flags found")
+                    return
+                if flags_dict:
+                    self._update_flag_metadata_tables(logical_port_name, flags_dict,
+                                                      self.get_current_time(),
+                                                      flag_tbl, flag_change_count_tbl,
+                                                      flag_set_time_tbl, flag_clear_time_tbl,
+                                                      log_context)
+
+                if db_cache is not None:
+                    # If cache is enabled, put flag values to cache
+                    db_cache[physical_port] = flags_dict
+
+            if not flags_dict:
+                return
+
+            self._write_values_to_table(flag_tbl, logical_port_name, flags_dict,
+                                        beautify_func=beautify_func)
+
+        except NotImplementedError:
+            self.logger.log_error(f"Post {log_context} to db failed for {logical_port_name} "
+                                  "as functionality is not implemented")
+            return
+
+    def _write_values_to_table(self, table, key, values_dict, beautify_func=None):
+        """
+        Beautifies the values and writes them to the given table along with a last update timestamp.
+
+        Args:
+            table (object): Database table object.
+            key (str): Key to write the values under (typically the logical port name).
+            values_dict (dict): Values to write. Beautified in place.
+            beautify_func (function, optional): Function to beautify the values. Defaults to self.beautify_info_dict.
+        """
+        # Use the provided beautify function or default to self.beautify_info_dict
+        (beautify_func or self.beautify_info_dict)(values_dict)
+        fvs = swsscommon.FieldValuePairs(
+            [(k, v) for k, v in values_dict.items()] +
+            [("last_update_time", self.get_current_time())]
+        )
+        table.set(key, fvs)
 
     def _validate_and_get_physical_port(self, logical_port_name, enable_flat_memory_check=False):
         """

--- a/sonic-xcvrd/xcvrd/dom/utilities/db/utils.py
+++ b/sonic-xcvrd/xcvrd/dom/utilities/db/utils.py
@@ -54,6 +54,31 @@ class DBUtils:
                                          "as functionality is not implemented")
             return
 
+    def post_diagnostic_values_from_dict_to_db(self, logical_port_name, table, values_dict,
+                                               beautify_func=None, enable_flat_memory_check=False):
+        """
+        Posts a caller-supplied dictionary of diagnostic values to the database.
+
+        This is the counterpart to post_diagnostic_values_to_db for callers that have
+        already read the values from hardware. Since the caller performs the read, there
+        is no get_values_func to invoke lazily and therefore no db_cache to consult.
+
+        Args:
+            logical_port_name (str): Logical port name.
+            table (object): Database table object.
+            values_dict (dict): Pre-read diagnostic values. Beautified in place.
+            beautify_func (function, optional): Function to beautify the values. Defaults to self.beautify_info_dict.
+            enable_flat_memory_check (bool, optional): Flag to check for flat memory support. Defaults to False.
+        """
+        physical_port = self._validate_and_get_physical_port(logical_port_name, enable_flat_memory_check)
+        if physical_port is None:
+            return
+
+        if not values_dict:
+            return
+
+        self._write_values_to_table(table, logical_port_name, values_dict, beautify_func=beautify_func)
+
     def post_flag_values_to_db(self, logical_port_name, get_values_func,
                                flag_tbl, flag_change_count_tbl, flag_set_time_tbl, flag_clear_time_tbl,
                                log_context, db_cache=None, beautify_func=None,

--- a/sonic-xcvrd/xcvrd/dom/utilities/db/utils.py
+++ b/sonic-xcvrd/xcvrd/dom/utilities/db/utils.py
@@ -9,11 +9,11 @@ class DBUtils:
     NEVER = "never"
     NOT_AVAILABLE = "N/A"
 
-    def __init__(self, sfp_obj_dict, port_mapping, task_stopping_event, logger):
-        self.sfp_obj_dict = sfp_obj_dict
+    def __init__(self, port_obj_dict, port_mapping, task_stopping_event, logger):
+        self.port_obj_dict = port_obj_dict
         self.port_mapping = port_mapping
         self.task_stopping_event = task_stopping_event
-        self.xcvrd_utils = XCVRDUtils(sfp_obj_dict, logger)
+        self.xcvrd_utils = XCVRDUtils(port_obj_dict, logger)
         self.logger = logger
 
     def post_diagnostic_values_to_db(self, logical_port_name, table, get_values_func,
@@ -191,7 +191,7 @@ class DBUtils:
 
         physical_port = pport_list[0]
 
-        if physical_port not in self.sfp_obj_dict:
+        if physical_port not in self.port_obj_dict:
             self.logger.log_error(f"Validate and get physical port failed for {logical_port_name} "
                                    "as no sfp object found")
             return None

--- a/sonic-xcvrd/xcvrd/dom/utilities/dom_sensor/beautify.py
+++ b/sonic-xcvrd/xcvrd/dom/utilities/dom_sensor/beautify.py
@@ -1,0 +1,42 @@
+import re
+
+
+class DOMBeautifyMixin:
+    """
+    Strips units from raw DOM values so they are stored in the DB as bare numerics.
+
+    Mixed into the DB utility classes that publish DOM data. Kept separate from
+    DOMDBUtils so that classes needing only the formatting (e.g. the CPO DOM
+    utilities) do not also inherit its table-writing methods.
+
+    Requires the host class to provide self.logger.
+    """
+    TEMP_UNIT = 'C'
+    VOLT_UNIT = 'Volts'
+    POWER_UNIT = 'dBm'
+    BIAS_UNIT = 'mA'
+
+    def _strip_unit(self, value, unit):
+        # Strip unit from raw data
+        if isinstance(value, str) and value.endswith(unit):
+            return value[:-len(unit)]
+        return str(value)
+
+    # Remove unnecessary unit from the raw data
+    def _beautify_dom_info_dict(self, dom_info_dict):
+        if dom_info_dict is None:
+            self.logger.log_warning("DOM info dict is None while beautifying")
+            return
+
+        for k, v in dom_info_dict.items():
+            if k == 'temperature':
+                dom_info_dict[k] = self._strip_unit(v, self.TEMP_UNIT)
+            elif k == 'voltage':
+                dom_info_dict[k] = self._strip_unit(v, self.VOLT_UNIT)
+            elif re.match('^(tx|rx)[1-8]power$', k):
+                dom_info_dict[k] = self._strip_unit(v, self.POWER_UNIT)
+            elif re.match('^(tx|rx)[1-8]bias$', k):
+                dom_info_dict[k] = self._strip_unit(v, self.BIAS_UNIT)
+            elif type(v) is not str:
+                # For all the other keys:
+                dom_info_dict[k] = str(v)

--- a/sonic-xcvrd/xcvrd/dom/utilities/dom_sensor/db_utils.py
+++ b/sonic-xcvrd/xcvrd/dom/utilities/dom_sensor/db_utils.py
@@ -13,10 +13,10 @@ class DOMDBUtils(DOMBeautifyMixin, DBUtils):
         - TRANSCEIVER_DOM_FLAG and its corresponding metadata tables (change count, set time, clear time)
         - TRANSCEIVER_DOM_THRESHOLD
     """
-    def __init__(self, sfp_obj_dict, port_mapping, xcvr_table_helper, task_stopping_event, logger):
-        super().__init__(sfp_obj_dict, port_mapping, task_stopping_event, logger)
+    def __init__(self, port_obj_dict, port_mapping, xcvr_table_helper, task_stopping_event, logger):
+        super().__init__(port_obj_dict, port_mapping, task_stopping_event, logger)
         self.xcvr_table_helper = xcvr_table_helper
-        self.dom_utils = DOMUtils(self.sfp_obj_dict, logger)
+        self.dom_utils = DOMUtils(self.port_obj_dict, logger)
         self.logger = logger
 
     def post_port_dom_temperature_info_to_db(self, logical_port_name, db_cache=None):

--- a/sonic-xcvrd/xcvrd/dom/utilities/dom_sensor/db_utils.py
+++ b/sonic-xcvrd/xcvrd/dom/utilities/dom_sensor/db_utils.py
@@ -57,52 +57,15 @@ class DOMDBUtils(DBUtils):
                                   "as no asic index found")
             return
 
-        physical_port = self._validate_and_get_physical_port(logical_port_name)
-        if physical_port is None:
-            return
-
-        try:
-            if db_cache is not None and physical_port in db_cache:
-                # If cache is enabled and dom flag values are in cache, just read from cache, no need read from EEPROM
-                dom_flags_dict = db_cache[physical_port]
-            else:
-                # Reading from the EEPROM as the cache is empty
-                dom_flags_dict = self.dom_utils.get_transceiver_dom_flags(physical_port)
-                if dom_flags_dict is None:
-                    self.logger.log_error(f"Post port dom flags to db failed for {logical_port_name} "
-                                          "as no dom flags found")
-                    return
-                if dom_flags_dict:
-                    dom_flags_dict_update_time = self.get_current_time()
-                    self._update_flag_metadata_tables(logical_port_name, dom_flags_dict,
-                                                     dom_flags_dict_update_time,
-                                                     self.xcvr_table_helper.get_dom_flag_tbl(asic_index),
-                                                     self.xcvr_table_helper.get_dom_flag_change_count_tbl(asic_index),
-                                                     self.xcvr_table_helper.get_dom_flag_set_time_tbl(asic_index),
-                                                     self.xcvr_table_helper.get_dom_flag_clear_time_tbl(asic_index),
-                                                     "DOM flags")
-
-                if db_cache is not None:
-                    # If cache is enabled, put dom flag values to cache
-                    db_cache[physical_port] = dom_flags_dict
-
-            if dom_flags_dict is not None:
-                if not dom_flags_dict:
-                    return
-
-                self._beautify_dom_info_dict(dom_flags_dict)
-                fvs = swsscommon.FieldValuePairs(
-                    [(k, v) for k, v in dom_flags_dict.items()] +
-                    [("last_update_time", self.get_current_time())]
-                )
-                self.xcvr_table_helper.get_dom_flag_tbl(asic_index).set(logical_port_name, fvs)
-            else:
-                return
-
-        except NotImplementedError:
-            self.logger.log_error(f"Post port dom flags to db failed for {logical_port_name} "
-                                  "as no dom flags found")
-            return
+        return self.post_flag_values_to_db(logical_port_name,
+                                           self.dom_utils.get_transceiver_dom_flags,
+                                           self.xcvr_table_helper.get_dom_flag_tbl(asic_index),
+                                           self.xcvr_table_helper.get_dom_flag_change_count_tbl(asic_index),
+                                           self.xcvr_table_helper.get_dom_flag_set_time_tbl(asic_index),
+                                           self.xcvr_table_helper.get_dom_flag_clear_time_tbl(asic_index),
+                                           "DOM flags",
+                                           db_cache=db_cache,
+                                           beautify_func=self._beautify_dom_info_dict)
 
     def post_port_dom_thresholds_to_db(self, logical_port_name, db_cache=None):
         asic_index = self.port_mapping.get_asic_id_for_logical_port(logical_port_name)

--- a/sonic-xcvrd/xcvrd/dom/utilities/dom_sensor/db_utils.py
+++ b/sonic-xcvrd/xcvrd/dom/utilities/dom_sensor/db_utils.py
@@ -1,10 +1,10 @@
-import re
 from xcvrd.dom.utilities.db.utils import DBUtils
+from xcvrd.dom.utilities.dom_sensor.beautify import DOMBeautifyMixin
 from xcvrd.dom.utilities.dom_sensor.utils import DOMUtils
 from swsscommon import swsscommon
 
 
-class DOMDBUtils(DBUtils):
+class DOMDBUtils(DOMBeautifyMixin, DBUtils):
     """
     This class provides utility functions for managing DB operations
     related to DOM on transceivers.
@@ -13,11 +13,6 @@ class DOMDBUtils(DBUtils):
         - TRANSCEIVER_DOM_FLAG and its corresponding metadata tables (change count, set time, clear time)
         - TRANSCEIVER_DOM_THRESHOLD
     """
-    TEMP_UNIT = 'C'
-    VOLT_UNIT = 'Volts'
-    POWER_UNIT = 'dBm'
-    BIAS_UNIT = 'mA'
-
     def __init__(self, sfp_obj_dict, port_mapping, xcvr_table_helper, task_stopping_event, logger):
         super().__init__(sfp_obj_dict, port_mapping, task_stopping_event, logger)
         self.xcvr_table_helper = xcvr_table_helper
@@ -79,28 +74,3 @@ class DOMDBUtils(DBUtils):
                                                  self.dom_utils.get_transceiver_dom_thresholds,
                                                  db_cache=db_cache,
                                                  beautify_func=self._beautify_dom_info_dict)
-
-    def _strip_unit(self, value, unit):
-        # Strip unit from raw data
-        if isinstance(value, str) and value.endswith(unit):
-            return value[:-len(unit)]
-        return str(value)
-
-    # Remove unnecessary unit from the raw data
-    def _beautify_dom_info_dict(self, dom_info_dict):
-        if dom_info_dict is None:
-            self.logger.log_warning("DOM info dict is None while beautifying")
-            return
-
-        for k, v in dom_info_dict.items():
-            if k == 'temperature':
-                dom_info_dict[k] = self._strip_unit(v, self.TEMP_UNIT)
-            elif k == 'voltage':
-                dom_info_dict[k] = self._strip_unit(v, self.VOLT_UNIT)
-            elif re.match('^(tx|rx)[1-8]power$', k):
-                dom_info_dict[k] = self._strip_unit(v, self.POWER_UNIT)
-            elif re.match('^(tx|rx)[1-8]bias$', k):
-                dom_info_dict[k] = self._strip_unit(v, self.BIAS_UNIT)
-            elif type(v) is not str:
-                # For all the other keys:
-                dom_info_dict[k] = str(v)

--- a/sonic-xcvrd/xcvrd/dom/utilities/status/db_utils.py
+++ b/sonic-xcvrd/xcvrd/dom/utilities/status/db_utils.py
@@ -45,47 +45,11 @@ class StatusDBUtils(DBUtils):
                                   "as no asic index found")
             return
 
-        physical_port = self._validate_and_get_physical_port(logical_port_name)
-        if physical_port is None:
-            return
-
-        try:
-            if db_cache is not None and physical_port in db_cache:
-                # If cache is enabled and status flag values are in cache, just read from cache, no need read from EEPROM
-                status_flags_dict = db_cache[physical_port]
-            else:
-                # Reading from the EEPROM as the cache is empty
-                status_flags_dict = self.status_utils.get_transceiver_status_flags(physical_port)
-                if status_flags_dict is None:
-                    self.logger.log_error(f"Post port transceiver hw status flags to db failed for {logical_port_name} "
-                                            "as no status flags found")
-                    return
-                if status_flags_dict:
-                    self._update_flag_metadata_tables(logical_port_name, status_flags_dict,
-                                                     self.get_current_time(),
-                                                     self.xcvr_table_helper.get_status_flag_tbl(asic_index),
-                                                     self.xcvr_table_helper.get_status_flag_change_count_tbl(asic_index),
-                                                     self.xcvr_table_helper.get_status_flag_set_time_tbl(asic_index),
-                                                     self.xcvr_table_helper.get_status_flag_clear_time_tbl(asic_index),
-                                                     "Status flags")
-
-                if db_cache is not None:
-                    # If cache is enabled, put status flag values to cache
-                    db_cache[physical_port] = status_flags_dict
-            if status_flags_dict is not None:
-                if not status_flags_dict:
-                    return
-
-                self.beautify_info_dict(status_flags_dict)
-                fvs = swsscommon.FieldValuePairs(
-                    [(k, v) for k, v in status_flags_dict.items()] +
-                    [("last_update_time", self.get_current_time())]
-                )
-                self.xcvr_table_helper.get_status_flag_tbl(asic_index).set(logical_port_name, fvs)
-            else:
-                return
-
-        except NotImplementedError:
-            self.logger.log_notice(f"Post port transceiver hw status flags to db failed for {logical_port_name} "
-                                   "as functionality is not implemented")
-            return
+        return self.post_flag_values_to_db(logical_port_name,
+                                           self.status_utils.get_transceiver_status_flags,
+                                           self.xcvr_table_helper.get_status_flag_tbl(asic_index),
+                                           self.xcvr_table_helper.get_status_flag_change_count_tbl(asic_index),
+                                           self.xcvr_table_helper.get_status_flag_set_time_tbl(asic_index),
+                                           self.xcvr_table_helper.get_status_flag_clear_time_tbl(asic_index),
+                                           "Status flags",
+                                           db_cache=db_cache)

--- a/sonic-xcvrd/xcvrd/dom/utilities/status/db_utils.py
+++ b/sonic-xcvrd/xcvrd/dom/utilities/status/db_utils.py
@@ -12,10 +12,10 @@ class StatusDBUtils(DBUtils):
         - TRANSCEIVER_STATUS_FLAG and its corresponding metadata tables (change count, set time, clear time)
     """
 
-    def __init__(self, sfp_obj_dict, port_mapping, xcvr_table_helper, task_stopping_event, logger):
-        super().__init__(sfp_obj_dict, port_mapping, task_stopping_event, logger)
+    def __init__(self, port_obj_dict, port_mapping, xcvr_table_helper, task_stopping_event, logger):
+        super().__init__(port_obj_dict, port_mapping, task_stopping_event, logger)
         self.xcvr_table_helper = xcvr_table_helper
-        self.status_utils = StatusUtils(self.sfp_obj_dict, logger)
+        self.status_utils = StatusUtils(self.port_obj_dict, logger)
         self.logger = logger
 
     def post_port_transceiver_hw_status_to_db(self, logical_port_name, db_cache=None):

--- a/sonic-xcvrd/xcvrd/dom/utilities/vdm/db_utils.py
+++ b/sonic-xcvrd/xcvrd/dom/utilities/vdm/db_utils.py
@@ -47,13 +47,8 @@ class VDMDBUtils(DBUtils):
         if not vdm_real_values_dict:
             return
 
-        self.beautify_info_dict(vdm_real_values_dict)
-        fvs = swsscommon.FieldValuePairs(
-            [(k, v) for k, v in vdm_real_values_dict.items()] +
-            [("last_update_time", self.get_current_time())]
-        )
-        table = self.xcvr_table_helper.get_vdm_real_value_tbl(asic_index)
-        table.set(logical_port_name, fvs)
+        self._write_values_to_table(self.xcvr_table_helper.get_vdm_real_value_tbl(asic_index),
+                                    logical_port_name, vdm_real_values_dict)
 
     def post_port_vdm_flags_to_db(self, logical_port_name, db_cache=None):
         return self._post_port_vdm_thresholds_or_flags_to_db(logical_port_name, self.xcvr_table_helper.get_vdm_flag_tbl,
@@ -114,14 +109,8 @@ class VDMDBUtils(DBUtils):
 
             for threshold_type, threshold_value_dict in vdm_threshold_type_value_dict.items():
                 if threshold_value_dict:
-                    self.beautify_info_dict(threshold_value_dict)
-                    fvs = swsscommon.FieldValuePairs(
-                        [(k, v) for k, v in threshold_value_dict.items()] +
-                        [("last_update_time", self.get_current_time())]
-                    )
-                    
                     table = get_vdm_table_func(self.port_mapping.get_asic_id_for_logical_port(logical_port_name), threshold_type)
-                    table.set(logical_port_name, fvs)
+                    self._write_values_to_table(table, logical_port_name, threshold_value_dict)
                 else:
                     return
         except NotImplementedError:

--- a/sonic-xcvrd/xcvrd/dom/utilities/vdm/db_utils.py
+++ b/sonic-xcvrd/xcvrd/dom/utilities/vdm/db_utils.py
@@ -16,10 +16,10 @@ class VDMDBUtils(DBUtils):
         - TRANSCEIVER_VDM_XXXX_THRESHOLD
             - XXXX refers to HALARM, LALARM, HWARN or LWARN
     """
-    def __init__(self, sfp_obj_dict, port_mapping, xcvr_table_helper, task_stopping_event, logger):
-        super().__init__(sfp_obj_dict, port_mapping, task_stopping_event, logger)
+    def __init__(self, port_obj_dict, port_mapping, xcvr_table_helper, task_stopping_event, logger):
+        super().__init__(port_obj_dict, port_mapping, task_stopping_event, logger)
         self.xcvr_table_helper = xcvr_table_helper
-        self.vdm_utils = VDMUtils(self.sfp_obj_dict, logger)
+        self.vdm_utils = VDMUtils(self.port_obj_dict, logger)
         self.logger = logger
 
     def post_port_vdm_real_values_from_dict_to_db(self, logical_port_name, vdm_real_values_dict):

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -166,14 +166,6 @@ def _wrapper_get_sfp_type(physical_port):
     return None
 
 
-def _wrapper_get_sfp_error_description(physical_port):
-    if platform_chassis:
-        try:
-            return platform_chassis.get_sfp(physical_port).get_error_description()
-        except NotImplementedError:
-            pass
-    return None
-
 def waiting_time_compensation_with_sleep(time_start, time_to_wait):
     time_now = time.time()
     time_diff = time_now - time_start
@@ -248,6 +240,14 @@ class SfpStateUpdateTask(threading.Thread):
 
         helper_logger.log_debug("mapping from {} {} to {}".format(status, port_dict, event))
         return event
+
+    def _get_port_error_description(self, physical_port):
+        if platform_chassis:
+            try:
+                return platform_chassis.get_sfp(physical_port).get_error_description()
+            except NotImplementedError:
+                pass
+        return None
 
     # Update port sfp info in db
     def post_port_info_to_db(self, logical_port_name, port_mapping, table, transceiver_dict,
@@ -629,7 +629,7 @@ class SfpStateUpdateTask(threading.Thread):
                                         if error_dict:
                                             vendor_specific_error_description = error_dict.get(key)
                                         else:
-                                            vendor_specific_error_description = _wrapper_get_sfp_error_description(key)
+                                            vendor_specific_error_description = self._get_port_error_description(key)
                                         error_descriptions.append(vendor_specific_error_description)
 
                                     # Add error info to database
@@ -821,7 +821,7 @@ class SfpStateUpdateTask(threading.Thread):
                 if error_dict:
                     vendor_specific_error_description = error_dict.get(port_change_event.port_index)
                 else:
-                    vendor_specific_error_description = _wrapper_get_sfp_error_description(port_change_event.port_index)
+                    vendor_specific_error_description = self._get_port_error_description(port_change_event.port_index)
                 error_descriptions.append(vendor_specific_error_description)
 
             error_description = '|'.join(error_descriptions)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -104,15 +104,6 @@ helper_logger = syslogger.SysLogger(SYSLOG_IDENTIFIER, enable_runtime_config=Tru
 #
 # Helper functions =============================================================
 #
-def _wrapper_is_replaceable(physical_port):
-    if platform_chassis is not None:
-        try:
-            return platform_chassis.get_sfp(physical_port).is_replaceable()
-        except NotImplementedError:
-            pass
-    return False
-
-
 def _wrapper_get_transceiver_info(physical_port):
     if platform_chassis is not None:
         try:
@@ -248,6 +239,14 @@ class SfpStateUpdateTask(threading.Thread):
         status, events = platform_sfputil.get_transceiver_change_event(timeout)
         return status, events, None
 
+    def _wrapper_is_replaceable(self, physical_port):
+        if platform_chassis is not None:
+            try:
+                return platform_chassis.get_sfp(physical_port).is_replaceable()
+            except NotImplementedError:
+                pass
+        return False
+
     # Update port sfp info in db
     def post_port_info_to_db(self, logical_port_name, port_mapping, table, transceiver_dict,
                              stop_event=threading.Event()):
@@ -280,7 +279,7 @@ class SfpStateUpdateTask(threading.Thread):
                     port_info_dict = _wrapper_get_transceiver_info(physical_port)
                     transceiver_dict[physical_port] = port_info_dict
                 if port_info_dict is not None:
-                    is_replaceable = _wrapper_is_replaceable(physical_port)
+                    is_replaceable = self._wrapper_is_replaceable(physical_port)
                     # if cmis is supported by the module
                     if 'cmis_rev' in port_info_dict:
                         fvs = swsscommon.FieldValuePairs(

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -140,19 +140,6 @@ def _wrapper_soak_sfp_insert_event(sfp_insert_events, port_dict):
             port_dict[key] = sfp_status_helper.SFP_STATUS_INSERTED
             del sfp_insert_events[key]
 
-def _wrapper_get_transceiver_change_event(timeout):
-    if platform_chassis is not None:
-        try:
-            status, events = platform_chassis.get_change_event(timeout)
-            sfp_events = events.get('sfp')
-            sfp_errors = events.get('sfp_error')
-            return status, sfp_events, sfp_errors
-        except NotImplementedError:
-            pass
-    status, events = platform_sfputil.get_transceiver_change_event(timeout)
-    return status, events, None
-
-
 def _wrapper_get_sfp_type(physical_port):
     if platform_chassis:
         try:
@@ -248,6 +235,18 @@ class SfpStateUpdateTask(threading.Thread):
             except NotImplementedError:
                 pass
         return None
+
+    def _get_port_change_event(self, timeout):
+        if platform_chassis is not None:
+            try:
+                status, events = platform_chassis.get_change_event(timeout)
+                sfp_events = events.get('sfp')
+                sfp_errors = events.get('sfp_error')
+                return status, sfp_events, sfp_errors
+            except NotImplementedError:
+                pass
+        status, events = platform_sfputil.get_transceiver_change_event(timeout)
+        return status, events, None
 
     # Update port sfp info in db
     def post_port_info_to_db(self, logical_port_name, port_mapping, table, transceiver_dict,
@@ -500,7 +499,7 @@ class SfpStateUpdateTask(threading.Thread):
             # Ensure not to block for any event if sfp insert event is pending
             if self.sfp_insert_events:
                 timeout = SFP_INSERT_EVENT_POLL_PERIOD_MSECS
-            status, port_dict, error_dict = _wrapper_get_transceiver_change_event(timeout)
+            status, port_dict, error_dict = self._get_port_change_event(timeout)
             if status:
                 # Soak SFP insert events across various ports (updates port_dict)
                 _wrapper_soak_sfp_insert_event(self.sfp_insert_events, port_dict)
@@ -862,7 +861,7 @@ class SfpStateUpdateTask(threading.Thread):
             return
 
         # Retry eeprom with an interval RETRY_EEPROM_READING_INTERVAL. No need to put sleep here
-        # because _wrapper_get_transceiver_change_event has a timeout argument.
+        # because _get_port_change_event has a timeout argument.
         now = time.time()
         if now - self.last_retry_eeprom_time < self.RETRY_EEPROM_READING_INTERVAL:
             return

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -591,10 +591,10 @@ class SfpStateUpdateTask(threading.Thread):
                                         media_settings_parser.notify_media_setting(logical_port, transceiver_dict, self.xcvr_table_helper, self.port_mapping)
                                     transceiver_dict.clear()
                             elif value == sfp_status_helper.SFP_STATUS_REMOVED:
-                                # Remove the SFP API object for this physical port
+                                # Remove the API object for this physical port
                                 try:
-                                    sfp = platform_chassis.get_sfp(int(key))
-                                    sfp.remove_xcvr_api()
+                                    device = common.get_port_device(int(key))
+                                    device.remove_xcvr_api()
                                 except (NotImplementedError, AttributeError) as e:
                                     helper_logger.log_error(f"Failed to remove xcvr api for port {key}: {str(e)}")
                                 helper_logger.log_notice("{}: Got SFP removed event".format(logical_port))
@@ -603,29 +603,8 @@ class SfpStateUpdateTask(threading.Thread):
                                 common.update_port_transceiver_status_table_sw(
                                     logical_port, self.xcvr_table_helper.get_status_sw_tbl(asic_index), sfp_status_helper.SFP_STATUS_REMOVED)
                                 helper_logger.log_notice("{}: received plug out and update port sfp status table.".format(logical_port))
-                                common.del_port_sfp_dom_info_from_db(logical_port, self.port_mapping, [
-                                                              self.xcvr_table_helper.get_intf_tbl(asic_index),
-                                                              self.xcvr_table_helper.get_dom_tbl(asic_index),
-                                                              self.xcvr_table_helper.get_dom_temperature_tbl(asic_index),
-                                                              self.xcvr_table_helper.get_dom_flag_tbl(asic_index),
-                                                              self.xcvr_table_helper.get_dom_flag_change_count_tbl(asic_index),
-                                                              self.xcvr_table_helper.get_dom_flag_set_time_tbl(asic_index),
-                                                              self.xcvr_table_helper.get_dom_flag_clear_time_tbl(asic_index),
-                                                              self.xcvr_table_helper.get_dom_threshold_tbl(asic_index),
-                                                              *[self.xcvr_table_helper.get_vdm_threshold_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
-                                                              self.xcvr_table_helper.get_vdm_real_value_tbl(asic_index),
-                                                              *[self.xcvr_table_helper.get_vdm_flag_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
-                                                              *[self.xcvr_table_helper.get_vdm_flag_change_count_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
-                                                              *[self.xcvr_table_helper.get_vdm_flag_set_time_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
-                                                              *[self.xcvr_table_helper.get_vdm_flag_clear_time_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
-                                                              self.xcvr_table_helper.get_status_tbl(asic_index),
-                                                              self.xcvr_table_helper.get_status_flag_tbl(asic_index),
-                                                              self.xcvr_table_helper.get_status_flag_change_count_tbl(asic_index),
-                                                              self.xcvr_table_helper.get_status_flag_set_time_tbl(asic_index),
-                                                              self.xcvr_table_helper.get_status_flag_clear_time_tbl(asic_index),
-                                                              self.xcvr_table_helper.get_pm_tbl(asic_index),
-                                                              self.xcvr_table_helper.get_firmware_info_tbl(asic_index)
-                                                              ])
+                                self.delete_port_data_from_db(logical_port, asic_index,
+                                                             delete_intf_tbl=True)
                             else:
                                 try:
                                     error_bits = int(value)
@@ -647,29 +626,7 @@ class SfpStateUpdateTask(threading.Thread):
                                     # In this case EEPROM is not accessible. The DOM info will be removed since it can be out-of-date.
                                     # The interface info remains in the DB since it is static.
                                     if sfp_status_helper.is_error_block_eeprom_reading(error_bits):
-                                        common.del_port_sfp_dom_info_from_db(logical_port,
-                                                                      self.port_mapping, [
-                                                                      self.xcvr_table_helper.get_dom_tbl(asic_index),
-                                                                      self.xcvr_table_helper.get_dom_temperature_tbl(asic_index),
-                                                                      self.xcvr_table_helper.get_dom_flag_tbl(asic_index),
-                                                                      self.xcvr_table_helper.get_dom_flag_change_count_tbl(asic_index),
-                                                                      self.xcvr_table_helper.get_dom_flag_set_time_tbl(asic_index),
-                                                                      self.xcvr_table_helper.get_dom_flag_clear_time_tbl(asic_index),
-                                                                      self.xcvr_table_helper.get_dom_threshold_tbl(asic_index),
-                                                                      *[self.xcvr_table_helper.get_vdm_threshold_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
-                                                                      self.xcvr_table_helper.get_vdm_real_value_tbl(asic_index),
-                                                                      *[self.xcvr_table_helper.get_vdm_flag_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
-                                                                      *[self.xcvr_table_helper.get_vdm_flag_change_count_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
-                                                                      *[self.xcvr_table_helper.get_vdm_flag_set_time_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
-                                                                      *[self.xcvr_table_helper.get_vdm_flag_clear_time_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
-                                                                      self.xcvr_table_helper.get_status_tbl(asic_index),
-                                                                      self.xcvr_table_helper.get_status_flag_tbl(asic_index),
-                                                                      self.xcvr_table_helper.get_status_flag_change_count_tbl(asic_index),
-                                                                      self.xcvr_table_helper.get_status_flag_set_time_tbl(asic_index),
-                                                                      self.xcvr_table_helper.get_status_flag_clear_time_tbl(asic_index),
-                                                                      self.xcvr_table_helper.get_pm_tbl(asic_index),
-                                                                      self.xcvr_table_helper.get_firmware_info_tbl(asic_index)
-                                                                      ])
+                                        self.delete_port_data_from_db(logical_port, asic_index)
                                 except (TypeError, ValueError) as e:
                                     helper_logger.log_error("{}: Got unrecognized event {}, ignored".format(logical_port, value))
 
@@ -739,6 +696,49 @@ class SfpStateUpdateTask(threading.Thread):
         if self.exc:
             raise self.exc
 
+    def delete_port_data_from_db(self, logical_port_name, asic_index,
+                                 delete_intf_tbl=False, delete_status_sw_tbl=False):
+        """Delete data of a logical port from the DB.
+
+        The DOM, VDM, status, PM and firmware info tables are always deleted, since their
+        content is only meaningful while the transceiver is present and its EEPROM readable.
+
+        Args:
+            logical_port_name (str): logical port name
+            asic_index (int): the asic index the logical port belongs to
+            delete_intf_tbl (bool): also delete TRANSCEIVER_INFO. It is permitted to keep it
+                in some circumstances, since it contains static data only.
+            delete_status_sw_tbl (bool): also delete TRANSCEIVER_STATUS_SW. It is kept while
+                the logical port exists, since the SFP status/error is recorded there.
+        """
+        tbl_to_del_list = [
+            self.xcvr_table_helper.get_dom_tbl(asic_index),
+            self.xcvr_table_helper.get_dom_temperature_tbl(asic_index),
+            self.xcvr_table_helper.get_dom_flag_tbl(asic_index),
+            self.xcvr_table_helper.get_dom_flag_change_count_tbl(asic_index),
+            self.xcvr_table_helper.get_dom_flag_set_time_tbl(asic_index),
+            self.xcvr_table_helper.get_dom_flag_clear_time_tbl(asic_index),
+            self.xcvr_table_helper.get_dom_threshold_tbl(asic_index),
+            *[self.xcvr_table_helper.get_vdm_threshold_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
+            self.xcvr_table_helper.get_vdm_real_value_tbl(asic_index),
+            *[self.xcvr_table_helper.get_vdm_flag_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
+            *[self.xcvr_table_helper.get_vdm_flag_change_count_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
+            *[self.xcvr_table_helper.get_vdm_flag_set_time_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
+            *[self.xcvr_table_helper.get_vdm_flag_clear_time_tbl(asic_index, key) for key in VDM_THRESHOLD_TYPES],
+            self.xcvr_table_helper.get_status_tbl(asic_index),
+            self.xcvr_table_helper.get_status_flag_tbl(asic_index),
+            self.xcvr_table_helper.get_status_flag_change_count_tbl(asic_index),
+            self.xcvr_table_helper.get_status_flag_set_time_tbl(asic_index),
+            self.xcvr_table_helper.get_status_flag_clear_time_tbl(asic_index),
+            self.xcvr_table_helper.get_pm_tbl(asic_index),
+            self.xcvr_table_helper.get_firmware_info_tbl(asic_index)
+        ]
+        if delete_intf_tbl:
+            tbl_to_del_list.append(self.xcvr_table_helper.get_intf_tbl(asic_index))
+        if delete_status_sw_tbl:
+            tbl_to_del_list.append(self.xcvr_table_helper.get_status_sw_tbl(asic_index))
+        common.del_port_sfp_dom_info_from_db(logical_port_name, self.port_mapping, tbl_to_del_list)
+
     def on_port_config_change(self , port_change_event):
         if port_change_event.event_type == port_event_helper.PortChangeEvent.PORT_REMOVE:
             self.on_remove_logical_port(port_change_event)
@@ -756,31 +756,10 @@ class SfpStateUpdateTask(threading.Thread):
         # To avoid race condition, remove the entry TRANSCEIVER_DOM_INFO, TRANSCEIVER_STATUS_INFO and TRANSCEIVER_INFO table.
         # The operation to remove entry from TRANSCEIVER_DOM_INFO is duplicate with DomInfoUpdateTask.on_remove_logical_port,
         # but it is necessary because TRANSCEIVER_DOM_INFO is also updated in this thread when a new SFP is inserted.
-        common.del_port_sfp_dom_info_from_db(port_change_event.port_name,
-                                      self.port_mapping, [
-                                      self.xcvr_table_helper.get_intf_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_dom_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_dom_temperature_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_dom_flag_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_dom_flag_change_count_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_dom_flag_set_time_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_dom_flag_clear_time_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_dom_threshold_tbl(port_change_event.asic_id),
-                                      *[self.xcvr_table_helper.get_vdm_threshold_tbl(port_change_event.asic_id, key) for key in VDM_THRESHOLD_TYPES],
-                                      self.xcvr_table_helper.get_vdm_real_value_tbl(port_change_event.asic_id),
-                                      *[self.xcvr_table_helper.get_vdm_flag_tbl(port_change_event.asic_id, key) for key in VDM_THRESHOLD_TYPES],
-                                      *[self.xcvr_table_helper.get_vdm_flag_change_count_tbl(port_change_event.asic_id, key) for key in VDM_THRESHOLD_TYPES],
-                                      *[self.xcvr_table_helper.get_vdm_flag_set_time_tbl(port_change_event.asic_id, key) for key in VDM_THRESHOLD_TYPES],
-                                      *[self.xcvr_table_helper.get_vdm_flag_clear_time_tbl(port_change_event.asic_id, key) for key in VDM_THRESHOLD_TYPES],
-                                      self.xcvr_table_helper.get_status_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_status_flag_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_status_flag_change_count_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_status_flag_set_time_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_status_flag_clear_time_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_status_sw_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_pm_tbl(port_change_event.asic_id),
-                                      self.xcvr_table_helper.get_firmware_info_tbl(port_change_event.asic_id)
-                                      ])
+        self.delete_port_data_from_db(port_change_event.port_name,
+                                      port_change_event.asic_id,
+                                      delete_intf_tbl=True,
+                                      delete_status_sw_tbl=True)
 
         # The logical port has been removed, no need retry EEPROM reading
         if port_change_event.port_name in self.retry_eeprom_set:

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1040,6 +1040,11 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         # Initialize shared utilities with platform objects
         common.init_globals(platform_chassis, platform_sfputil)
 
+        # Imported here rather than at module scope because cpo_state_task imports from this module
+        # Initialize shared chassis global in cpo_state_task.
+        from .cpo import cpo_state_task
+        cpo_state_task.platform_chassis = platform_chassis
+
         if multi_asic.is_multi_asic():
             # Load the namespace details first from the database_global.json file.
             swsscommon.SonicDBConfig.initializeGlobalConfig()

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -174,79 +174,6 @@ def _wrapper_get_sfp_error_description(physical_port):
             pass
     return None
 
-# Update port sfp info in db
-
-
-def post_port_sfp_info_to_db(logical_port_name, port_mapping, table, transceiver_dict,
-                             stop_event=threading.Event()):
-    ganged_port = False
-    ganged_member_num = 1
-
-    physical_port_list = port_mapping.logical_port_name_to_physical_port_list(logical_port_name)
-    if physical_port_list is None:
-        helper_logger.log_error("No physical ports found for logical port '{}'".format(logical_port_name))
-        return PHYSICAL_PORT_NOT_EXIST
-
-    if len(physical_port_list) > 1:
-        ganged_port = True
-
-    for physical_port in physical_port_list:
-        if stop_event.is_set():
-            break
-
-        if not common._wrapper_get_presence(physical_port):
-            helper_logger.log_notice("Transceiver not present in port {}".format(logical_port_name))
-            continue
-
-        port_name = common.get_physical_port_name(logical_port_name, ganged_member_num, ganged_port)
-        ganged_member_num += 1
-
-        try:
-            if physical_port in transceiver_dict:
-                port_info_dict = transceiver_dict[physical_port]
-            else:
-                port_info_dict = _wrapper_get_transceiver_info(physical_port)
-                transceiver_dict[physical_port] = port_info_dict
-            if port_info_dict is not None:
-                is_replaceable = _wrapper_is_replaceable(physical_port)
-                # if cmis is supported by the module
-                if 'cmis_rev' in port_info_dict:
-                    fvs = swsscommon.FieldValuePairs(
-                        [(field, str(value)) for field, value in port_info_dict.items()] +
-                        [('is_replaceable', str(is_replaceable))]
-                    )
-                # else cmis is not supported by the module
-                else:
-                    fvs = swsscommon.FieldValuePairs([
-                        ('type', port_info_dict['type']),
-                        ('vendor_rev', port_info_dict['vendor_rev']),
-                        ('serial', port_info_dict['serial']),
-                        ('manufacturer', port_info_dict['manufacturer']),
-                        ('model', port_info_dict['model']),
-                        ('vendor_oui', port_info_dict['vendor_oui']),
-                        ('vendor_date', port_info_dict['vendor_date']),
-                        ('connector', port_info_dict['connector']),
-                        ('encoding', port_info_dict['encoding']),
-                        ('ext_identifier', port_info_dict['ext_identifier']),
-                        ('ext_rateselect_compliance', port_info_dict['ext_rateselect_compliance']),
-                        ('cable_type', port_info_dict['cable_type']),
-                        ('cable_length', str(port_info_dict['cable_length'])),
-                        ('specification_compliance', port_info_dict['specification_compliance']),
-                        ('nominal_bit_rate', str(port_info_dict['nominal_bit_rate'])),
-                        ('application_advertisement', port_info_dict['application_advertisement']
-                        if 'application_advertisement' in port_info_dict else 'N/A'),
-                        ('is_replaceable', str(is_replaceable)),
-                        ('dom_capability', port_info_dict['dom_capability']
-                        if 'dom_capability' in port_info_dict else 'N/A')
-                    ])
-                table.set(port_name, fvs)
-            else:
-                return SFP_EEPROM_NOT_READY
-
-        except NotImplementedError:
-            helper_logger.log_error("This functionality is currently not implemented for this platform")
-            sys.exit(NOT_IMPLEMENTED_ERROR)
-
 def waiting_time_compensation_with_sleep(time_start, time_to_wait):
     time_now = time.time()
     time_diff = time_now - time_start
@@ -322,6 +249,77 @@ class SfpStateUpdateTask(threading.Thread):
         helper_logger.log_debug("mapping from {} {} to {}".format(status, port_dict, event))
         return event
 
+    # Update port sfp info in db
+    def post_port_info_to_db(self, logical_port_name, port_mapping, table, transceiver_dict,
+                             stop_event=threading.Event()):
+        ganged_port = False
+        ganged_member_num = 1
+
+        physical_port_list = port_mapping.logical_port_name_to_physical_port_list(logical_port_name)
+        if physical_port_list is None:
+            helper_logger.log_error("No physical ports found for logical port '{}'".format(logical_port_name))
+            return PHYSICAL_PORT_NOT_EXIST
+
+        if len(physical_port_list) > 1:
+            ganged_port = True
+
+        for physical_port in physical_port_list:
+            if stop_event.is_set():
+                break
+
+            if not common._wrapper_get_presence(physical_port):
+                helper_logger.log_notice("Transceiver not present in port {}".format(logical_port_name))
+                continue
+
+            port_name = common.get_physical_port_name(logical_port_name, ganged_member_num, ganged_port)
+            ganged_member_num += 1
+
+            try:
+                if physical_port in transceiver_dict:
+                    port_info_dict = transceiver_dict[physical_port]
+                else:
+                    port_info_dict = _wrapper_get_transceiver_info(physical_port)
+                    transceiver_dict[physical_port] = port_info_dict
+                if port_info_dict is not None:
+                    is_replaceable = _wrapper_is_replaceable(physical_port)
+                    # if cmis is supported by the module
+                    if 'cmis_rev' in port_info_dict:
+                        fvs = swsscommon.FieldValuePairs(
+                            [(field, str(value)) for field, value in port_info_dict.items()] +
+                            [('is_replaceable', str(is_replaceable))]
+                        )
+                    # else cmis is not supported by the module
+                    else:
+                        fvs = swsscommon.FieldValuePairs([
+                            ('type', port_info_dict['type']),
+                            ('vendor_rev', port_info_dict['vendor_rev']),
+                            ('serial', port_info_dict['serial']),
+                            ('manufacturer', port_info_dict['manufacturer']),
+                            ('model', port_info_dict['model']),
+                            ('vendor_oui', port_info_dict['vendor_oui']),
+                            ('vendor_date', port_info_dict['vendor_date']),
+                            ('connector', port_info_dict['connector']),
+                            ('encoding', port_info_dict['encoding']),
+                            ('ext_identifier', port_info_dict['ext_identifier']),
+                            ('ext_rateselect_compliance', port_info_dict['ext_rateselect_compliance']),
+                            ('cable_type', port_info_dict['cable_type']),
+                            ('cable_length', str(port_info_dict['cable_length'])),
+                            ('specification_compliance', port_info_dict['specification_compliance']),
+                            ('nominal_bit_rate', str(port_info_dict['nominal_bit_rate'])),
+                            ('application_advertisement', port_info_dict['application_advertisement']
+                            if 'application_advertisement' in port_info_dict else 'N/A'),
+                            ('is_replaceable', str(is_replaceable)),
+                            ('dom_capability', port_info_dict['dom_capability']
+                            if 'dom_capability' in port_info_dict else 'N/A')
+                        ])
+                    table.set(port_name, fvs)
+                else:
+                    return SFP_EEPROM_NOT_READY
+
+            except NotImplementedError:
+                helper_logger.log_error("This functionality is currently not implemented for this platform")
+                sys.exit(NOT_IMPLEMENTED_ERROR)
+
     # Update port sfp info and dom threshold in db during xcvrd bootup
     def _post_port_sfp_info_and_dom_thr_to_db_once(self, port_mapping, xcvr_table_helper, stop_event=threading.Event()):
         # Connect to STATE_DB and create transceiver dom/sfp info tables
@@ -344,7 +342,7 @@ class SfpStateUpdateTask(threading.Thread):
             namespace = common.get_namespace_from_asic_id(asic_index)
             is_warm_fast_reboot = self.warm_fast_reboot_status.get(namespace, False)
 
-            rc = post_port_sfp_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict, stop_event)
+            rc = self.post_port_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict, stop_event)
             if rc != SFP_EEPROM_NOT_READY:
                 if is_warm_fast_reboot == False:
                     media_settings_parser.notify_media_setting(logical_port_name, transceiver_dict, xcvr_table_helper, port_mapping)
@@ -567,12 +565,12 @@ class SfpStateUpdateTask(threading.Thread):
                                 common.update_port_transceiver_status_table_sw(
                                     logical_port, self.xcvr_table_helper.get_status_sw_tbl(asic_index), sfp_status_helper.SFP_STATUS_INSERTED)
                                 helper_logger.log_notice("{}: received plug in and update port sfp status table.".format(logical_port))
-                                rc = post_port_sfp_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict)
+                                rc = self.post_port_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict)
                                 # If we didn't get the sfp info, assuming the eeprom is not ready, give a try again.
                                 if rc == SFP_EEPROM_NOT_READY:
                                     helper_logger.log_warning("{}: SFP EEPROM is not ready. One more try...".format(logical_port))
                                     time.sleep(TIME_FOR_SFP_READY_SECS)
-                                    rc = post_port_sfp_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict)
+                                    rc = self.post_port_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict)
                                     if rc == SFP_EEPROM_NOT_READY:
                                         # If still failed to read EEPROM, put it to retry set
                                         self.retry_eeprom_set.add(logical_port)
@@ -835,7 +833,7 @@ class SfpStateUpdateTask(threading.Thread):
         if common._wrapper_get_presence(port_change_event.port_index) and read_eeprom:
             transceiver_dict = {}
             status = sfp_status_helper.SFP_STATUS_INSERTED if not status else status
-            rc = post_port_sfp_info_to_db(port_change_event.port_name, self.port_mapping, int_tbl, transceiver_dict)
+            rc = self.post_port_info_to_db(port_change_event.port_name, self.port_mapping, int_tbl, transceiver_dict)
             if rc == SFP_EEPROM_NOT_READY:
                 # Failed to read EEPROM, put it to retry set
                 self.retry_eeprom_set.add(port_change_event.port_name)
@@ -866,7 +864,7 @@ class SfpStateUpdateTask(threading.Thread):
         retry_success_set = set()
         for logical_port in self.retry_eeprom_set:
             asic_index = self.port_mapping.get_asic_id_for_logical_port(logical_port)
-            rc = post_port_sfp_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict)
+            rc = self.post_port_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict)
             if rc != SFP_EEPROM_NOT_READY:
                 self.dom_db_utils.post_port_dom_thresholds_to_db(logical_port)
                 self.vdm_db_utils.post_port_vdm_thresholds_to_db(logical_port)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -320,6 +320,17 @@ class SfpStateUpdateTask(threading.Thread):
                 helper_logger.log_error("This functionality is currently not implemented for this platform")
                 sys.exit(NOT_IMPLEMENTED_ERROR)
 
+    def post_port_thresholds_to_db(self, logical_port_name, dom_db_cache=None, vdm_db_cache=None):
+        """Post the DOM and VDM thresholds for a port to the DB.
+
+        Args:
+            logical_port_name (str): logical port name
+            dom_db_cache (dict, optional): per-physical-port cache for the DOM thresholds
+            vdm_db_cache (dict, optional): per-physical-port cache for the VDM thresholds
+        """
+        self.dom_db_utils.post_port_dom_thresholds_to_db(logical_port_name, db_cache=dom_db_cache)
+        self.vdm_db_utils.post_port_vdm_thresholds_to_db(logical_port_name, db_cache=vdm_db_cache)
+
     # Update port sfp info and dom threshold in db during xcvrd bootup
     def _post_port_sfp_info_and_dom_thr_to_db_once(self, port_mapping, xcvr_table_helper, stop_event=threading.Event()):
         # Connect to STATE_DB and create transceiver dom/sfp info tables
@@ -356,9 +367,9 @@ class SfpStateUpdateTask(threading.Thread):
                 break
             
             if logical_port_name not in retry_eeprom_set:
-                self.dom_db_utils.post_port_dom_thresholds_to_db(logical_port_name, db_cache=dom_thresholds_cache)
-                # Read the VDM thresholds and post them to the DB
-                self.vdm_db_utils.post_port_vdm_thresholds_to_db(logical_port_name, db_cache=vdm_thresholds_cache)
+                self.post_port_thresholds_to_db(logical_port_name,
+                                                dom_db_cache=dom_thresholds_cache,
+                                                vdm_db_cache=vdm_thresholds_cache)
 
         return retry_eeprom_set
 
@@ -576,8 +587,7 @@ class SfpStateUpdateTask(threading.Thread):
                                         self.retry_eeprom_set.add(logical_port)
 
                                 if rc != SFP_EEPROM_NOT_READY:
-                                    self.dom_db_utils.post_port_dom_thresholds_to_db(logical_port)
-                                    self.vdm_db_utils.post_port_vdm_thresholds_to_db(logical_port)
+                                    self.post_port_thresholds_to_db(logical_port)
 
                                     if not self.is_warm_fast_reboot_for_lport(logical_port):
                                         media_settings_parser.notify_media_setting(logical_port, transceiver_dict, self.xcvr_table_helper, self.port_mapping)
@@ -838,8 +848,7 @@ class SfpStateUpdateTask(threading.Thread):
                 # Failed to read EEPROM, put it to retry set
                 self.retry_eeprom_set.add(port_change_event.port_name)
             else:
-                self.dom_db_utils.post_port_dom_thresholds_to_db(port_change_event.port_name)
-                self.vdm_db_utils.post_port_vdm_thresholds_to_db(port_change_event.port_name)
+                self.post_port_thresholds_to_db(port_change_event.port_name)
                 if not self.is_warm_fast_reboot_for_lport(port_change_event.port_name):
                     media_settings_parser.notify_media_setting(port_change_event.port_name, transceiver_dict, self.xcvr_table_helper, self.port_mapping)
         else:
@@ -866,8 +875,7 @@ class SfpStateUpdateTask(threading.Thread):
             asic_index = self.port_mapping.get_asic_id_for_logical_port(logical_port)
             rc = self.post_port_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict)
             if rc != SFP_EEPROM_NOT_READY:
-                self.dom_db_utils.post_port_dom_thresholds_to_db(logical_port)
-                self.vdm_db_utils.post_port_vdm_thresholds_to_db(logical_port)
+                self.post_port_thresholds_to_db(logical_port)
 
                 if not self.is_warm_fast_reboot_for_lport(logical_port):
                     media_settings_parser.notify_media_setting(logical_port, transceiver_dict, self.xcvr_table_helper, self.port_mapping)

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvr_table_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvr_table_helper.py
@@ -45,6 +45,8 @@ TRANSCEIVER_VDM_LALARM_FLAG_CLEAR_TIME = 'TRANSCEIVER_VDM_LALARM_FLAG_CLEAR_TIME
 TRANSCEIVER_VDM_HWARN_FLAG_CLEAR_TIME = 'TRANSCEIVER_VDM_HWARN_FLAG_CLEAR_TIME'
 TRANSCEIVER_VDM_LWARN_FLAG_CLEAR_TIME = 'TRANSCEIVER_VDM_LWARN_FLAG_CLEAR_TIME'
 TRANSCEIVER_PM_TABLE = 'TRANSCEIVER_PM'
+TRANSCEIVER_ELS_INFO_TABLE = 'TRANSCEIVER_ELS_INFO'
+TRANSCEIVER_ELS_DOM_THRESHOLD_TABLE = 'TRANSCEIVER_ELS_DOM_THRESHOLD'
 
 NPU_SI_SETTINGS_SYNC_STATUS_KEY = 'NPU_SI_SETTINGS_SYNC_STATUS'
 NPU_SI_SETTINGS_DEFAULT_VALUE = 'NPU_SI_SETTINGS_DEFAULT'
@@ -70,8 +72,11 @@ class XcvrTableHelper:
         self.status_flag_clear_time_tbl = {}
         self.status_sw_tbl = {}
         self.vdm_real_value_tbl = {}
+        self.els_info_tbl = {}
+        self.els_dom_threshold_tbl = {}
         VDM_THRESHOLD_TYPES = ['halarm', 'lalarm', 'hwarn', 'lwarn']
         self.vdm_threshold_tbl = {f'vdm_{t}_threshold_tbl': {} for t in VDM_THRESHOLD_TYPES}
+        self.els_vdm_threshold_tbl = {f'els_vdm_{t}_threshold_tbl': {} for t in VDM_THRESHOLD_TYPES}
         self.vdm_flag_tbl = {f'vdm_{t}_flag_tbl': {} for t in VDM_THRESHOLD_TYPES}
         self.vdm_flag_change_count_tbl = {f'vdm_{t}_flag_change_count_tbl': {} for t in VDM_THRESHOLD_TYPES}
         self.vdm_flag_set_time_tbl = {f'vdm_{t}_flag_set_time_tbl': {} for t in VDM_THRESHOLD_TYPES}
@@ -101,8 +106,11 @@ class XcvrTableHelper:
             self.cfg_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
             self.cfg_port_tbl[asic_id] = swsscommon.Table(self.cfg_db[asic_id], swsscommon.CFG_PORT_TABLE_NAME)
             self.vdm_real_value_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_VDM_REAL_VALUE_TABLE)
+            self.els_info_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_ELS_INFO_TABLE)
+            self.els_dom_threshold_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_ELS_DOM_THRESHOLD_TABLE)
             for t in VDM_THRESHOLD_TYPES:
                 self.vdm_threshold_tbl[f'vdm_{t}_threshold_tbl'][asic_id] = swsscommon.Table(self.state_db[asic_id], f'TRANSCEIVER_VDM_{t.upper()}_THRESHOLD')
+                self.els_vdm_threshold_tbl[f'els_vdm_{t}_threshold_tbl'][asic_id] = swsscommon.Table(self.state_db[asic_id], f'TRANSCEIVER_ELS_VDM_{t.upper()}_THRESHOLD')
                 self.vdm_flag_tbl[f'vdm_{t}_flag_tbl'][asic_id] = swsscommon.Table(self.state_db[asic_id], f'TRANSCEIVER_VDM_{t.upper()}_FLAG')
                 self.vdm_flag_change_count_tbl[f'vdm_{t}_flag_change_count_tbl'][asic_id] = swsscommon.Table(self.state_db[asic_id], f'TRANSCEIVER_VDM_{t.upper()}_FLAG_CHANGE_COUNT')
                 self.vdm_flag_set_time_tbl[f'vdm_{t}_flag_set_time_tbl'][asic_id] = swsscommon.Table(self.state_db[asic_id], f'TRANSCEIVER_VDM_{t.upper()}_FLAG_SET_TIME')
@@ -152,6 +160,15 @@ class XcvrTableHelper:
 
     def get_vdm_threshold_tbl(self, asic_id, threshold_type):
         return self.vdm_threshold_tbl[f'vdm_{threshold_type}_threshold_tbl'][asic_id]
+
+    def get_els_info_tbl(self, asic_id):
+        return self.els_info_tbl[asic_id]
+
+    def get_els_dom_threshold_tbl(self, asic_id):
+        return self.els_dom_threshold_tbl[asic_id]
+
+    def get_els_vdm_threshold_tbl(self, asic_id, threshold_type):
+        return self.els_vdm_threshold_tbl[f'els_vdm_{threshold_type}_threshold_tbl'][asic_id]
 
     def get_vdm_real_value_tbl(self, asic_id):
         return self.vdm_real_value_tbl[asic_id]


### PR DESCRIPTION
#### Description
As outlined in the [xcvrd CPO HLD](https://github.com/sonic-net/SONiC/blob/c334d5cbb1cd7c76500bcdcdadbdab2e627869a8/doc/pmon/xcvrd_cpo.md), a CPO-specific subclass of `SfpStateUpdateTask` is required to handle ELSFP plug-in / plug-out events on CPO hardware.

#### Motivation and Context
Customization of the `SfpStateUpdateTask` is necessary to correctly handle CPO hardware.

#### How Has This Been Tested?
Added unit-testing.

Tested on a non-CPO switch manually, to ensure no regression:
- All links came up.
- `TRANSCEIVER_INFO`, `TRANSCEIVER_DOM_THRESHOLD`, VDM threshold tables (`TRANSCEIVER_VDM_{HALARM,LALARM,HWARN,LWARN}_THRESHOLD`) and `TRANSCEIVER_STATUS_SW` all had data populated as expected for each interface.
