### PR TITLE
[stormond] prevent cumulative FSIO totals from collapsing during FSRO

### DIFF
--- a/sonic-stormond/scripts/stormond
+++ b/sonic-stormond/scripts/stormond
@@ -254,6 +254,14 @@ class DaemonStorage(daemon_base.DaemonBase):
         # that akin to an INIT state. 
 
 
+    # Fetch the last known-good value of an FSIO field from STATE_DB. This is used
+    # to retain the previous latest/total FSIO values (keeping cumulative totals
+    # monotonic) when the live /proc/diskstats counters cannot be read.
+    def _get_last_fsio_statedb_value(self, device, field):
+        value = self.state_db.hget('{}|{}'.format(STORAGE_DEVICE_TABLE, device), field)
+        return "0" if value is None else value
+
+
     def _reconcile_fsio_rw_values(self, fsio_dict, device):
 
         # If stormond is coming up for the first time, neither STATE_DB info nor JSON file would be present.
@@ -342,14 +350,33 @@ class DaemonStorage(daemon_base.DaemonBase):
                 dynamic_kvp_dict["firmware"] = storage_object.get_firmware()
                 dynamic_kvp_dict["health"] = storage_object.get_health()
                 dynamic_kvp_dict["temperature"] = storage_object.get_temperature()
-                dynamic_kvp_dict["latest_fsio_reads"] = storage_object.get_fs_io_reads()
-                dynamic_kvp_dict["latest_fsio_writes"] = storage_object.get_fs_io_writes()
+
+                latest_fsio_reads = storage_object.get_fs_io_reads()
+                latest_fsio_writes = storage_object.get_fs_io_writes()
+
                 dynamic_kvp_dict["disk_io_reads"] = storage_object.get_disk_io_reads()
                 dynamic_kvp_dict["disk_io_writes"] = storage_object.get_disk_io_writes()
                 dynamic_kvp_dict["reserved_blocks"] = storage_object.get_reserved_blocks()
                 dynamic_kvp_dict["last_sync_time"] = self.get_formatted_time(time.time())
 
-                dynamic_kvp_dict["total_fsio_reads"], dynamic_kvp_dict["total_fsio_writes"] = self._reconcile_fsio_rw_values(dynamic_kvp_dict, storage_device)
+                # get_fs_io_reads()/get_fs_io_writes() return 0 when the underlying
+                # /proc/diskstats counters cannot be read (e.g. the disk has gone
+                # read-only). For an actively used storage disk these cumulative
+                # counters are effectively never 0 during normal operation, so both
+                # being 0 is treated as a counter read failure. In that scenario we
+                # retain the last known-good latest and total values from STATE_DB so
+                # the cumulative totals stay monotonic, while surfacing 0 in the log to
+                # signal the counter read failure.
+                if latest_fsio_reads == 0 and latest_fsio_writes == 0:
+                    self.log.log_warning("FSIO counters unavailable for {}. Retaining last known-good FSIO values.".format(storage_device))
+                    dynamic_kvp_dict["latest_fsio_reads"] = self._get_last_fsio_statedb_value(storage_device, "latest_fsio_reads")
+                    dynamic_kvp_dict["latest_fsio_writes"] = self._get_last_fsio_statedb_value(storage_device, "latest_fsio_writes")
+                    dynamic_kvp_dict["total_fsio_reads"] = self._get_last_fsio_statedb_value(storage_device, "total_fsio_reads")
+                    dynamic_kvp_dict["total_fsio_writes"] = self._get_last_fsio_statedb_value(storage_device, "total_fsio_writes")
+                else:
+                    dynamic_kvp_dict["latest_fsio_reads"] = latest_fsio_reads
+                    dynamic_kvp_dict["latest_fsio_writes"] = latest_fsio_writes
+                    dynamic_kvp_dict["total_fsio_reads"], dynamic_kvp_dict["total_fsio_writes"] = self._reconcile_fsio_rw_values(dynamic_kvp_dict, storage_device)
 
                 # Update storage device statistics to STATE_DB
                 self.update_storage_info_status_db(storage_device, dynamic_kvp_dict)
@@ -357,7 +384,7 @@ class DaemonStorage(daemon_base.DaemonBase):
                 # Log to syslog
                 self.log.log_notice("Storage Device: {}, Firmware: {}, health: {}%, Temp: {}C, FS IO Reads: {}, FS IO Writes: {}".format(\
                 storage_device, dynamic_kvp_dict["firmware"], dynamic_kvp_dict["health"], dynamic_kvp_dict["temperature"], dynamic_kvp_dict["total_fsio_reads"],dynamic_kvp_dict["total_fsio_writes"]))
-                self.log.log_notice("Latest FSIO Reads: {}, Latest FSIO Writes: {}".format(dynamic_kvp_dict["latest_fsio_reads"], dynamic_kvp_dict["latest_fsio_writes"]))
+                self.log.log_notice("Latest FSIO Reads: {}, Latest FSIO Writes: {}".format(latest_fsio_reads, latest_fsio_writes))
                 self.log.log_notice("Disk IO Reads: {}, Disk IO Writes: {}, Reserved Blocks: {}".format(dynamic_kvp_dict["disk_io_reads"], dynamic_kvp_dict["disk_io_writes"], \
                 dynamic_kvp_dict["reserved_blocks"]))
                 self.log.log_notice("Last successful sync time to STATE_DB: {}".format(dynamic_kvp_dict["last_sync_time"]))

--- a/sonic-stormond/tests/test_DaemonStorage.py
+++ b/sonic-stormond/tests/test_DaemonStorage.py
@@ -453,6 +453,53 @@ class TestDaemonStorage(object):
 
 
     @patch('sonic_py_common.daemon_base.db_connect', MagicMock())
+    def test_get_dynamic_fields_fsio_counters_unavailable(self):
+        # Simulate the disk going read-only: get_fs_io_reads/writes return 0.
+        # The daemon must retain the last known-good latest and total FSIO values
+        # from STATE_DB (keeping cumulative totals monotonic) and log 0 for latest.
+        stormon_daemon = stormond.DaemonStorage(log_identifier)
+        stormon_daemon.log.log_warning = MagicMock()
+
+        mock_storage_device_object = MagicMock()
+        mock_storage_device_object.get_firmware.return_value = "N/A"
+        mock_storage_device_object.get_health.return_value = "N/A"
+        mock_storage_device_object.get_temperature.return_value = "N/A"
+        mock_storage_device_object.get_fs_io_reads.return_value = 0
+        mock_storage_device_object.get_fs_io_writes.return_value = 0
+        mock_storage_device_object.get_disk_io_reads.return_value = "1000"
+        mock_storage_device_object.get_disk_io_writes.return_value = "2000"
+        mock_storage_device_object.get_reserved_blocks.return_value = "3"
+
+        last_good = {
+            "latest_fsio_reads": "29166", "latest_fsio_writes": "20689390",
+            "total_fsio_reads": "57330", "total_fsio_writes": "20922224"}
+        stormon_daemon.state_db = MagicMock()
+        stormon_daemon.state_db.hget = MagicMock(side_effect=lambda key, field: last_good.get(field))
+
+        stormon_daemon.storage.devices = {'sda' : mock_storage_device_object}
+        stormon_daemon.get_dynamic_fields_update_state_db()
+
+        stored = stormon_daemon.device_table.get('sda')
+        # Cumulative totals must be retained (monotonic), not collapsed to 0.
+        assert stored["total_fsio_reads"] == "57330"
+        assert stored["total_fsio_writes"] == "20922224"
+        # Last known-good latest values are persisted.
+        assert stored["latest_fsio_reads"] == "29166"
+        assert stored["latest_fsio_writes"] == "20689390"
+        # A warning is emitted to flag the counter read failure.
+        stormon_daemon.log.log_warning.assert_called_once()
+
+
+    @patch('sonic_py_common.daemon_base.db_connect', MagicMock())
+    def test_get_last_fsio_statedb_value_defaults_to_zero(self):
+        stormon_daemon = stormond.DaemonStorage(log_identifier)
+        stormon_daemon.state_db = MagicMock()
+        stormon_daemon.state_db.hget = MagicMock(return_value=None)
+
+        assert stormon_daemon._get_last_fsio_statedb_value('sda', 'total_fsio_reads') == "0"
+
+
+    @patch('sonic_py_common.daemon_base.db_connect', MagicMock())
     def test_get_dynamic_fields_exception(self):
         stormon_daemon = stormond.DaemonStorage(log_identifier)
         stormon_daemon.log.log_notice = MagicMock()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

When a storage disk is inaccessible (e.g. a read-only like FSRO event), psutil.disk_io_counters() raises and the StorageCommon FSIO getters return 0. stormond previously fed that 0 into _reconcile_fsio_rw_values(), collapsing the lifetime totals derived from the latest per-poll counter. This was visible in syslog when firmware/health/temp went N/A:

  FS IO Writes: 20,938,935 -> 232,834
  Latest FSIO Writes: 20,706,101 -> 0

A lifetime cumulative counter must never regress. 


```
NOTICE pmon#stormond[40]: Polling Interval set to 3600 seconds
NOTICE pmon#stormond[40]: FSIO JSON file Interval set to 86400 seconds
NOTICE pmon#stormond[40]: Storage Device: nvme0n1, Firmware: XXXXXXXX, health: 100.0%, Temp: 49.0C, FS IO Reads: 57330, FS IO Writes: 20938935
NOTICE pmon#stormond[40]: Latest FSIO Reads: 29166, Latest FSIO Writes: 20706101
NOTICE pmon#stormond[40]: Disk IO Reads: 222,007 [113 GB], Disk IO Writes: 625,653 [320 GB], Reserved Blocks: 100.0
NOTICE pmon#stormond[40]: Last successful sync time to STATE_DB: 2026-08-08 18:36:41

// After disk inaccessible 

NOTICE pmon#stormond[40]: Polling Interval set to 3600 seconds
NOTICE pmon#stormond[40]: FSIO JSON file Interval set to 86400 seconds
NOTICE pmon#stormond[40]: Storage Device: nvme0n1, Firmware: N/A, health: N/A%, Temp: N/AC, FS IO Reads: 28164, FS IO Writes: 232834
NOTICE pmon#stormond[40]: Latest FSIO Reads: 0, Latest FSIO Writes: 0
NOTICE pmon#stormond[40]: Disk IO Reads: 222,007 [113 GB], Disk IO Writes: 625,653 [320 GB], Reserved Blocks: 100.0
NOTICE pmon#stormond[40]: Last successful sync time to STATE_DB: 2026-08-08 19:36:41
```


#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

To prevent these values from collapsing, when both latest reads and writes are 0 (for an active disk these /proc/diskstats counters are effectively never 0, and a read failure zeroes both together), retain the last known-good latest and total values from STATE_DB so the totals stay monotonic. Requiring both to be 0 avoids false positives on an idle disk; the only false positive is a fully unused disk whose last-good is already 0, making it harmless. Last-good latest (not 0) is persisted so crash-restart reconciliation stays correct, while syslog still shows 0 to signal the failure.

Adds `_get_last_fsio_statedb_value()` helper and tests for the FSRO path.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Tested on local testbed and added testcases `test_get_dynamic_fields_fsio_counters_unavailable`  and `test_get_last_fsio_statedb_value_defaults_to_zero` to verify the scenario and changes. 

#### Additional Information (Optional)
