### PR TITLE
[xcvrd] Fix CMIS lane masks for mixed-speed breakout

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -3702,6 +3702,44 @@ class TestXcvrdScript(object):
 
         assert result == [3, 3, 3, 3, 1, 1, 1, 1]
 
+    def test_CmisManagerTask_get_desired_app_map_mixed_width_subports(self):
+        """Mixed widths use cumulative lanes instead of width times subport."""
+        mock_xcvr_api = MagicMock()
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, {1: MagicMock()}, stop_event)
+        task.port_dict['Ethernet4'] = {'index': 1, 'asic_id': 0}
+
+        cfg_port_tbl = MagicMock()
+        cfg_port_tbl.getKeys = MagicMock(return_value=['Ethernet4', 'Ethernet0', 'Ethernet2'])
+
+        def get_side_effect(key):
+            data = {
+                'Ethernet0': (True, [('speed', '400000'), ('lanes', '1,2'),
+                                     ('subport', '1'), ('index', '1')]),
+                'Ethernet2': (True, [('speed', '400000'), ('lanes', '3,4'),
+                                     ('subport', '2'), ('index', '1')]),
+                'Ethernet4': (True, [('speed', '800000'), ('lanes', '5,6,7,8'),
+                                     ('subport', '3'), ('index', '1')]),
+            }
+            return data.get(key, (False, []))
+
+        cfg_port_tbl.get = MagicMock(side_effect=get_side_effect)
+        task.xcvr_table_helper.get_cfg_port_tbl = MagicMock(return_value=cfg_port_tbl)
+        task._gearbox_lanes_dict = {}
+
+        def get_app_desired(api, lane_count, speed):
+            return {(2, 400000): 4, (4, 800000): 1}.get((lane_count, speed))
+
+        mock_xcvr_api.get_host_lane_assignment_option = MagicMock(
+            side_effect=lambda app: {1: 0x11, 4: 0x55}[app])
+
+        with patch('xcvrd.xcvrd_utilities.common.get_cmis_application_desired',
+                   side_effect=get_app_desired):
+            result = task.get_desired_app_map(mock_xcvr_api, 'Ethernet4')
+
+        assert result == [4, 4, 4, 4, 1, 1, 1, 1]
+
     def test_CmisManagerTask_get_desired_app_map_no_matching_app(self):
         """Test get_desired_app_map when get_cmis_application_desired returns None"""
         mock_xcvr_api = MagicMock()
@@ -3828,6 +3866,31 @@ class TestXcvrdScript(object):
             {'lport': 'Ethernet0', 'subport': 1, 'speed': 200000, 'host_lane_count': 2},
         ]
 
+    def test_CmisManagerTask_get_cmis_lane_start_bits_mixed_width(self):
+        """Host and media starts sum lower-numbered sibling lane counts."""
+        mock_xcvr_api = MagicMock()
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, {1: MagicMock()}, stop_event)
+        task.port_dict['Ethernet4'] = {
+            'media_lane_count': 4,
+            'media_lane_assignment_options': 0x11,
+        }
+
+        task.get_sibling_port_configs = MagicMock(return_value=[
+            {'lport': 'Ethernet4', 'subport': 3, 'speed': 800000, 'host_lane_count': 4},
+            {'lport': 'Ethernet0', 'subport': 1, 'speed': 400000, 'host_lane_count': 2},
+            {'lport': 'Ethernet2', 'subport': 2, 'speed': 400000, 'host_lane_count': 2},
+        ])
+        mock_xcvr_api.get_media_lane_count = MagicMock(return_value=2)
+
+        with patch('xcvrd.xcvrd_utilities.common.get_cmis_application_desired',
+                   return_value=4):
+            result = task.get_cmis_lane_start_bits(mock_xcvr_api, 'Ethernet4', 3)
+
+        assert result == (4, 4)
+        assert task.get_cmis_media_lanes_mask(mock_xcvr_api, 1, 'Ethernet4', result[1]) == 0xf0
+
     DEFAULT_DP_STATE = {
         'DP1State': 'DataPathActivated',
         'DP2State': 'DataPathActivated',
@@ -3911,16 +3974,17 @@ class TestXcvrdScript(object):
         assert common.get_interface_speed(ifname) == expected
 
     @patch('xcvrd.xcvrd_utilities.common.is_cmis_api', MagicMock(return_value=True))
-    @pytest.mark.parametrize("host_lane_count, speed, subport, expected", [
+    @pytest.mark.parametrize("host_lane_count, speed, host_lane_start_bit, expected", [
         (8, 400000, 0, 0xFF),
-        (4, 100000, 1, 0xF),
-        (4, 100000, 2, 0xF0),
         (4, 100000, 0, 0xF),
-        (4, 100000, 9, 0x0),
-        (1, 50000, 2, 0x2),
-        (1, 200000, 2, 0x0)
+        (4, 100000, 4, 0xF0),
+        (4, 100000, 0, 0xF),
+        (4, 100000, 8, 0x0),
+        (1, 50000, 1, 0x2),
+        (1, 200000, 1, 0x0)
     ])
-    def test_CmisManagerTask_get_cmis_host_lanes_mask(self, host_lane_count, speed, subport, expected):
+    def test_CmisManagerTask_get_cmis_host_lanes_mask(
+            self, host_lane_count, speed, host_lane_start_bit, expected):
         appl_advert_dict = {
             1: {
                 'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)',
@@ -3955,7 +4019,8 @@ class TestXcvrdScript(object):
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, {1: MagicMock()}, stop_event)
 
         appl = common.get_cmis_application_desired(mock_xcvr_api, host_lane_count, speed)
-        assert task.get_cmis_host_lanes_mask(mock_xcvr_api, appl, host_lane_count, subport) == expected
+        assert task.get_cmis_host_lanes_mask(
+            mock_xcvr_api, appl, host_lane_count, host_lane_start_bit) == expected
 
     @pytest.mark.parametrize("gearbox_data, expected_dict", [
         # Test case 1: Gearbox port with 2 line lanes

--- a/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
+++ b/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
@@ -245,9 +245,9 @@ class CmisManagerTask(threading.Thread):
         # QSFP+C has 4 lanes, all others have 8
         return 0x0f if module_type == 'QSFP+C' else 0xff
 
-    def get_cmis_host_lanes_mask(self, api, appl, host_lane_count, subport):
+    def get_cmis_host_lanes_mask(self, api, appl, host_lane_count, host_lane_start_bit):
         """
-        Retrieves mask of active host lanes based on appl, host lane count and subport
+        Retrieves mask of active host lanes based on appl, lane count and start bit
 
         Args:
             api:
@@ -256,9 +256,8 @@ class CmisManagerTask(threading.Thread):
                 Integer, the transceiver-specific application code
             host_lane_count:
                 Integer, number of lanes on the host side
-            subport:
-                Integer, 1-based logical port number of the physical port after breakout
-                         0 means port is a non-breakout port
+            host_lane_start_bit:
+                Integer, zero-based starting host lane
 
         Returns:
             Integer, a mask of the active lanes on the host side
@@ -266,26 +265,26 @@ class CmisManagerTask(threading.Thread):
         """
         host_lanes_mask = 0
 
-        if appl is None or host_lane_count <= 0 or subport < 0:
+        if appl is None or host_lane_count <= 0 or host_lane_start_bit < 0:
             self.log_error("Invalid input to get host lane mask - appl {} host_lane_count {} "
-                            "subport {}!".format(appl, host_lane_count, subport))
+                            "host_lane_start_bit {}!".format(
+                                appl, host_lane_count, host_lane_start_bit))
             return host_lanes_mask
 
         host_lane_assignment_option = api.get_host_lane_assignment_option(appl)
-        host_lane_start_bit = (host_lane_count * (0 if subport == 0 else subport - 1))
         if host_lane_assignment_option & (1 << host_lane_start_bit):
             host_lanes_mask = ((1 << host_lane_count) - 1) << host_lane_start_bit
         else:
             self.log_error("Unable to find starting host lane - host_lane_assignment_option {}"
-                            " host_lane_start_bit {} host_lane_count {} subport {} appl {}!".format(
+                            " host_lane_start_bit {} host_lane_count {} appl {}!".format(
                             host_lane_assignment_option, host_lane_start_bit, host_lane_count,
-                            subport, appl))
+                            appl))
 
         return host_lanes_mask
 
-    def get_cmis_media_lanes_mask(self, api, appl, lport, subport):
+    def get_cmis_media_lanes_mask(self, api, appl, lport, media_lane_start_bit):
         """
-        Retrieves mask of active media lanes based on appl, lport and subport
+        Retrieves mask of active media lanes based on appl, lport and start bit
 
         Args:
             api:
@@ -294,9 +293,8 @@ class CmisManagerTask(threading.Thread):
                 Integer, the transceiver-specific application code
             lport:
                 String, logical port name
-            subport:
-                Integer, 1-based logical port number of the physical port after breakout
-                         0 means port is a non-breakout port
+            media_lane_start_bit:
+                Integer, zero-based starting media lane
 
         Returns:
             Integer, a mask of the active lanes on the media side
@@ -306,19 +304,19 @@ class CmisManagerTask(threading.Thread):
         media_lane_count = self.port_dict[lport]['media_lane_count']
         media_lane_assignment_option = self.port_dict[lport]['media_lane_assignment_options']
 
-        if appl < 1 or media_lane_count <= 0 or subport < 0:
+        if appl < 1 or media_lane_count <= 0 or media_lane_start_bit < 0:
             self.log_error("Invalid input to get media lane mask - appl {} media_lane_count {} "
-                            "lport {} subport {}!".format(appl, media_lane_count, lport, subport))
+                            "lport {} media_lane_start_bit {}!".format(
+                                appl, media_lane_count, lport, media_lane_start_bit))
             return media_lanes_mask
 
-        media_lane_start_bit = (media_lane_count * (0 if subport == 0 else subport - 1))
         if media_lane_assignment_option & (1 << media_lane_start_bit):
             media_lanes_mask = ((1 << media_lane_count) - 1) << media_lane_start_bit
         else:
             self.log_error("Unable to find starting media lane - media_lane_assignment_option {}"
-                            " media_lane_start_bit {} media_lane_count {} lport {} subport {} appl {}!".format(
+                            " media_lane_start_bit {} media_lane_count {} lport {} appl {}!".format(
                             media_lane_assignment_option, media_lane_start_bit, media_lane_count,
-                            lport, subport, appl))
+                            lport, appl))
 
         return media_lanes_mask
 
@@ -464,6 +462,36 @@ class CmisManagerTask(threading.Thread):
 
         return siblings
 
+    def get_cmis_lane_start_bits(self, api, lport, subport):
+        """Return host and media offsets after lower-numbered siblings."""
+        host_lane_start_bit = 0
+        media_lane_start_bit = 0
+
+        siblings = sorted(
+            self.get_sibling_port_configs(lport),
+            key=lambda sibling: (sibling['subport'], sibling['lport']))
+        for sibling in siblings:
+            if sibling['subport'] >= subport:
+                break
+
+            sibling_appl = common.get_cmis_application_desired(
+                api, sibling['host_lane_count'], sibling['speed'])
+            if sibling_appl is None:
+                self.log_error("{}: no suitable app for preceding sibling {}".format(
+                    lport, sibling['lport']))
+                return -1, -1
+
+            sibling_media_lane_count = int(api.get_media_lane_count(sibling_appl))
+            if sibling_media_lane_count <= 0:
+                self.log_error("{}: invalid media lane count {} for preceding sibling {}".format(
+                    lport, sibling_media_lane_count, sibling['lport']))
+                return -1, -1
+
+            host_lane_start_bit += sibling['host_lane_count']
+            media_lane_start_bit += sibling_media_lane_count
+
+        return host_lane_start_bit, media_lane_start_bit
+
     def get_desired_app_map(self, api, lport):
         """
         Build a per-lane desired application code map for all lanes of the
@@ -481,17 +509,20 @@ class CmisManagerTask(threading.Thread):
             (0 = unused/unassigned)
         """
         desired_map = [0] * self.CMIS_MAX_HOST_LANES
-        for sibling in self.get_sibling_port_configs(lport):
+        host_lane_start_bit = 0
+        siblings = sorted(
+            self.get_sibling_port_configs(lport),
+            key=lambda sibling: (sibling['subport'], sibling['lport']))
+        for sibling in siblings:
             sibling_appl = common.get_cmis_application_desired(
                 api, sibling['host_lane_count'], sibling['speed'])
-            if sibling_appl is None:
-                continue
-
-            sibling_mask = self.get_cmis_host_lanes_mask(
-                api, sibling_appl, sibling['host_lane_count'], sibling['subport'])
-            for lane in range(self.CMIS_MAX_HOST_LANES):
-                if (1 << lane) & sibling_mask:
-                    desired_map[lane] = sibling_appl
+            if sibling_appl is not None:
+                sibling_mask = self.get_cmis_host_lanes_mask(
+                    api, sibling_appl, sibling['host_lane_count'], host_lane_start_bit)
+                for lane in range(self.CMIS_MAX_HOST_LANES):
+                    if (1 << lane) & sibling_mask:
+                        desired_map[lane] = sibling_appl
+            host_lane_start_bit += sibling['host_lane_count']
 
         return desired_map
 
@@ -888,12 +919,19 @@ class CmisManagerTask(threading.Thread):
         appl = self.port_dict[lport]['appl']
         self.log_notice("{}: Setting appl={}".format(lport, appl))
 
+        host_lane_start_bit, media_lane_start_bit = self.get_cmis_lane_start_bits(
+            api, lport, subport)
+        if host_lane_start_bit < 0 or media_lane_start_bit < 0:
+            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
+            return False
+
         self.port_dict[lport]['max_host_lanes_mask'] = self.get_cmis_max_host_lanes_mask(api)
         self.port_dict[lport]['host_lanes_mask'] = self.get_cmis_host_lanes_mask(api,
-                                                        appl, host_lane_count, subport)
+                                                        appl, host_lane_count, host_lane_start_bit)
         if self.port_dict[lport]['host_lanes_mask'] <= 0:
-            self.log_error("{}: Invalid lane mask received - host_lane_count {} subport {} "
-                            "appl {}!".format(lport, host_lane_count, subport, appl))
+            self.log_error("{}: Invalid lane mask received - host_lane_count {} "
+                            "host_lane_start_bit {} appl {}!".format(
+                                lport, host_lane_count, host_lane_start_bit, appl))
             self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
             return False
         host_lanes_mask = self.port_dict[lport]['host_lanes_mask']
@@ -905,11 +943,12 @@ class CmisManagerTask(threading.Thread):
         media_lane_assignment_options = self.port_dict[lport]['media_lane_assignment_options']
         self.port_dict[lport]['max_media_lanes_mask'] = self.port_dict[lport]['max_host_lanes_mask']
         self.port_dict[lport]['media_lanes_mask'] = self.get_cmis_media_lanes_mask(api,
-                                                        appl, lport, subport)
+                                                        appl, lport, media_lane_start_bit)
         if self.port_dict[lport]['media_lanes_mask'] <= 0:
             self.log_error("{}: Invalid media lane mask received - media_lane_count {} "
-                            "media_lane_assignment_options {} subport {}"
-                            " appl {}!".format(lport, media_lane_count, media_lane_assignment_options, subport, appl))
+                            "media_lane_assignment_options {} media_lane_start_bit {}"
+                            " appl {}!".format(lport, media_lane_count, media_lane_assignment_options,
+                                              media_lane_start_bit, appl))
             self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
             return False
         media_lanes_mask = self.port_dict[lport]['media_lanes_mask']


### PR DESCRIPTION
#### Description

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/29317

This PR fixes incorrect CMIS host and media lane-mask calculation for mixed-speed breakout configurations. The existing implementation calculates each logical port's starting lane using its own lane count and subport number:

```text
lane_count * (subport - 1)
```
This assumes that all logical ports sharing a physical transceiver use the same number of lanes. The assumption is invalid for mixed-width breakout configurations.


#### Motivation and Context

For a mixed-speed breakout with sibling host-lane widths `2 + 2 + 4`, the third logical port must start at lane offset:

```text
2 + 2 = 4
```
The previous calculation instead produced:

```text
4 * (3 - 1) = 8
```

Offset `8` is outside an eight-lane CMIS module. This can cause xcvrd to calculate an invalid lane mask and apply CMIS application selections or lane-specific settings to the wrong lanes. As a result, the affected breakout port may fail to configure or reach link up.

The corrected implementation derives the offset from the actual lane widths of all lower-numbered sibling ports. For the reported `2 + 2 + 4` configuration, the final four-lane port correctly receives host and media lane mask `0xf0`, corresponding to lanes 5-8.

#### How Has This Been Tested?

Added unit-test coverage for:

- Existing uniform breakout lane-mask behavior.
- Mixed-width sibling configuration with lane widths `2 + 2 + 4`.
- Unordered sibling entries returned from CONFIG_DB.
- Cumulative host and media lane offsets of `4`.
- Ran the unit tests using below command and made sure they passed.

```bash
pytest sonic-xcvrd/tests/test_xcvrd.py -v 
```

#### Additional Information (Optional)
