### PR TITLE
Add speed_rpm field support for fans

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -76,6 +76,7 @@ FAN_INFO_PRESENCE_FIELD = 'presence'
 FAN_INFO_STATUS_FIELD = 'status'
 FAN_INFO_DIRECTION_FIELD = 'direction'
 FAN_INFO_SPEED_FIELD = 'speed'
+FAN_INFO_SPEED_RPM_FIELD = 'speed_rpm'
 FAN_INFO_LED_STATUS_FIELD = 'led_status'
 FAN_INFO_TIMESTAMP_FIELD = 'timestamp'
 
@@ -948,12 +949,14 @@ class DaemonPsud(daemon_base.DaemonBase):
             fan_name = try_get(fan.get_name, '{} FAN {}'.format(psu_name, index + 1))
             direction = try_get(fan.get_direction, NOT_AVAILABLE) if presence else NOT_AVAILABLE
             speed = try_get(fan.get_speed, NOT_AVAILABLE) if presence else NOT_AVAILABLE
+            speed_rpm = try_get(fan.get_speed_rpm, NOT_AVAILABLE) if presence else NOT_AVAILABLE
             status = "True" if presence else "False"
             fvs = swsscommon.FieldValuePairs(
                 [(FAN_INFO_PRESENCE_FIELD, str(presence)),
                  (FAN_INFO_STATUS_FIELD, status),
                  (FAN_INFO_DIRECTION_FIELD, direction),
                  (FAN_INFO_SPEED_FIELD, str(speed)),
+                 (FAN_INFO_SPEED_RPM_FIELD, str(speed_rpm)),
                  (FAN_INFO_TIMESTAMP_FIELD, datetime.now().strftime('%Y%m%d %H:%M:%S'))
                  ])
             try:

--- a/sonic-psud/tests/mock_platform.py
+++ b/sonic-psud/tests/mock_platform.py
@@ -109,6 +109,7 @@ class MockFan(fan_base.FanBase):
 
         self._direction = direction
         self._speed = speed
+        self._speed_rpm = int(speed * 200)
         self._status_led_color = self.STATUS_LED_COLOR_OFF
 
     def get_direction(self):
@@ -116,6 +117,9 @@ class MockFan(fan_base.FanBase):
 
     def get_speed(self):
         return self._speed
+
+    def get_speed_rpm(self):
+        return self._speed_rpm
 
     def get_status_led(self):
         return self._status_led_color

--- a/sonic-psud/tests/test_DaemonPsud.py
+++ b/sonic-psud/tests/test_DaemonPsud.py
@@ -637,6 +637,7 @@ class TestDaemonPsud(object):
              (psud.FAN_INFO_STATUS_FIELD, "True"),
              (psud.FAN_INFO_DIRECTION_FIELD, mock_fan.get_direction()),
              (psud.FAN_INFO_SPEED_FIELD, str(mock_fan.get_speed())),
+             (psud.FAN_INFO_SPEED_RPM_FIELD, str(mock_fan.get_speed_rpm())),
              (psud.FAN_INFO_TIMESTAMP_FIELD, fake_time.strftime('%Y%m%d %H:%M:%S'))
              ])
         daemon_psud._update_psu_fan_data(mock_psu1)

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -462,6 +462,7 @@ class FanUpdater(logger.Logger):
         fan_status = self.fan_status_dict[fan_name]
 
         speed = NOT_AVAILABLE
+        speed_rpm = NOT_AVAILABLE
         speed_target = NOT_AVAILABLE
         is_under_speed = NOT_AVAILABLE
         is_over_speed = NOT_AVAILABLE
@@ -471,6 +472,7 @@ class FanUpdater(logger.Logger):
         presence = try_get(fan.get_presence, False)
         if presence:
             speed = try_get(fan.get_speed)
+            speed_rpm = try_get(fan.get_speed_rpm, NOT_AVAILABLE)
             speed_target = try_get(fan.get_target_speed)
             is_under_speed = try_get(fan.is_under_speed)
             is_over_speed = try_get(fan.is_over_speed)
@@ -525,6 +527,7 @@ class FanUpdater(logger.Logger):
              ('status', str(fan_fault_status)),
              ('direction', str(fan_direction)),
              ('speed', str(speed)),
+             ('speed_rpm', str(speed_rpm)),
              ('speed_target', str(speed_target)),
              ('is_under_speed', str(is_under_speed)),
              ('is_over_speed', str(is_over_speed)),

--- a/sonic-thermalctld/tests/mock_platform.py
+++ b/sonic-thermalctld/tests/mock_platform.py
@@ -21,6 +21,7 @@ class MockFan(fan_base.FanBase):
         self._replaceable = True
 
         self._speed = 20
+        self._speed_rpm = 2400
         self._speed_tolerance = 20
         self._target_speed = 20
         self._direction = self.FAN_DIRECTION_INTAKE
@@ -28,6 +29,9 @@ class MockFan(fan_base.FanBase):
 
     def get_speed(self):
         return self._speed
+
+    def get_speed_rpm(self):
+        return self._speed_rpm
 
     def get_speed_tolerance(self):
         return self._speed_tolerance

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import datetime
 import threading
 import time
 import importlib.util
@@ -300,6 +301,40 @@ class TestFanUpdater(object):
         assert fan_list[0].get_status_led() == MockFan.STATUS_LED_COLOR_GREEN
         assert fan_updater.log_notice.call_count == 1
         fan_updater.log_notice.assert_called_with('Fan high speed warning cleared: FanDrawer 0 fan 1 speed is back to normal')
+
+    @mock.patch('thermalctld.update_entity_info', mock.MagicMock())
+    @mock.patch('thermalctld.datetime')
+    def test_refresh_fan_status_includes_speed_rpm(self, mock_datetime):
+        fake_time = datetime.datetime(2021, 1, 1, 12, 34, 56)
+        mock_datetime.now.return_value = fake_time
+
+        fan_drawer = MockFanDrawer(0)
+        mock_fan = MockFan()
+        mock_fan._speed_rpm = 4321
+        fan_drawer._fan_list.append(mock_fan)
+
+        fan_updater = thermalctld.FanUpdater(MockChassis(), multiprocessing.Event())
+        fan_updater.table = mock.MagicMock()
+        fan_updater._set_fan_led = mock.MagicMock()
+
+        expected_fvp = thermalctld.swsscommon.FieldValuePairs(
+            [('presence', 'True'),
+             ('drawer_name', 'FanDrawer 0'),
+             ('model', 'Fan Model'),
+             ('serial', 'Fan Serial'),
+             ('status', 'True'),
+             ('direction', mock_fan.get_direction()),
+             ('speed', str(mock_fan.get_speed())),
+             ('speed_rpm', str(mock_fan.get_speed_rpm())),
+             ('speed_target', str(mock_fan.get_target_speed())),
+             ('is_under_speed', 'False'),
+             ('is_over_speed', 'False'),
+             ('is_replaceable', 'True'),
+             ('timestamp', fake_time.strftime('%Y%m%d %H:%M:%S'))
+             ])
+
+        fan_updater._refresh_fan_status(fan_drawer, 0, mock_fan, 0, thermalctld.FanType.DRAWER)
+        fan_updater.table.set.assert_called_with('FanDrawer 0 fan 1', expected_fvp)
 
     def test_update_psu_fans(self):
         chassis = MockChassis()

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 import datetime
+import multiprocessing
 import threading
 import time
 import importlib.util


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
To populate redis DB with fan speed in RPM, for same a new DB entry has been made with "speed_rpm".

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Currently we are showing fan speed in %age and a new requirement came to populate fan speed in rpm which is not getting saved in redis DB. Therefore one entry has been made as "speed_rpm" to populate fan speed with rpm values.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Loaded image in local target and checked for rdis-db data population as show below: 
Note: the setup contains two PSU and 4 Fan tray with each two fans.
Checked for redis DB entry is getting updated properly, without affecting current fanshow display.
Note: this is only to update DB with fan speed with RPM values. Along-with existing speed in %age.
Test log :
root@sonic:/home/admin# for k in $(sonic-db-cli STATE_DB KEYS "FAN_INFO|*"); do echo "=== $k ==="; sonic-db-cli STATE_DB HGETALL "$k"; echo; done
=== FAN_INFO|PSU1.fan1 ===
{'presence': 'True', 'status': 'True', 'direction': 'N/A', 'speed': '50', 'speed_rpm': '10080', 'timestamp': '20260602 11:06:27', 'led_status': 'N/A', 'drawer_name': 'N/A', 'model': 'NXA-PAC-500W-PE', 'serial': 'LIT2709A9HY', 'speed_target': '50', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False'}

=== FAN_INFO|fantray1.fan1 ===
{'presence': 'True', 'drawer_name': 'fantray1', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJEW25372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '49', 'speed_rpm': '12134', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

=== FAN_INFO|fantray2.fan2 ===
{'presence': 'True', 'drawer_name': 'fantray2', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJ9625372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '49', 'speed_rpm': '10305', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

=== FAN_INFO|PSU2.fan1 ===
{'presence': 'True', 'status': 'True', 'direction': 'N/A', 'speed': '50', 'speed_rpm': '9952', 'timestamp': '20260602 11:06:27', 'led_status': 'N/A', 'drawer_name': 'N/A', 'model': 'NXA-PAC-500W-PE', 'serial': 'LIT2709A9DV', 'speed_target': '50', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False'}

=== FAN_INFO|fantray2.fan1 ===
{'presence': 'True', 'drawer_name': 'fantray2', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJ9625372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '49', 'speed_rpm': '12026', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

=== FAN_INFO|fantray3.fan1 ===
{'presence': 'True', 'drawer_name': 'fantray3', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJZK25372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '49', 'speed_rpm': '12162', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

=== FAN_INFO|fantray4.fan2 ===
{'presence': 'True', 'drawer_name': 'fantray4', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJZT25372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '48', 'speed_rpm': '10246', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

=== FAN_INFO|fantray4.fan1 ===
{'presence': 'True', 'drawer_name': 'fantray4', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJZT25372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '49', 'speed_rpm': '12053', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

=== FAN_INFO|fantray1.fan2 ===
{'presence': 'True', 'drawer_name': 'fantray1', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJEW25372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '49', 'speed_rpm': '10325', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

=== FAN_INFO|fantray3.fan2 ===
{'presence': 'True', 'drawer_name': 'fantray3', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJZK25372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '49', 'speed_rpm': '10285', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

root@sonic:/home/admin# sonic-db-cli STATE_DB KEYS 'FAN_INFO|*' | sort | while read -r k; do printf '%-28s %s\n' "$k" "$(sonic-db-cli STATE_DB HGET "$k" speed_rpm)"; done
FAN_INFO|fantray1.fan1 12134
FAN_INFO|fantray1.fan2 10325
FAN_INFO|fantray2.fan1 12026
FAN_INFO|fantray2.fan2 10305
FAN_INFO|fantray3.fan1 12162
FAN_INFO|fantray3.fan2 10285
FAN_INFO|fantray4.fan1 12053
FAN_INFO|fantray4.fan2 10246
FAN_INFO|PSU1.fan1 10080
FAN_INFO|PSU2.fan1 9952
root@sonic:/home/admin#

#### Additional Information (Optional)
Related sonic-platform-common PR : https://github.com/sonic-net/sonic-platform-common/pull/753
